### PR TITLE
Bugfix to ccl::basename.  Specifying a directory now yields a relativ…

### DIFF
--- a/cocoa-ide/builder-utilities.lisp
+++ b/cocoa-ide/builder-utilities.lisp
@@ -164,7 +164,7 @@
         ;; e.g. "/Users/foo/.emacs"
         (if type
             (make-pathname :type type)
-            (make-pathname :directory (first (last dir)))))))
+            (make-pathname :directory (list :relative (first (last dir))))))))
 
 ;;; PATH (&rest components)
 ;;; ------------------------------------------------------------------------


### PR DESCRIPTION
…e pathspec instead of an absolute, i.e. #P"/one/two/three/" ->> #P"three/" instead of #P"/three/"

This breaks ccl::path, if one of the arguments to path is an absolute directory path, then the resulting path value is incorrect.

This breaks ccl::copy-nibfile, if srcnib is a directory into which we should recurse, its target output directory is incorrectly constructed (to a directory in root, no less!)