### PR TITLE
Add &LEXPR to LAMBDA-LIST-KEYWORDS

### DIFF
--- a/level-1/l1-init.lisp
+++ b/level-1/l1-init.lisp
@@ -165,7 +165,7 @@
 
 
 (defconstant lambda-list-keywords 
-  '(&OPTIONAL &REST &AUX &KEY &ALLOW-OTHER-KEYS &BODY &ENVIRONMENT &WHOLE)
+  '(&OPTIONAL &REST &AUX &KEY &ALLOW-OTHER-KEYS &BODY &ENVIRONMENT &WHOLE CCL::&LEXPR)
   "symbols which are magical in a lambda list")
 
 (defstatic *type-system-initialized* nil)


### PR DESCRIPTION
According to CLHS entry for Constant Variable `LAMBDA-LIST-KEYWORDS`, it is "a list of all the lambda list keywords used in the implementation, including the additional ones used only by macro definition forms".

`(arglist #'+)` on CCL returns `(CCL::&LEXPR CCL::NUMBERS)`, which includes a keyword `&LEXPR` that is not on the `LAMBDA-LIST-KEYWORDS` list.

Therefore I conclude that CCL is not compliant when it comes to this issue.

This is a suggested patch to fix this behaviour.
