### PR TITLE
Expose Lisp thread names to Linux

### DIFF
--- a/level-1/l1-lisp-threads.lisp
+++ b/level-1/l1-lisp-threads.lisp
@@ -463,7 +463,35 @@
         (unless (zerop natural) natural)))))
 
 
-                         
+
+#+linux-target
+(defun set-os-thread-name (lisp-thread name)
+  "Set the OS-visible name of the thread with pthread_setname_np."
+  (let ((name
+          (if (<= (length name) 15)
+              name
+              (subseq name 0 15))))
+    (let ((natural (lisp-thread-os-thread lisp-thread)))
+      (when natural
+        (with-utf-8-cstr (name name)
+          (external-call "pthread_setname_np"
+                         :pthread_t natural
+                         :address name
+                         :int))))))
+
+#+linux-target
+(defun get-os-thread-name (lisp-thread)
+  "Read the OS-visible name of the thread with pthread_getname_np."
+  (let ((natural (lisp-thread-os-thread lisp-thread)))
+    (when natural
+      (%stack-block ((buffer 16))
+        (external-call "pthread_getname_np"
+                       :pthread_t natural
+                       :address buffer
+                       :size_t 16
+                       :int)
+        (%get-utf-8-cstring buffer)))))
+
 ;;; This returns something lower-level than the pthread, if that
 ;;; concept makes sense.  On current versions of Linux, it returns
 ;;; the pid of the clone()d process; on Darwin, it returns a Mach

--- a/level-1/l1-lisp-threads.lisp
+++ b/level-1/l1-lisp-threads.lisp
@@ -467,13 +467,10 @@
 #+linux-target
 (defun set-os-thread-name (lisp-thread name)
   "Set the OS-visible name of the thread with pthread_setname_np."
-  (let ((name
-          (if (<= (length name) 15)
-              name
-              (subseq name 0 15))))
-    (let ((natural (lisp-thread-os-thread lisp-thread)))
-      (when natural
-        (with-utf-8-cstr (name name)
+  (let ((natural (lisp-thread-os-thread lisp-thread)))
+    (when natural
+      (let ((end (min 15 (length name))))
+        (with-cstr (name name 0 end)
           (external-call "pthread_setname_np"
                          :pthread_t natural
                          :address name
@@ -490,7 +487,7 @@
                        :address buffer
                        :size_t 16
                        :int)
-        (%get-utf-8-cstring buffer)))))
+        (%get-cstring buffer)))))
 
 ;;; This returns something lower-level than the pthread, if that
 ;;; concept makes sense.  On current versions of Linux, it returns

--- a/level-1/l1-processes.lisp
+++ b/level-1/l1-processes.lisp
@@ -159,7 +159,7 @@
 
 (set-type-predicate 'process 'processp)
 
-(defun make-process (name &key 
+(defun make-process (name &key
 			  thread
 			  persistent
                           (priority 0)
@@ -190,7 +190,9 @@
       (unless lisp-thread
         (setq lisp-thread
               (or thread
-                  (new-thread name stack-size  vstack-size  tstack-size)))))
+                  (new-thread name stack-size  vstack-size  tstack-size)))
+        #+linux-target
+        (set-os-thread-name lisp-thread name)))
     (add-to-all-processes p)
     (setf (car (process-splice p)) p)
     p))


### PR DESCRIPTION
On Linux only, this patch uses `pthread_setname_np` to make the names of Lisp threads visible to standard Linux tools (e.g. GDB, htop).

I hacked this in for myself, but I thought it might be useful for others.