### PR TITLE
Ignore the built application on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /*headers64/
 
 /*bundle*.app/
+/Clozure\ CL*.app/
 cocoa-ide/altconsole/.gdb_history
 cocoa-ide/altconsole/AltConsole
 cocoa-ide/altconsole/AltConsole.app


### PR DESCRIPTION
I build the CCL GUI application just by `(require :cocoa-application)` on OSX, which leaves `Clozure CL64.app` (or equivalent 32-bit app) in the top directory of the repo.  This tries to ignore that.

Note I am not sure I am building the app the right way: this is how I've always done it but I don't know why or if there is a better way which doesn't leave it in the repo.  So this might not be needed.