### PR TITLE
fix need libpthread-1.dll in windows 64 build

### DIFF
--- a/lisp-kernel/win64/Makefile
+++ b/lisp-kernel/win64/Makefile
@@ -97,7 +97,7 @@ KSPOBJ = $(SPOBJ)
 all:	../../wx86cl64.exe
 
 
-OSLIBS = -lpsapi -lws2_32
+OSLIBS = -lpsapi -lws2_32 -static -lpthread
 
 
 ../../wx86cl64.exe:	$(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) Makefile pei-x86-64.x


### PR DESCRIPTION
See https://github.com/Clozure/ccl/issues/55
Checked with visual studio's dumpbin.exe. 32 bit ccl doesn't require libpthread-1.dll. But 64 bit ccl does. It's added by mingw64-x86_64-gcc. After static link it, now it's able to run wx86cl64 with only ccl image
Reference:
https://stackoverflow.com/questions/13768515/how-to-do-static-linking-of-libwinpthread-1-dll-in-mingw