### PR TITLE
Remove `void lazarus()` from Lisp kernel

### DIFF
--- a/lisp-kernel/pmcl-kernel.c
+++ b/lisp-kernel/pmcl-kernel.c
@@ -1696,27 +1696,7 @@ check_arm_cpu()
 #endif
   return win;
 }
-#endif  
-
-void
-lazarus()
-{
-  TCR *tcr = get_tcr(false);
-  if (tcr) {
-    /* Some threads may be dying; no threads should be created. */
-    LOCK(lisp_global(TCR_AREA_LOCK),tcr);
-    tcr->vs_area->active = tcr->vs_area->high - node_size;
-    tcr->save_vsp = (LispObj *)(tcr->vs_area->active);
-#ifndef ARM
-    tcr->ts_area->active = tcr->ts_area->high;
-    tcr->save_tsp = (LispObj *)(tcr->ts_area->active);
 #endif
-    tcr->catch_top = 0;
-    tcr->db_link = 0;
-    tcr->xframe = 0;
-    start_lisp(tcr, 0);
-  }
-}
 
 #ifdef LINUX
 #ifdef X8664
@@ -2185,18 +2165,6 @@ main
   lisp_global(MANAGED_STATIC_REFBITS) = (LispObj)managed_static_refbits;
   lisp_global(MANAGED_STATIC_REFIDX) = (LispObj)managed_static_refidx;
   lisp_global(MANAGED_STATIC_DNODES) = (LispObj)managed_static_area->ndnodes;
-#ifdef ANDROID
-  /* In some versions of Android, atexit() generates a runtime warning
-     about the dangers of using atexit() with shared libraries.
-     Android is what it is.  It's a steaming pile of what it is, in fact.
-  */
-  {
-    extern int __cxa_atexit(void (*) (void *), void *, void *);
-    __cxa_atexit(lazarus, NULL, NULL);
-  }
-#else
-  atexit(lazarus);
-#endif
 #ifdef ARM
 #ifdef LINUX
 #ifdef SET_INITIAL_THREAD_AFFINITY


### PR DESCRIPTION
Fixes #24.

Given its name, I can infer that `lazarus` is mean to resurrect a dying thread if it still has a TCR: if TCR exists, then it calls start_lisp; if it doesn't, then it does nothing. start_lisp, in turn, is an assembly function that has the following comment inside it:

>  This is called from C code when a thread (including the initial thread) starts execution.  (Historically, it also provided a primitive way of "resettting" a thread in the event of catastrophic failure, but this hasn't worked in a long time.)

I assume that lazarus() is the function mentioned here. It does seem to try and "reset" a thread in the event of it doing an exit call (lazarus is bound to atexit() calls in the main function).

If that is true, therefore I infer that a possible fix be to remove this function from the CCL codebase, along with its atexit() bindings. This should solve GitHub issue #24 where a call that then calls lazarus() sometimes deadlocks when `(ccl:quit)` is called.