### PR TITLE
Disable PIE on linuxx8632

### DIFF
--- a/lisp-kernel/linuxx8632/Makefile
+++ b/lisp-kernel/linuxx8632/Makefile
@@ -73,8 +73,13 @@ OSLIBS = -ldl -lm -lpthread -lrt
 LINK_SCRIPT = # ./elf_x86_32.x
 USE_LINK_SCRIPT = # -T $(LINK_SCRIPT)
 
+# Disable PIE: we need to ensure the kernel functions are mapped to low
+# addresses that fit in a fixnum. Otherwise ASLR could randomly load the
+# text section at an address outside this range.
+PIE = -no-pie
+
 ../../lx86cl:	$(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) Makefile  $(LINK_SCRIPT)
-	$(CC)  -m32 $(CDEBUG)  -Wl,--export-dynamic $(HASH_STYLE) -o $@ $(USE_LINK_SCRIPT) $(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) -Wl,--no-as-needed $(OSLIBS)
+	$(CC)  -m32 $(PIE) $(CDEBUG)  -Wl,--export-dynamic $(HASH_STYLE) -o $@ $(USE_LINK_SCRIPT) $(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) -Wl,--no-as-needed $(OSLIBS)
 
 
 $(SPOBJ): $(SPINC)


### PR DESCRIPTION
Many Linux distributions now build position independent executables by
default to better support ASLR. This means the text section can be
loaded randomly anywhere in the lower 3G of virtual address space on
32-bit Linux. Many of these addresses cannot be represented as fixnums,
which causes `_SPffcall` to crash early in boot calling a bogus address.

Explicitly disable PIE when building the kernel to avoid this. Fixes
Issue #236.

This is only a partial solution to the problem, however, as shared
libraries may still be loaded at high addresses. See Issue #274 which I
think is a related issue.