### PR TITLE
building in both cygwin and msys2

### DIFF
--- a/lisp-kernel/win32/Makefile
+++ b/lisp-kernel/win32/Makefile
@@ -44,21 +44,18 @@ SVN_REVISION := "$(shell svnversion || echo unknown)"
 
 VPATH = ../
 RM = rm
-CC = i686-w64-mingw32-gcc
 
 ifeq ($(MSYSTEM),)
+CC = i686-w64-mingw32-gcc
 AS = i686-w64-mingw32-as
+LD = i686-w64-mingw32-ld
 else
+CC = /mingw32/bin/i686-w64-mingw32-gcc
 AS = /mingw32/bin/as
+LD = /mingw32/bin/ld
 endif
 
 M4 = m4
-
-ifeq ($(MSYSTEM),)
-LD = i686-w64-mingw32-ld
-else
-LD = /mingw32/bin/ld
-endif
 
 ASFLAGS = -g --32
 M4FLAGS = -DWIN_32 -DWINDOWS -DX86 -DX8632

--- a/lisp-kernel/win32/Makefile
+++ b/lisp-kernel/win32/Makefile
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 # This makefile is written to be used with the mingw toolchain
-# running in the Cygwin environment.
-#
+# running in the Cygwin environment or Msys2 environment.
+
+# If running in the Cygwin environment:
 # Install the following Cygwin packages:
 # * make
 # * m4
@@ -27,14 +28,38 @@
 #
 # Accept the dependencies the installation tool may add.
 
+# If running in the Msys2 environment:
+# Install the following Msys2 packages using pacman -S:
+# * make
+# * m4
+# * mingw-w64-i686-binutils
+# * mingw-w64-i686-crt
+# * mingw-w64-i686-gcc
+# * mingw-w64-i686-headers
+# * mingw-w64-i686-winpthreads
+# Accept the dependencies the installation tool may add.
+# Currently only install make, m4 and mingw-w64-i686-gcc will install other
+# mingw-w64-* dependencies. May change in the future.
 SVN_REVISION := "$(shell svnversion || echo unknown)"
 
 VPATH = ../
 RM = rm
 CC = i686-w64-mingw32-gcc
+
+ifeq ($(MSYSTEM),)
 AS = i686-w64-mingw32-as
+else
+AS = /mingw32/bin/as
+endif
+
 M4 = m4
+
+ifeq ($(MSYSTEM),)
 LD = i686-w64-mingw32-ld
+else
+LD = /mingw32/bin/ld
+endif
+
 ASFLAGS = -g --32
 M4FLAGS = -DWIN_32 -DWINDOWS -DX86 -DX8632
 CDEFINES = -DWIN_32 -DWINDOWS -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE  -D__MSVCRT__ -D__MSVCRT_VERSION__=0x700 -D_WIN32_WINNT=0x0502 -DSVN_REVISION=$(SVN_REVISION)

--- a/lisp-kernel/win64/Makefile
+++ b/lisp-kernel/win64/Makefile
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 # This makefile is written to be used with the mingw toolchain
-# running in the Cygwin environment.
-#
+# running in the Cygwin environment or Msys2 environment.
+
+# If running in the Cygwin environment:
 # Install the following Cygwin packages:
 # * make
 # * m4
@@ -27,16 +28,38 @@
 #
 # Accept the dependencies the installation tool may add.
 
+# If running in the Msys2 environment:
+# Install the following Msys2 packages using pacman -S:
+# * make
+# * m4
+# * mingw-w64-x86_64-binutils
+# * mingw-w64-x86_64-crt
+# * mingw-w64-x86_64-gcc
+# * mingw-w64-x86_64-headers
+# * mingw-w64-x86_64-winpthreads
+# Accept the dependencies the installation tool may add.
+# Currently only install make, m4 and mingw-w64-x86_64-gcc will install other
+# mingw-w64-* dependencies. May change in the future.
+# Running make using msys2-installation-directory/mingw64.exe, not msys2.exe.
 SVN_REVISION := "$(shell svnversion || echo unknown)"
 
 VPATH = ../
 RM = rm
 # gcc64, as64: until there's a real win64 gcc, assume that gcc and gas
 # are installed under these names
+
+ifeq ($(MSYSTEM),)
 CC = x86_64-w64-mingw32-gcc
 AS = x86_64-w64-mingw32-as
-M4 = m4
 LD = x86_64-w64-mingw32-ld
+else
+CC = /mingw64/bin/x86_64-w64-mingw32-gcc
+AS = /mingw64/bin/as
+LD = /mingw64/bin/ld
+endif
+
+M4 = m4
+
 ASFLAGS = -g --64
 M4FLAGS = -DWIN_64 -DWINDOWS -DX86 -DX8664 -DHAVE_TLS -DEMUTLS -DTCR_IN_GPR
 CDEFINES = -DWIN_64 -DWINDOWS -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS -DEMUTLS -DTCR_IN_GPR -DSVN_REVISION=$(SVN_REVISION)


### PR DESCRIPTION
Msys2 is now very popular and I saw there are lispers comments in issues that they also use msys2 instead of cygwin. Compare to cygwin, it has pacman as package management tool, but less POSIX support. And msys2 is official recommended way to install gnu emacs on windows, so I believe there're many lisp programmers using msys2. For building ccl in msys2, it doesn't have many difference than cygwin so I modify Makefile and provide a instruction in comment. Tested on both cygwin and msys2 after modification. Because https://github.com/Clozure/ccl/pull/57 is still under discussion, currently only modify win32 Makefile.