### PR TITLE
gitignore: ignore some more ephemera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 bin/*fsl
 cocoa-ide/*fsl
 cocoa-ide/*~.*
+cocoa-ide/altconsole/*.o
 cocoa-ide/altconsole/.gdb_history
 cocoa-ide/altconsole/AltConsole
 cocoa-ide/altconsole/AltConsole.app
@@ -45,6 +46,8 @@ examples/cocoa/*~.*
 examples/cocoa/easygui/*fsl
 examples/cocoa/easygui/*~.*
 examples/cocoa/easygui/example/*fsl
+examples/cocoa/easygui/example/fasls/*fsl
+examples/cocoa/easygui/fasls/*fsl
 examples/jfli/.cvsignore
 examples/rubix/*~.*
 l1-fasls/*fsl
@@ -97,3 +100,5 @@ tools/*fsl
 tools/*~.*
 xdump/*.*fsl
 xdump/*~.*
+darwin-x86-headers/
+darwin-x86-headers64/


### PR DESCRIPTION
This tries to make it be the case that `git status` on a repo where the release tarball has been unpacked and a build has been done but no other changes have been made will be completely quiet.

In particular ignore the darwin headers directories which come from
the release tarballs, and additionally ignore some object files in the AltConsole, and some
extra places where fasls seem to end up when rebuilding.

Note: this has only been checked on a Mac: there may be similar changes needed for other platforms.  Sorry.