### PR TITLE
Fix STREAM-LISTEN on concatenated streams.

### DIFF
--- a/level-1/l1-streams.lisp
+++ b/level-1/l1-streams.lisp
@@ -4217,8 +4217,8 @@
   (do* ((c (concatenated-stream-current-input-stream s)
 	   (concatenated-stream-next-input-stream s)))
        ((null c))
-    (when (stream-listen c)
-      (return t))))
+    (cond ((stream-listen c)     (return t))
+          ((not (stream-eofp c)) (return nil)))))
 
 (defmethod stream-eofp ((s concatenated-stream))
   (do* ((c (concatenated-stream-current-input-stream s)


### PR DESCRIPTION
When calling `stream-listen` on a concatenated stream `cs` with an underlying stream `s`, if `(stream-listen s)` returns `nil`, then `s` is discarded and the function continues with the next underlying stream in `cs`.

This is wrong: `s` should only be discarded when its end of file has been reached, which is in general not the same thing as `listen` returning `nil`.