### PR TITLE
Don't use svnversion in kernel makefiles

### DIFF
--- a/lisp-kernel/darwinx8632/Makefile
+++ b/lisp-kernel/darwinx8632/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 SDKROOT=/
 OSVERSION=10.6
@@ -45,7 +45,7 @@ ASFLAGS += -Q
 SDKROOT := "$(shell xcrun --show-sdk-path)"
 endif
 
-CDEFINES = -DDARWIN -DX86 -DX8632 -DSVN_REVISION=$(SVN_REVISION) -DUSE_DTRACE
+CDEFINES = -DDARWIN -DX86 -DX8632 -DVC_REVISION=$(VC_REVISION) -DUSE_DTRACE
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/darwinx8664/Makefile
+++ b/lisp-kernel/darwinx8664/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 OSVERSION=10.6
 
@@ -44,7 +44,7 @@ ifeq ($(yosemite_plus),t)
 ASFLAGS += -Q
 endif
 
-CDEFINES = -DDARWIN -DX86 -DX8664 -DTCR_IN_GPR -DSVN_REVISION=$(SVN_REVISION) \
+CDEFINES = -DDARWIN -DX86 -DX8664 -DTCR_IN_GPR -DVC_REVISION=$(VC_REVISION) \
 	   -DUSE_DTRACE
 CDEBUG = -g
 COPT = -O

--- a/lisp-kernel/freebsdx8632/Makefile
+++ b/lisp-kernel/freebsdx8632/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION != svnversion
+VC_REVISION != sh -c "git describe --dirty 2>/dev/null || echo unknown"
 
 VPATH = ..
 RM = /bin/rm
@@ -21,7 +21,7 @@ AS = as
 M4 = m4
 ASFLAGS = --32
 M4FLAGS = -DFREEBSD -DX86 -DX8632 -DHAVE_TLS
-CDEFINES = -DFREEBSD -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE -DHAVE_TLS -DSVN_REVISION="$(SVN_REVISION)"
+CDEFINES = -DFREEBSD -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE -DHAVE_TLS -DVC_REVISION="$(VC_REVISION)"
 CDEBUG = -g
 COPT = #-O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/freebsdx8664/Makefile
+++ b/lisp-kernel/freebsdx8664/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION != svnversion
+VC_REVISION != sh -c "git describe --dirty 2>/dev/null || echo unknown"
 
 VPATH = ..
 RM = /bin/rm
@@ -21,7 +21,7 @@ AS = as
 M4 = m4
 ASFLAGS = --64
 M4FLAGS = -DFREEBSD -DX86 -DX8664 -DHAVE_TLS
-CDEFINES = -DFREEBSD -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS -DSVN_REVISION="$(SVN_REVISION)"
+CDEFINES = -DFREEBSD -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS -DVC_REVISION="$(VC_REVISION)"
 CDEBUG = -g
 COPT = #-O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/linuxarm/Makefile
+++ b/lisp-kernel/linuxarm/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 # default float-abi to whatever the toolchain defaults to.
 FLOAT_ABI_OPTION =
@@ -33,7 +33,7 @@ CC = $(CROSS)gcc
 M4 = m4
 ASFLAGS = -mfpu=vfp -march=armv7-a $(FLOAT_ABI_OPTION)
 M4FLAGS = -DLINUX -DARM
-CDEFINES = -DLINUX -DARM -D_REENTRANT -D_GNU_SOURCE -DSVN_REVISION=$(SVN_REVISION)
+CDEFINES = -DLINUX -DARM -D_REENTRANT -D_GNU_SOURCE -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/linuxarm64/Makefile
+++ b/lisp-kernel/linuxarm64/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 # See <http://people.debian.org/~wookey/bootstrap.html>
 #CROSS=aarch64-linux-gnu-
@@ -24,7 +24,7 @@ CC = ${CROSS}gcc
 M4 = m4
 ASFLAGS = 
 M4FLAGS = -DLINUX -DARM64
-CDEFINES = -DLINUX -DARM64 -D_REENTRANT -D_GNU_SOURCE -DUSE_FUTEX -DSVN_REVISION=$(SVN_REVISION)
+CDEFINES = -DLINUX -DARM64 -D_REENTRANT -D_GNU_SOURCE -DUSE_FUTEX -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/linuxppc/Makefile
+++ b/lisp-kernel/linuxppc/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ../
 RM = /bin/rm
@@ -23,7 +23,7 @@ AS = as
 M4 = m4
 ASFLAGS = -mregnames -mppc32 -maltivec
 M4FLAGS = -DLINUX -DPPC
-CDEFINES = -DLINUX -DPPC -D_REENTRANT -D_GNU_SOURCE -DSVN_REVISION=$(SVN_REVISION)
+CDEFINES = -DLINUX -DPPC -D_REENTRANT -D_GNU_SOURCE -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/linuxppc64/Makefile
+++ b/lisp-kernel/linuxppc64/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ../
 RM = /bin/rm
@@ -23,7 +23,7 @@ AS = as
 M4 = m4
 ASFLAGS = -mregnames -mppc64 -a64 -maltivec
 M4FLAGS = -DLINUX -DPPC -DPPC64
-CDEFINES = -DLINUX -D_REENTRANT -DPPC -DPPC64 -D_GNU_SOURCE -DSVN_REVISION=$(SVN_REVISION)
+CDEFINES = -DLINUX -D_REENTRANT -DPPC -DPPC64 -D_GNU_SOURCE -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
 COPT = -O2
 # word size issues are a little more relevant on a 64-bit platform

--- a/lisp-kernel/linuxx8632/Makefile
+++ b/lisp-kernel/linuxx8632/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ../
 RM = /bin/rm
@@ -21,7 +21,7 @@ AS = as
 M4 = m4
 ASFLAGS = --32
 M4FLAGS = -DLINUX -DX86 -DX8632 -DHAVE_TLS
-CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE -DHAVE_TLS -DSVN_REVISION=$(SVN_REVISION) # -DGC_INTEGRITY_CHECKING -DDISABLE_EGC
+CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE -DHAVE_TLS -DVC_REVISION=$(VC_REVISION) # -DGC_INTEGRITY_CHECKING -DDISABLE_EGC
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/linuxx8664/Makefile
+++ b/lisp-kernel/linuxx8664/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ../
 RM = /bin/rm
@@ -21,7 +21,7 @@ AS = as
 M4 = m4
 ASFLAGS = --64
 M4FLAGS = -DLINUX -DX86 -DX8664 -DHAVE_TLS
-CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS  -DSVN_REVISION=$(SVN_REVISION) #-DDISABLE_EGC -DUSE_FUTEX
+CDEFINES = -DLINUX -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS  -DVC_REVISION=$(VC_REVISION) #-DDISABLE_EGC -DUSE_FUTEX
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/lisp-debug.c
+++ b/lisp-kernel/lisp-debug.c
@@ -45,14 +45,14 @@ typedef enum {
   debug_kill
 } debug_command_return;
 
-#ifdef SVN_REVISION
+#ifdef VC_REVISION
 #define xstr(s) str(s)
 #define str(s) #s
-char *kernel_svn_revision = xstr(SVN_REVISION);
+char *kernel_vc_revision = xstr(VC_REVISION);
 #undef xstr
 #undef str
 #else
-char *kernel_svn_revision = "unknown";
+char *kernel_vc_revision = "unknown";
 #endif
 
 #ifdef ARM
@@ -946,7 +946,7 @@ debug_show_lisp_version(ExceptionInformation *xp, siginfo_t *info, int arg)
 {
   extern void *plsym(ExceptionInformation *,char*);
 
-  fprintf(dbgout, "Lisp kernel svn revision: %s\n", kernel_svn_revision);
+  fprintf(dbgout, "Lisp kernel vc revision: %s\n", kernel_vc_revision);
   if (xp)
     plsym(xp, "*OPENMCL-VERSION*");
   return debug_continue;

--- a/lisp-kernel/solarisx64/Makefile
+++ b/lisp-kernel/solarisx64/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ..
 RM = /bin/rm
@@ -26,7 +26,7 @@ M4 = gm4
 CC = gcc
 ASFLAGS = --64 --divide
 M4FLAGS = -DSOLARIS -DX86 -DX8664
-CDEFINES = -DSOLARIS -D_REENTRANT -DX86 -DX8664 -D__EXTENSIONS__ -DHAVE_TLS -DSVN_REVISION=$(SVN_REVISION) #-DDISABLE_EGC
+CDEFINES = -DSOLARIS -D_REENTRANT -DX86 -DX8664 -D__EXTENSIONS__ -DHAVE_TLS -DVC_REVISION=$(VC_REVISION) #-DDISABLE_EGC
 CDEBUG = -g
 COPT = #-O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/solarisx86/Makefile
+++ b/lisp-kernel/solarisx86/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ..
 RM = /bin/rm
@@ -26,7 +26,7 @@ M4 = gm4
 CC = gcc
 ASFLAGS = --32 --divide
 M4FLAGS = -DSOLARIS -DX86 -DX8632
-CDEFINES = -DSOLARIS -D_REENTRANT -DX86 -DX8632 -D__EXTENSIONS__ -DHAVE_TLS -DSVN_REVISION=$(SVN_REVISION) #-DDISABLE_EGC
+CDEFINES = -DSOLARIS -D_REENTRANT -DX86 -DX8632 -D__EXTENSIONS__ -DHAVE_TLS -DVC_REVISION=$(VC_REVISION) #-DDISABLE_EGC
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/win32/Makefile
+++ b/lisp-kernel/win32/Makefile
@@ -40,7 +40,7 @@
 # Accept the dependencies the installation tool may add.
 # Currently only install make, m4 and mingw-w64-i686-gcc will install other
 # mingw-w64-* dependencies. May change in the future.
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ../
 RM = rm
@@ -59,7 +59,7 @@ M4 = m4
 
 ASFLAGS = -g --32
 M4FLAGS = -DWIN_32 -DWINDOWS -DX86 -DX8632
-CDEFINES = -DWIN_32 -DWINDOWS -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE  -D__MSVCRT__ -D__MSVCRT_VERSION__=0x700 -D_WIN32_WINNT=0x0502 -DSVN_REVISION=$(SVN_REVISION)
+CDEFINES = -DWIN_32 -DWINDOWS -D_REENTRANT -DX86 -DX8632 -D_GNU_SOURCE  -D__MSVCRT__ -D__MSVCRT_VERSION__=0x700 -D_WIN32_WINNT=0x0502 -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
 COPT = -O
 # Once in a while, -Wformat says something useful.  The odds are against that,

--- a/lisp-kernel/win64/Makefile
+++ b/lisp-kernel/win64/Makefile
@@ -41,7 +41,7 @@
 # Currently only install make, m4 and mingw-w64-x86_64-gcc will install other
 # mingw-w64-* dependencies. May change in the future.
 # Running make using msys2-installation-directory/mingw64.exe, not msys2.exe.
-SVN_REVISION := "$(shell svnversion || echo unknown)"
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
 
 VPATH = ../
 RM = rm
@@ -62,7 +62,7 @@ M4 = m4
 
 ASFLAGS = -g --64
 M4FLAGS = -DWIN_64 -DWINDOWS -DX86 -DX8664 -DHAVE_TLS -DEMUTLS -DTCR_IN_GPR
-CDEFINES = -DWIN_64 -DWINDOWS -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS -DEMUTLS -DTCR_IN_GPR -DSVN_REVISION=$(SVN_REVISION)
+CDEFINES = -DWIN_64 -DWINDOWS -D_REENTRANT -DX86 -DX8664 -D_GNU_SOURCE -DHAVE_TLS -DEMUTLS -DTCR_IN_GPR -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
 COPT = -O2
 # Once in a while, -Wformat says something useful.  The odds are against that,


### PR DESCRIPTION
Use git describe --dirty instead.  The idea behind this is for the
lisp kernel debugger to be able to print out the revision of the
source code that was used to build it (via the "v" debugger command).

(ref #75)
