### PR TITLE
Make FD-STREAM-EOFP reliably return T when at EOF.

### DIFF
--- a/level-1/l1-streams.lisp
+++ b/level-1/l1-streams.lisp
@@ -5689,9 +5689,10 @@
                      nil)))))))
 
 (defun fd-stream-eofp (s ioblock)
-  (declare (ignore s))
-  (ioblock-eof ioblock))
-  
+  (or (ioblock-eof ioblock)
+      (progn (fd-stream-advance s ioblock nil)
+             (ioblock-eof ioblock))))
+
 (defun fd-stream-listen (s ioblock)
   (if (interactive-stream-p s)
     (unread-data-available-p (ioblock-device ioblock))


### PR DESCRIPTION
Right now, `fd-stream-eofp` just checks the `iobuffer-eof` flag. This is wrong because the only function that sets this flag is `fd-stream-advance`, which isn't called unless we actually try to read from the stream.

For instance, open an empty file and immediately call `stream-eofp`: you get NIL.

