### PR TITLE
Add and export CCL:GET-ERRNO

### DIFF
--- a/lib/ccl-export-syms.lisp
+++ b/lib/ccl-export-syms.lisp
@@ -773,6 +773,7 @@
      package-locally-nicknamed-by-list
      add-package-local-nickname
      remove-package-local-nickname
+     get-errno
      ) "CCL"
    )
   )

--- a/lib/misc.lisp
+++ b/lib/misc.lisp
@@ -1694,3 +1694,6 @@ are running on, or NIL if we can't find any useful information."
 #+x86-target
 (defun invariant-tsc-p ()
   (logbitp 8  (nth-value 3 (x86-cpuid #x80000007))))
+
+(defun get-errno ()
+  (- (%get-errno)))


### PR DESCRIPTION
Fixes GitHub issue Clozure/ccl#215.

SBCL offers SB-ALIEN:GET-ERRNO. CCL has CCL::%GET-ERRNO. We wrap this internal
function in CCL:GET-ERRNO and export this last symbol.