### PR TITLE
use ucontext_t instead of struct ucontext on Linux

### DIFF
--- a/lisp-kernel/lisp-debug.c
+++ b/lisp-kernel/lisp-debug.c
@@ -208,6 +208,7 @@ foreign_name_and_offset(natural addr, int *delta)
 
 
 #if defined(LINUX) || defined(SOLARIS)
+#include <stdio_ext.h>
 #define fpurge __fpurge
 #endif
 

--- a/lisp-kernel/platform-linuxx8632.h
+++ b/lisp-kernel/platform-linuxx8632.h
@@ -19,7 +19,9 @@
 #define PLATFORM_CPU PLATFORM_CPU_X86
 #define PLATFORM_WORD_SIZE PLATFORM_WORD_SIZE_32
 
-typedef struct ucontext ExceptionInformation;
+#include <ucontext.h>
+
+typedef ucontext_t ExceptionInformation;
 
 #define MAXIMUM_MAPPABLE_MEMORY (9U<<28)
 #define IMAGE_BASE_ADDRESS 0x10000000

--- a/lisp-kernel/platform-linuxx8664.h
+++ b/lisp-kernel/platform-linuxx8664.h
@@ -19,7 +19,9 @@
 #define PLATFORM_CPU PLATFORM_CPU_X86
 #define PLATFORM_WORD_SIZE PLATFORM_WORD_SIZE_64
 
-typedef struct ucontext ExceptionInformation;
+#include <ucontext.h>
+
+typedef ucontext_t ExceptionInformation;
 
 #define MAXIMUM_MAPPABLE_MEMORY (512L<<30L)
 #define IMAGE_BASE_ADDRESS 0x300000000000L

--- a/lisp-kernel/pmcl-kernel.c
+++ b/lisp-kernel/pmcl-kernel.c
@@ -1728,6 +1728,12 @@ ensure_gs_available(char *progname)
 {
   LispObj fs_addr = 0L, gs_addr = 0L, cur_thread = (LispObj)pthread_self();
   char *gnu_get_libc_version(void);
+  /*
+   * According arch_prctl(2), there's no function prototype for
+   * arch_prctl().  Thus, we have to declare it ourselves.
+   * Note that addr is unsigned long * for GET operations.
+   */
+  extern int arch_prctl(int code, unsigned long *addr);
   
   arch_prctl(ARCH_GET_GS, &gs_addr);
   arch_prctl(ARCH_GET_FS, &fs_addr);

--- a/lisp-kernel/thread_manager.c
+++ b/lisp-kernel/thread_manager.c
@@ -866,6 +866,13 @@ setup_tcr_extra_segment(TCR *tcr)
   amd64_set_gsbase(tcr);
 #endif
 #ifdef LINUX
+  /*
+   * According arch_prctl(2), there's no function prototype for
+   * arch_prctl().  Thus, we have to declare it ourselves.
+   * Note that addr is unsigned long for SET operations.
+   */
+  extern int arch_prctl(int code, unsigned long addr);
+
   arch_prctl(ARCH_SET_GS, (natural)tcr);
 #endif
 #ifdef DARWIN

--- a/lisp-kernel/x86-exceptions.c
+++ b/lisp-kernel/x86-exceptions.c
@@ -1677,7 +1677,7 @@ struct rt_sigframe {
 	siginfo_t  *pinfo;
 	void  *puc;
 	siginfo_t info;
-	struct ucontext uc;
+	ucontext_t uc;
 	struct _fpstate fpstate;
 	char retcode[8];
 };
@@ -2425,7 +2425,7 @@ setup_sigaltstack(area *a)
      It's easier to just reserve that page here than it would be to
      change copy_ucontext().
   */
-  stack.ss_size -= sizeof(struct ucontext);
+  stack.ss_size -= sizeof(ucontext_t);
 #endif
   if (sigaltstack(&stack, NULL) != 0) {
     perror("sigaltstack");


### PR DESCRIPTION
In addition to using ucontext_t, fix a couple of build warnings involving implicitly-declared functions.
