### PR TITLE
defmacro - record fully qualified argstring

### DIFF
--- a/lib/macros.lisp
+++ b/lib/macros.lisp
@@ -670,7 +670,8 @@
                           (if (eq arg '&aux)
                             (return)
                             (push arg temp)))
-                        (format nil "~:a" (nreverse temp)))))
+                        (let ((*package* (find-package "KEYWORD")))
+                          (format nil "~:S" (nreverse temp))))))
       (if (and body-pos (memq '&optional normalized)) (decf body-pos))
       `(progn
          (eval-when (:compile-toplevel)


### PR DESCRIPTION
ccl:arglist would have the unexpected side effect of semi-randomly
interning symbols found in macro lambda lists. This change ensures that
symbols are only interned in packages where they have actually been used.

See http://lisptips.com/post/20871695085/printing-package-qualified-symbols

See Also: #44