### PR TITLE
Add rational decimal reader syntax

### DIFF
--- a/level-1/l1-numbers.lisp
+++ b/level-1/l1-numbers.lisp
@@ -71,7 +71,7 @@
                      (when (and (neq i nstart) ; need some digits first
                                 (memq c '#.(list (char-code #\E)(char-code #\F)
                                                  (char-code #\D)(char-code #\L)
-                                                 (char-code #\S))))
+                                                 (char-code #\S)(char-code #\R))))
                        (return-from new-numtoken (parse-float string len start)))
                      (return-from new-numtoken nil))
                     (t     ; seen a "digit" in base that ain't decimal

--- a/lib/numbers.lisp
+++ b/lib/numbers.lisp
@@ -78,6 +78,9 @@
                      (return integer))
                     ((memq c '(#\e #\E))
                      (return integer))
+                    ((memq c '(#\r #\R))
+                     (setq type 'rational)
+                     (return integer))
                     ((setq c (digit-char-p c))
                      (setq digits (1+ digits))
                      (setq integer (+ c (* 10 integer))))                  
@@ -118,7 +121,9 @@
 	    (coerce double-float-nan type)))
 	 (expt (setq expt (%i+ expt (* esign eexp))))
 	 (t (return-from parse-float nil)))))
-    (fide sign integer expt (subtypep type 'short-float))))
+    (if (eq type 'rational)
+        (* (if (zerop sign) 1 -1) integer (expt 10 expt))
+        (fide sign integer expt (subtypep type 'short-float)))))
 
 
 ;; an interesting test case: 1.448997445238699


### PR DESCRIPTION
This allows entering rational numbers as decimals using an `r` exponent marker and/or a `*read-default-float-format*` of `rational`.  Examples:

    1.2r0
    ; => 6/5

    (let ((*read-default-float-format* 'rational))
      (read-from-string "6.75"))
    ; => 27/4

[SBCL added this](http://sbcl.org/all-news.html#1.5.2) a while back and I thought it might be nice to have in CCL too.

Corresponding `ccl-tests` PR: https://github.com/Clozure/ccl-tests/pull/4