### PR TITLE
[Sketch] OS-level tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ lisp-kernel/darwinx8664/mach_exc_server.c
 lisp-kernel/darwinx8664/probes.h
 lisp-kernel/static-linuxppc/external-functions.h
 
+lisp-kernel/linuxx8664/probes.h
+lisp-kernel/linuxx8632/probes.h

--- a/lib/ccl-export-syms.lisp
+++ b/lib/ccl-export-syms.lisp
@@ -482,6 +482,7 @@
      set-gc-notification-threshold
      *pending-gc-notification-hook*
      current-time-in-nanoseconds
+     create-perf-map
      
      population
      make-population

--- a/lib/perf-help.lisp
+++ b/lib/perf-help.lisp
@@ -1,0 +1,78 @@
+;;; Copyright 2009 Clozure Associates
+;;; This file is part of Clozure CL.
+;;;
+;;; Clozure CL is licensed under the terms of the Lisp Lesser GNU
+;;; Public License , known as the LLGPL and distributed with Clozure
+;;; CL as the file "LICENSE".  The LLGPL consists of a preamble and
+;;; the LGPL, which is distributed with Clozure CL as the file "LGPL".
+;;; Where these conflict, the preamble takes precedence.
+;;;
+;;; Clozure CL is referenced in the preamble as the "LIBRARY."
+;;;
+;;; The LLGPL is also available online at
+;;; http://opensource.franz.com/preamble.html
+
+(in-package "CCL")
+
+(defloadvar *readonly-remapped-p* nil)
+
+(defun %remap-readonly-area ()
+  (unless *readonly-remapped-p*
+    (impurify)
+    (let* ((a (do-consing-areas (a)
+                (when (eql (%fixnum-ref a target::area.code)
+                           ccl::area-readonly)
+                  (return a))))
+           (low (%int-to-ptr (ash (%fixnum-ref a target::area.low) target::fixnumshift)))
+           (active (ash (%fixnum-ref a target::area.active) target::fixnumshift))
+           (high (ash (%fixnum-ref a target::area.active) target::fixnumshift))
+           (tsize (- high (%ptr-to-int low)))
+           (lsize (- active (%ptr-to-int low)))
+           (p (#_malloc lsize)))
+      (#_memcpy p low lsize)
+      (#_munmap low tsize)
+      (#_mmap low
+              tsize
+              (logior #$PROT_READ #$PROT_WRITE #$PROT_EXEC)
+              (logior #$MAP_FIXED #$MAP_ANONYMOUS #$MAP_PRIVATE)
+              -1
+              0)
+      (#_memcpy low p lsize)
+      (#_mprotect low tsize (logior #$PROT_READ  #$PROT_EXEC))
+      (#_free p)
+      (setq *readonly-remapped-p* t))))
+
+(defun perf-lisp-function-name (f)
+  (let* ((name (function-name f)))
+    (if (and (symbolp name)
+	     (eq f (fboundp name)))
+      (with-standard-io-syntax
+	(format nil "~s" name))
+      (let ((str (format nil "~s" f)))
+	(subseq (nsubstitute #\0 #\# (nsubstitute #\. #\Space str)) 1)))))
+
+#+x86-target
+(defun collect-pure-functions ()
+  (purify)
+  (collect ((functions))
+    (%map-areas (lambda (o)
+                  (when (typep o
+                               #+x8664-target 'function-vector
+                               #-x8664-target 'function)
+                    (functions (function-vector-to-function o))))
+                :readonly)
+    (functions)))
+
+(defun write-perf-map (stream)
+  (dolist (f (collect-pure-functions))
+    (format stream "~16,'0x ~x ~a~%"
+            (logandc2 (%address-of f) target::fulltagmask)
+            (1+ (ash (1- (%function-code-words f)) target::word-shift))
+            (perf-lisp-function-name f))))
+
+(defun create-perf-map (&key path)
+  (let* ((pid (getpid))
+         (path (or path (format nil "/tmp/perf-~d.map" pid))))
+    (%remap-readonly-area)
+    (with-open-file (out path :direction :output :if-exists :supersede)
+      (write-perf-map out))))

--- a/lib/systems.lisp
+++ b/lib/systems.lisp
@@ -229,6 +229,7 @@
     (dominance        "ccl:bin;dominance"        ("ccl:library;dominance.lisp"))
     (swank-loader     "ccl:bin;swank-loader"     ("ccl:library;swank-loader.lisp"))    
     (remote-lisp      "ccl:bin;remote-lisp"      ("ccl:library;remote-lisp.lisp" "ccl:lib;swink.lisp"))
+    (perf-help      "ccl:bin;perf-help"          ("ccl:library;perf-help.lisp"))
  
     (prepare-mcl-environment "ccl:bin;prepare-mcl-environment" ("ccl:lib;prepare-mcl-environment.lisp"))
     (defsystem        "ccl:tools;defsystem"      ("ccl:tools;defsystem.lisp"))

--- a/lisp-kernel/linuxx8632/Makefile
+++ b/lisp-kernel/linuxx8632/Makefile
@@ -21,7 +21,7 @@ AS = as
 M4 = m4
 ASFLAGS = --32
 M4FLAGS = -DLINUX -DX86 -DX8632 -DHAVE_TLS
-CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE -DHAVE_TLS -DSVN_REVISION=$(SVN_REVISION) # -DGC_INTEGRITY_CHECKING -DDISABLE_EGC
+CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE -DHAVE_TLS -DSVN_REVISION=$(SVN_REVISION) -DUSE_DTRACE # -DGC_INTEGRITY_CHECKING -DDISABLE_EGC
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,
@@ -43,14 +43,15 @@ endif
 .s.o:
 	$(M4) $(M4FLAGS) -I../ $< | $(AS)  $(ASFLAGS) -o $@
 .c.o:
-	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT) $(WFORMAT) -m32 -o $@
+	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT) $(WFORMAT) -I. -m32 -o $@
 
 SPOBJ = pad.o x86-spjump32.o x86-spentry32.o x86-subprims32.o
 ASMOBJ = x86-asmutils32.o imports.o
 
 COBJ  = pmcl-kernel.o gc-common.o x86-gc.o bits.o  x86-exceptions.o \
 	x86-utils.o \
-	image.o thread_manager.o lisp-debug.o memory.o unix-calls.o
+	image.o thread_manager.o lisp-debug.o memory.o unix-calls.o \
+	probes.o
 
 DEBUGOBJ = lispdcmd.o plprint.o plsym.o xlbt.o x86_print.o
 KERNELOBJ= $(COBJ) x86-asmutils32.o  imports.o
@@ -79,9 +80,13 @@ USE_LINK_SCRIPT = # -T $(LINK_SCRIPT)
 
 $(SPOBJ): $(SPINC)
 $(ASMOBJ): $(SPINC)
-$(COBJ): $(CHEADERS)
+$(COBJ): $(CHEADERS) probes.h
 $(DEBUGOBJ): $(CHEADERS) lispdcmd.h
 
+probes.h: probes.d
+	dtrace -h -s $<
+probes.o: probes.d
+	dtrace -G -s $<
 
 cclean:
 	$(RM) -f $(KERNELOBJ) $(DEBUGOBJ) ../../lx86cl

--- a/lisp-kernel/linuxx8664/Makefile
+++ b/lisp-kernel/linuxx8664/Makefile
@@ -21,7 +21,7 @@ AS = as
 M4 = m4
 ASFLAGS = --64
 M4FLAGS = -DLINUX -DX86 -DX8664 -DHAVE_TLS
-CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS  -DSVN_REVISION=$(SVN_REVISION) #-DDISABLE_EGC -DUSE_FUTEX
+CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS  -DSVN_REVISION=$(SVN_REVISION) -DUSE_DTRACE #-DDISABLE_EGC -DUSE_FUTEX
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,
@@ -43,14 +43,15 @@ endif
 .s.o:
 	$(M4) $(M4FLAGS) -I../ $< | $(AS)  $(ASFLAGS) -o $@
 .c.o:
-	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT) $(WFORMAT) -m64 -o $@
+	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT) $(WFORMAT) -I. -m64 -o $@
 
 SPOBJ = pad.o x86-spjump64.o x86-spentry64.o x86-subprims64.o
 ASMOBJ = x86-asmutils64.o imports.o
 
 COBJ  = pmcl-kernel.o gc-common.o x86-gc.o bits.o  x86-exceptions.o \
 	x86-utils.o \
-	image.o thread_manager.o lisp-debug.o memory.o unix-calls.o
+	image.o thread_manager.o lisp-debug.o memory.o unix-calls.o \
+	probes.o
 
 DEBUGOBJ = lispdcmd.o plprint.o plsym.o xlbt.o x86_print.o
 KERNELOBJ= $(COBJ) x86-asmutils64.o  imports.o
@@ -79,9 +80,13 @@ USE_LINK_MAP = # -T ./elf_x86_64.x
 
 $(SPOBJ): $(SPINC)
 $(ASMOBJ): $(SPINC)
-$(COBJ): $(CHEADERS)
+$(COBJ): $(CHEADERS) probes.h
 $(DEBUGOBJ): $(CHEADERS) lispdcmd.h
 
+probes.h: probes.d
+	dtrace -h -s $<
+probes.o: probes.d
+	dtrace -G -s $<
 
 cclean:
 	$(RM) -f $(KERNELOBJ) $(DEBUGOBJ) ../../lx86cl64

--- a/lisp-kernel/os-linux.h
+++ b/lisp-kernel/os-linux.h
@@ -22,3 +22,7 @@
 #define SIG_SUSPEND_THREAD (SIGRTMIN+6)
 #define SIG_KILL_THREAD (SIGRTMIN+7)
 #endif
+
+#ifdef USE_DTRACE
+#include "probes.h"
+#endif

--- a/scripts/get-bootstrap-binaries.py
+++ b/scripts/get-bootstrap-binaries.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+
+# needs Python 2.7
+
+# This script is for the benefit of buildbot workers.  Here's a
+# summary of what it does.
+#
+# First, it creates a directory named "bootstrap" in the ccl directory
+# (assumed to be the parent directory of the one this script lives in).
+# This is where it will download bootstrapping heap images and interface
+# databases.
+#
+# Next, "git describe --abbrev=0" is used to determine the  most recent
+# tag.  This tag is assumed to correspond to a GitHub release.  The
+# script then calls GitHub to get all the information about the release.
+#
+# Finally, the script looks through the release data to determine the
+# URLs of the release assets needed for the current platform.  It then
+# downloads those assets as needed.
+#
+# It goes to some trouble to avoid needlessly re-downloading files by
+# using ETag and If-None-Match headers.  When making a request that
+# returns a 304 status code, it is not supposed to count against the
+# GitHub rate limit, but whatever I am doing here seems to use up the
+# rate limit allowance anyway.
+#
+# See https://developer.github.com/v3/#conditional-requests
+
+import sys, os, errno, platform, getopt, requests, json, subprocess;
+
+# GitHub rate-limits anonymous requests (from a single IP address) to
+# 60 requests per hour.  The limit for authenticated users is much
+# higher.  The buildbot master will arrange to set these environment
+# variables with appropriate credentials.
+guser = os.getenv("GITHUB_USER")
+gtoken = os.getenv("GITHUB_TOKEN")
+
+def git_tag():
+    output = subprocess.check_output(["git", "describe", "--abbrev=0"])
+    return output.strip()
+                               
+def ensure_directory_exists(path):
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+def fetch(url, dest, auth):
+    print "fetching", url
+    headers = {"accept": "application/octet-stream"}
+    r = requests.get(url, headers=headers, auth=auth) 
+    if r.status_code == 200:
+        with open(dest, "wb") as f:
+            for chunk in r.iter_content(1024 * 64):
+                f.write(chunk)
+        etag = r.headers["etag"]
+        return etag
+    else:
+        r.raise_for_status()
+        return None
+
+# ETags for already-downloaded files are saved in a json dictionary in
+# a file named "etags.json" in the bootstrapping directory.
+#
+# Format:
+#    {"dx86cl.image.bz2": "\"621c87a2fdbdcce8d9aeb7249589b28c\"",
+#     "dx86cl64.image.bz2": "\"...\""}
+
+def load_etags(dir):
+    path = os.path.join(dir, "etags.json")
+    etags = {}
+    try:
+        with open(path, "r") as f:
+            etags = json.load(f)
+    except IOError:
+        print "note: couldn't open saved etags file", path
+    except ValueError:
+        print "note: removing seemingly corrupt saved etags file"
+        os.remove(path)
+    finally:
+        return etags
+
+def save_etags(data, dir):
+    old = load_etags(dir)
+    new = old.copy()
+    new.update(data)
+
+    path = os.path.join(dir, "etags.json")
+    with open(path, "w") as f:
+        json.dump(new, f)
+
+def main(argv):
+    force = False
+    verbose = False
+    
+    try:
+        opts, args = getopt.getopt(argv, "fvc:b:")
+    except getopt.GetoptError as err:
+        print str(err)
+        usage()
+        sys.exit(1)
+    for opt, val in opts:
+        if opt == "-f":
+            force = True
+        elif opt == "-v":
+            verbose = True
+        else:
+            assert False, "unhandled option"
+
+    system = platform.system()
+    machine = platform.machine()
+            
+    if system == "Darwin":
+        binaries = ["dx86cl.image.bz2", "dx86cl64.image.bz2",
+                    "darwin-x86-headers.tar.bz2",
+                    "darwin-x86-headers64.tar.bz2"]
+    elif system == "Linux":
+        if machine == "armv7l":
+            binaries = ["armcl.image.bz2", "arm-headers.tar.bz2"]
+        else:
+            binaries = ["lx86cl.image.bz2", "lx86cl64.image.bz2",
+                        "x86-headers.tar.bz2", "x86-headers64.tar.bz2"]
+    elif system == "FreeBSD":
+        binaries = ["fx86cl.image.bz2", "fx86cl64.image.bz2"
+                    "freebsd-headers.tar.bz2", "freebsd-headers64.tar.bz2"]
+    elif system == "SunOS":
+        binaries = ["sx86cl.image.gz", "sx86cl64.image.gz",
+                    "solarisx86-headers.tar.bz2", "solarisx64-headers.tar.bz2"]
+    elif system == "Windows":
+        binaries = ["wx86cl.image.zip", "wx86cl64.image.zip",
+                    "win32-headers.tar.bz2", "win64-headers64.tar.bz2"]
+    else:
+        raise RuntimeError("unknown system {0}".format(system))
+
+    scripts_directory = os.path.dirname(os.path.abspath(__file__))
+    ccl_directory = os.path.dirname(scripts_directory)
+    bootstrap_dir = os.path.join(ccl_directory, "bootstrap")
+
+    ensure_directory_exists(bootstrap_dir)
+
+    if guser and gtoken:
+        auth = (guser, gtoken)
+    else:
+        auth = None
+
+    # It would be nice to be able to do ETag processing for this
+    # endpoint so that we could cache the release info.
+    # Unfortunately, release assets (which are all included as part of
+    # the overall release info) keep a count of how many times they
+    # have been downloaded.  This count seems to increase even when a
+    # GET request ends up returning a status code of 304 Not Modified.
+    # Thus, this very script ends up changing the release info (and
+    # hence the ETag) as a side effect of checking whether the
+    # bootstrapping binaries have been updated.
+
+    tag = git_tag()        
+    url = "https://api.github.com/repos/Clozure/ccl/releases/tags/" + tag
+    r = requests.get(url, auth=auth)
+    assert r.status_code == 200, r.text
+
+    release_info = r.json()
+    assets = release_info["assets"]
+
+    downloads = []
+    for a in assets:
+        if a["name"] in binaries:
+            downloads.append({"name": a["name"], "url": a["url"]})
+
+            
+    local_etags = load_etags(bootstrap_dir)
+    etags = {}
+
+    for d in downloads:
+        name = d["name"]
+        url = d["url"]
+        dest = os.path.join(bootstrap_dir, name)
+        local_etag = local_etags.get(name)
+        if force or not os.path.exists(dest):
+            etag = fetch(url, dest, auth)
+            if etag:
+                etags[name] = etag
+        elif os.path.exists(dest) and local_etag:
+            # make a conditional request to see if the remote file
+            # is still the same as the local version
+            headers = {"accept": "application/octet-stream",
+                       "if-none-match": local_etag}
+            r = requests.get(url, headers=headers, auth=auth)
+            if r.status_code == 304:
+                print name, "is up-to-date"
+            elif r.status_code == 200:
+                with open(dest, "wb") as f:
+                    for chunk in r.iter_content(1024 * 64):
+                        f.write(chunk)
+                etag = r.headers["etag"]
+                if etag:
+                    etags[name] = etag
+            else:
+                r.raise_for_status()
+        else:
+            # Some other situation.  Just downlaod the asset.
+            etag = fetch(url, dest, auth)
+            if etag:
+                etags[name] = etag
+            
+    save_etags(etags, bootstrap_dir)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
This is my working branch for exploring OS-level tracing capabilities. So far it includes:

- USDT probe support for Linux (via SystemTap)

This adds a build dependency (SystemTap) on Linux systems, so it might make sense to put this behind a flag. IMHO the (build-only) dependency is worth its weight and USDT probes should be there by default. What this gives you is that you can attach to probes (these were already defined for use with DTrace on Darwin) of running CCL processes via BCC’s [trace](https://github.com/iovisor/bcc/blob/master/tools/trace.py):

```
# trace -p 2570 \
      'u:ccl:egc__start "used %d, gen %d", arg1, arg2' \
      'u:ccl:egc__finish "freed %d, gen %d", arg1, arg2' \
      'u:ccl:gc__start "used %d", arg1' \
      'u:ccl:gc__finish "freed %d", arg1'
> PID    TID    COMM         FUNC             -
2570   3469   lx86cl64     egc__start       used 2097152, gen 0
2570   3469   lx86cl64     egc__finish      freed 1514896, gen 0
2570   3484   lx86cl64     egc__start       used 2170256, gen 0
2570   3484   lx86cl64     egc__finish      freed 2065552, gen 0
2570   3499   lx86cl64     egc__start       used 2196624, gen 0
2570   3499   lx86cl64     egc__finish      freed 2090240, gen 0
2570   3514   lx86cl64     egc__start       used 2221312, gen 0
2570   3514   lx86cl64     egc__finish      freed 2116432, gen 0
...
2570   2571   lx86cl64     gc__start        used 55574528
2570   2571   lx86cl64     gc__finish       freed 32111648
2570   2571   lx86cl64     egc__start       used 2227232, gen 0
2570   2571   lx86cl64     egc__finish      freed 0, gen 0
...
```

- `PERF-HELPER`, a mechanism to export symbol map files for use with Linux’s `perf(1)`. The code/magic for this module was provided by Gary Byers, and worked out of the box, credit to him! In a nutshell it allows you to dump a map of the current heap:

```
(require "PERF-HELP")
(ccl:create-perf-map) ; will create "/tmp/perf-<PID>.map"
```

which allows `perf(1)` to reconstruct stack traces of a running CCL process.  Now when you profile CCL via perf:

```
perf record -F 999 -p <PID> -g -- sleep 20 # Sample at 999 Hz for 20 seconds
perf report # labels stack frames using /tmp/perf-<PID>.map
```

Or instead of using `perf report` [generate fancy SVG flame graphs](http://mr.gy/tmp/ring-bench.svg), see http://www.brendangregg.com/flamegraphs.html :-)

If you look at the flame graph you can see that there are still a bunch of “unknown” frames. Some of these are kernel frames, and merely unresolved because I ran the example as a regular user, but some are indeed frames that point into the CCL process but can’t be resolved via the perf map. That’s a FIXME.

**TODO**

- Add more USDT probes: there already exist probes for GC/EGC events as well as thread startup. There should be more events in CCL that make for interesting probes, suggestions welcome.