### PR TITLE
Fix wrong bindings of *gensym-counter* in gensym

### DIFF
--- a/level-1/l1-utils.lisp
+++ b/level-1/l1-utils.lisp
@@ -770,7 +770,9 @@ vector
         (integer (setq counter string-or-integer)) ; & emit-style-warning
         (string (setq prefix (ensure-simple-string string-or-integer)))))
     (unless counter
-      (with-lock-grabbed (*gensym-lock*)
+      (unless (and (numberp *gensym-counter*)(not (minusp *gensym-counter*)))
+        (error 'type-error :datum *gensym-counter* :expected-type 'unsigned-byte))
+      (with-lock-grabbed (*gensym-lock*) ; 
         (setq *gensym-counter* (1+ (setq counter *gensym-counter*)))))
     (make-symbol (%str-cat prefix (%integer-to-string counter)))))
 


### PR DESCRIPTION
Fixes:
```lisp
(let ((*gensym-counter* -1))
       (gensym))
(let ((*gensym-counter* (1- most-negative-fixnum)))
       (gensym))
````
Should all signal a type-error
see https://gitlab.common-lisp.net/ansi-test/ansi-test/merge_requests/19

Did rebuild ccl and run the tests:
```lisp
? (run-tests)
Doing 21904 pending tests of 21904 tests total.
Invoking restart: #<RESTART CL-TEST::FOO #x143C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x143C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x143C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x143C15D>
Invoking restart: #<RESTART CL-TEST::FOO #x143C15D>

=============== All tests succeeded ===============
````