### PR TITLE
treat printing with level 0 for structs without slots

### DIFF
--- a/level-1/l1-io.lisp
+++ b/level-1/l1-io.lisp
@@ -525,7 +525,9 @@ printed using \"#:\" syntax.  NIL means no prefix is printed.")
               (not (null (ccl::struct-def object)))
               (null (cdr (sd-slots (ccl::struct-def object)))))
          ;; else fall through to write-a-uvector
-         (write-a-structure object stream level))
+         ;; ansi PRINT-LEVEL.8 & PRINT-LEVEL.9
+         (unless (depth stream level)
+           (write-a-structure object stream level)))
         ((depth stream level))
         ((eq %type 'package)
          (write-a-package object stream))


### PR DESCRIPTION
This fixes ansi-test print-level.8 & print-level.9
Simplified:
```lisp
(defstruct print-level-struct)
(let* ((*print-pretty* nil))
  (write-to-string (make-print-level-struct) :level 0   :readably nil))
--> "#"
````
ecl & clasp & clisp respect this, sbcl doesn't

Should the fix be ok, I also have to to change
* https://github.com/Clozure/ccl-tests/blob/master/ansi-tests/print-level.lsp#L94
* https://github.com/Clozure/ccl-tests/blob/master/ansi-tests/print-level.lsp#L107

so that the regression-tests reflect the new behaviour

