### PR TITLE
In %bignum-random, normalize generated bignum

### DIFF
--- a/level-0/l0-bignum64.lisp
+++ b/level-0/l0-bignum64.lisp
@@ -2080,9 +2080,9 @@
       (setf (bignum-ref bignum sign-index)
             (logand #x7fffffff (the (unsigned-byte 32)
                                  (random (expt 2 (1- digit-size)) state))))
-      (let* ((result (mod bignum number)))
+      (let* ((result (rem (%normalize-bignum-macro bignum) number)))
         (if (eq result bignum)
-          (copy-uvector bignum)
+          (copy-bignum bignum)
           result)))))
 
 


### PR DESCRIPTION
%bignum-random wasn't normalizing its bignums before passing them to MOD (aka REM).

Luckily the current implementation of REM managed to ignore the bogosity and happened fix up the result, at least in the 64 bit version.  Perhaps 32 bit version wasn't as lucky -- see ticket 1403 in trac.  Note however that this change is in l0-bignum64 only.  I can't find the 32 bit version of %bignum-random, so I couldn't fix it.
