### PR TITLE
[WIP] Make get-internal-real-time monotonic

### DIFF
--- a/level-1/l1-lisp-threads.lisp
+++ b/level-1/l1-lisp-threads.lisp
@@ -96,12 +96,6 @@
     (* (logior (pref time #>FILETIME.dwLowDateTime)
                (ash (pref time #>FILETIME.dwHighDateTime) 32))
        100)))
-(defloadvar *lisp-start-timeval*
-    (progn
-      (let* ((r (make-record :timeval)))
-        (gettimeofday r)
-        r)))
-
 
 (defloadvar *internal-real-time-session-seconds* nil)
 

--- a/level-1/l1-lisp-threads.lisp
+++ b/level-1/l1-lisp-threads.lisp
@@ -97,33 +97,15 @@
                (ash (pref time #>FILETIME.dwHighDateTime) 32))
        100)))
 
-(defloadvar *internal-real-time-session-seconds* nil)
-
-
 (defun get-internal-real-time ()
   "Return the real time in the internal time format. (See
   INTERNAL-TIME-UNITS-PER-SECOND.) This is useful for finding elapsed time."
-  (rlet ((tv :timeval))
-    (gettimeofday tv)
-    (let* ((units (truncate (the fixnum (pref tv :timeval.tv_usec)) (/ 1000000 internal-time-units-per-second)))
-           (initial *internal-real-time-session-seconds*))
-      (if initial
-        (locally
-            (declare (type (unsigned-byte 32) initial))
-          (+ (* internal-time-units-per-second
-                (the (unsigned-byte 32)
-                  (- (the (unsigned-byte 32) (pref tv :timeval.tv_sec))
-                     initial)))
-             units))
-        (progn
-          (setq *internal-real-time-session-seconds*
-                (pref tv :timeval.tv_sec))
-          units)))))
+  (values (truncate (current-time-in-nanoseconds)
+                    (load-time-value
+                     (/ 1000000000 internal-time-units-per-second)))))
 
 (defun get-tick-count ()
-  (values (floor (get-internal-real-time)
-                 (floor internal-time-units-per-second
-                        *ticks-per-second*))))
+  (values (truncate (current-time-in-nanoseconds) *ns-per-tick*)))
 
 
 

--- a/lib/time.lisp
+++ b/lib/time.lisp
@@ -282,25 +282,3 @@
   INTERNAL-TIME-UNITS-PER-SECOND.) This is useful for finding CPU usage."
   (multiple-value-bind (user sys) (%internal-run-time)
     (+ user sys)))
-
-#-(or darwin-target windows-target)
-(defloadvar preferred-posix-clock-id
-  (rlet ((ts :timespec))
-    (if (eql 0 (#_clock_gettime #$CLOCK_MONOTONIC ts))
-      #$CLOCK_MONOTONIC
-      #$CLOCK_REALTIME)))    
-
-(defun current-time-in-nanoseconds ()
-  #-(or darwin-target windows-target)
-  (rlet ((ts :timespec))
-    (#_clock_gettime preferred-posix-clock-id ts)
-    (+ (* (pref ts :timespec.tv_sec) 1000000000)
-       (pref ts :timespec.tv_nsec)))
-  #+darwin-target (#_mach_absolute_time)
-  #+windows-target
-  (rlet ((time #>FILETIME))
-    (#_GetSystemTimeAsFileTime time)
-    (* (logior (pref time #>FILETIME.dwLowDateTime)
-               (ash (pref time #>FILETIME.dwHighDateTime) 32))
-       100)))
-


### PR DESCRIPTION
See Also: #20

This work-in-progress PR moves `ccl:current-time-in-nanoseconds` from lib/time to l1-lisp-threads, and uses it to implement `get-internal-real-time` and `ccl::get-tick-count`.

The previous implementation of `get-internal-real-time` remembered the initial seconds value and subtracted it from values before returning them. I.e. the values returned by `get-internal-real-time` would be close to zero after starting CCL. The new implementation does no such thing, the value returned is relative  to system boot time.

Additionally it changes `ccl:current-time-in-nanoseconds` to

- return a monotonic value on Windows (>=Vista, see https://msdn.microsoft.com/en-us/library/windows/desktop/ms724411%28v=vs.85%29.aspx)
- return a nanosecond value on Darwin (presumably, there was a bug here, see https://developer.apple.com/library/content/qa/qa1398/_index.html)

Could anyone on Windows/Darwin test these changes? I remember Microsoft to provide virtual machine images for testing, but I doubt they include a C compiler? Anyway, this should print as shown below:

```
(let* ((a (get-internal-real-time)) (at (ccl::get-tick-count))
         (_ (sleep 3))
        (b (get-internal-real-time)) (bt (ccl::get-tick-count)))
   (print (float (/ (- b a) internal-time-units-per-second)))
   (print (float (- bt at)))
   (print ccl::*ticks-per-second*)
   (values))
;Compiler warnings :
;   In an anonymous lambda form at position 0: Unused lexical variable _
3.000157 
3000.0 
1000
```

