### PR TITLE
Fix stream-eofp on concatenated streams.

### DIFF
--- a/level-1/l1-streams.lisp
+++ b/level-1/l1-streams.lisp
@@ -4224,7 +4224,7 @@
   (do* ((c (concatenated-stream-current-input-stream s)
 	   (concatenated-stream-next-input-stream s)))
        ((null c) t)
-    (when (stream-listen c)
+    (unless (stream-eofp c)
       (return nil))))
 
 (defmethod stream-clear-input ((s concatenated-stream))


### PR DESCRIPTION
`stream-eofp` on a concatenated stream can return `t` even though `stream-eofp` on one of the underlying streams returns `nil`.

For instance, for a concatenated stream `cs` whose only underlying stream is a socket `s` on which no input is available but which is still open, `(stream-eofp s)` correctly returns `nil`, but `(stream-eofp cs)`
returns `t`.

This is because `(stream-eofp cs)` calls `(stream-listen s)`, which (correctly) returns `nil`, from which `stream-eofp` (incorrectly) deduces that `s` is at end of file.

This is wrong, because `stream-listen` cannot detect EOF; use `stream-eofp` on the underlying stream instead.