### PR TITLE
WITH-STANDARD-IO-SYNTAX: do not use PLN lookup

### DIFF
--- a/level-1/l1-symhash.lisp
+++ b/level-1/l1-symhash.lisp
@@ -888,7 +888,8 @@ value of the variable CCL:*MAKE-PACKAGE-USE-DEFAULTS*."
 ;;; We use a lock to synchronize access to the local nickname system; using
 ;;; shared hash tables is not enough as the lists that are the values of the
 ;;; hash tables may be modified by different threads at the same time.
-(defvar *package-local-nicknames-lock* (make-lock))
+(defvar *package-local-nicknames-lock*
+  (make-lock "Lock for the package-local nicknames system"))
 (defvar *package-local-nicknames* (make-hash-table :test #'eq :weak t))
 (defvar *package-locally-nicknamed-by* (make-hash-table :test #'eq :weak t))
 

--- a/lib/macros.lisp
+++ b/lib/macros.lisp
@@ -1596,7 +1596,7 @@ to open."
        *READ-SUPPRESS*                  NIL
        *READTABLE*                      the standard readtable"
   (multiple-value-bind (decls body) (parse-body body env)
-    `(let ((*package* (pkg-arg "COMMON-LISP-USER"))
+    `(let ((*package* (%find-pkg "COMMON-LISP-USER"))
            (*print-array* t)
            (*print-base* 10.)
            (*print-case* :upcase)


### PR DESCRIPTION
Fixes #207

