### PR TITLE
Assure that :key is not nil, even with :key nil

### DIFF
--- a/lib/sequences.lisp
+++ b/lib/sequences.lisp
@@ -2122,6 +2122,8 @@
            ((= i end2) (setq seq2 s2))
         (push (pop seq2) s2))))
   (when test-not (setq test test-not))
+  (unless key 
+    (setq key #'identity))
   (if from-end
       ;from-end
       (let* ((count1 end1)


### PR DESCRIPTION
Fixed #132 
```lisp
? (mismatch '(a b) '(a b c) :key nil)
2
? 
? (run-tests)
Doing 21904 pending tests of 21904 tests total.
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x1C3C15D>

=============== All tests succeeded ===============

(FUNCALL DO-TESTS :COMPILE COMPILE :VERBOSE VERBOSE :CATCH-ERRORS T)
took 169,940,971 microseconds (169.940980 seconds) to run.
       2,389,930 microseconds (  2.389930 seconds, 1.41%) of which was spent in GC.
During that period, and with 8 available CPU cores,
     158,033,785 microseconds (158.033780 seconds) were spent in user mode
      11,925,601 microseconds ( 11.925601 seconds) were spent in system mode
 8,112,020,496 bytes of memory allocated.
 23,253 minor page faults, 9 major page faults, 0 swaps.
````
