### PR TITLE
[RFC] Extend and export CCL::CONDITIONAL-STORE

### DIFF
--- a/doc/manual/threads.ccldoc
+++ b/doc/manual/threads.ccldoc
@@ -1515,6 +1515,30 @@ A process cannot meaningfully attempt to enable itself.")
         (ref (definition :function make-lock)) ", " (ref (definition :function make-read-write-lock)) ", "
         (ref (definition :function make-semaphore)) ", " (ref (definition :function process-input-wait)) ", "
         (ref (definition :function process-output-wait)))))
+    (definition (:macro conditional-store) "conditional-store place old-value new-value"
+     "Attempts to atomically replace {param old-value} in {param place} with {param new-value}."
+     (defsection "Arguments and Values"
+       (listing :definition
+         (item "{param place}" ccldoc::=> "a {emphasis place}.")
+         (item "{param old-value}" ccldoc::=> "an {emphasis object}.")
+         (item "{param new-value}" ccldoc::=> "an {emphasis object}.")
+         (item "{param result}" ccldoc::=> "a {emphasis boolean} indicating whether the operation succeeded.")))
+     (defsection "Description"
+       (para "Attempts to atomically replace {param old-value} in {param place} with {param new-value},
+              and returns as its {param result} a {emphasis boolean} that indicates
+              whether the operation was successful.")
+       (para "If {param result} is {emphasis true},
+              the value of {param place} was replaced with the {param new-value}.
+              If {param result} is {emphasis false},
+              the value of {param place} was not {code eq} to {param old-value} and left unchanged.")
+       (para "{param Place} can be one of:")
+       (listing :bullet
+         (item "a {emphasis special variable},")
+         (item "a {emphasis car} or a {emphasis cdr} (i.e. {code (car …)} or {code (cdr …)}),")
+         (item "a {emphasis structure slot} referenced by its accessor (i.e. not via {code with-slots}).")))
+     (defsection "Notes"
+       (para "This operations is known as Compare and Swap (CAS),
+              and can be used to implement lock-free synchronization in multithreaded programs.")))
     (definition (:toplevel-command ":Y") "( :y p)" "Yields control of terminal input to a specified
 	      lisp process (thread)."
      (defsection "Arguments and Values"

--- a/lib/ccl-export-syms.lisp
+++ b/lib/ccl-export-syms.lisp
@@ -575,6 +575,8 @@
      process-input-wait
      process-output-wait
      wait-for-signal
+
+     conditional-store
                                         ; termination
      terminate-when-unreachable
      terminate

--- a/lib/macros.lisp
+++ b/lib/macros.lisp
@@ -3617,6 +3617,9 @@ element-type is numeric."
       (if struct-transform
         (setq place (defstruct-ref-transform struct-transform (cdr place) env)
               sym (car place)))
+      (if (eq (car place) 'the)
+        (setq place (caddr place)
+              sym (car place)))
       (if (member  sym '(svref ccl::%svref ccl::struct-ref))
         (let* ((v (gensym)))
           `(let* ((,v ,(cadr place)))

--- a/lib/macros.lisp
+++ b/lib/macros.lisp
@@ -3620,12 +3620,18 @@ element-type is numeric."
       (if (eq (car place) 'the)
         (setq place (caddr place)
               sym (car place)))
-      (if (member  sym '(svref ccl::%svref ccl::struct-ref))
-        (let* ((v (gensym)))
-          `(let* ((,v ,(cadr place)))
-            (ccl::store-gvector-conditional ,(caddr place)
-             ,v ,old-value ,new-value)))
-        (signal-program-error "Don't know how to do conditional store to ~s" place)))))
+      (case sym
+        ((svref ccl::%svref ccl::struct-ref)
+         (let* ((v (gensym)))
+           `(let* ((,v ,(cadr place)))
+              (ccl::store-gvector-conditional
+               ,(caddr place) ,v ,old-value ,new-value))))
+        (car
+         `(%rplaca-conditional ,(cadr place) ,old-value ,new-value))
+        (cdr
+         `(%rplacd-conditional ,(cadr place) ,old-value ,new-value))
+        (otherwise
+         (signal-program-error "Don't know how to do conditional store to ~s" place))))))
 
 (defmacro step (form)
   "The form is evaluated with single stepping enabled. Function calls


### PR DESCRIPTION
I made use of this hidden gem to implement [CAS based queues for Erlangen](https://github.com/eugeneia/erlangen/blob/cas/queues.lisp#L1). It has some rough edges, but I feel like a polished `conditional-store` would make a fine addition to the CCL API. What do you think?

So far I have

- added some code to deal with type annotated structure slots (i.e. `conditional-store` on a slot with a type specified would fail, because it could not handle the emitted `the` forms)
- added clauses for `car` and `cdr` places that call out to `ccl::%rplaca-conditional` and `ccl::%rplacd-conditional` respectively
- added `conditional-store` to the list of symbols exported from the CCL package and wrote some documentation for `conditional-store`

Some issues remain:

- it does not work with `with-slots` due to the type uncertainty at run-time. (i.e. we know the slot name, but not the type of the structure object
- it does not work on array references (could be low hanging fruit?)

I don’t *fully* understand why/how this macro works on the types of places it does, and not on others. This is mainly due to my lack of understanding how slot accesses are implemented. Any hints to what I have to watch out for when dealing with *places* is appreciated. For instance this is the first time I have used `&environment`, and suddenly there are so many questions. Like, who deals with `(the ...)` forms, what do I break when I mess with these during macro expansion?

**Example usage:**

```
? (defstruct foo (x 0) (y 1 :type fixnum))
FOO
? (let ((c (cons :a :b))
       (f (make-foo)))
   (ccl:conditional-store (car c) :a :c)
   (ccl:conditional-store (cdr c) :b :d)
   (ccl:conditional-store (foo-x f) 0 2)
   (ccl:conditional-store (foo-y f) 1 3)
   (values c f))
(:C . :D)
#S(FOO :X 2 :Y 3)
```