### PR TITLE
ccl:arglist - set explicit *PACKAGE* during READ

### DIFF
--- a/lib/arglist.lisp
+++ b/lib/arglist.lisp
@@ -82,7 +82,8 @@
           (declare (dynamic-extent eof))
           (loop
             (multiple-value-setq (val errorp)
-              (ignore-errors (values (read stream nil eof))))
+              (ignore-errors (values (let ((*package* (symbol-package sym)))
+                                       (read stream nil eof)))))
             (when errorp
               (push '&rest res)
               (push ':unparseable res)


### PR DESCRIPTION
ccl:arglist would intern symbols of macro lambda lists into the current
package. This patch changes the current package to the SYMBOL-PACKAGE
of the first argument.

I.e.: (ccl:arglist 'cl:setf) → (&REST COMMON-LISP::ARGS)

See Also: #44 