### PR TITLE
Add count argument to semaphore

### DIFF
--- a/level-0/l0-aprims.lisp
+++ b/level-0/l0-aprims.lisp
@@ -191,21 +191,21 @@ synchronization between threads."
     (report-bad-arg rw 'read-write-lock)))
   
 
-(defun %make-semaphore-ptr ()
+(defun %make-semaphore-ptr (&key (count 0))
   (let* ((p (ff-call (%kernel-import target::kernel-import-new-semaphore)
-	     :signed-fullword 0
-             :address)))
+		     :signed-fullword count
+		     :address)))
     (if (%null-ptr-p p)
-      (error "Can't create semaphore.")
+	(error "Can't create semaphore.")
       (record-system-lock
        (%setf-macptr
 	(make-gcable-macptr $flags_DisposeSemaphore)
 	p)))))
 
-(defun make-semaphore ()
+(defun make-semaphore (&key (count 0))
   "Create and return a semaphore, which can be used for synchronization
 between threads."
-  (%istruct 'semaphore (%make-semaphore-ptr)))
+  (%istruct 'semaphore (%make-semaphore-ptr :count count)))
 
 (defun semaphorep (x)
   (istruct-typep x 'semaphore))

--- a/level-0/l0-aprims.lisp
+++ b/level-0/l0-aprims.lisp
@@ -191,7 +191,7 @@ synchronization between threads."
     (report-bad-arg rw 'read-write-lock)))
   
 
-(defun %make-semaphore-ptr (&key (count 0))
+(defun %make-semaphore-ptr (count)
   (let* ((p (ff-call (%kernel-import target::kernel-import-new-semaphore)
 	     :signed-fullword count
              :address)))
@@ -205,7 +205,7 @@ synchronization between threads."
 (defun make-semaphore (&key (count 0))
   "Create and return a semaphore, which can be used for synchronization
 between threads."
-  (%istruct 'semaphore (%make-semaphore-ptr :count count)))
+  (%istruct 'semaphore (%make-semaphore-ptr count)))
 
 (defun semaphorep (x)
   (istruct-typep x 'semaphore))

--- a/level-0/l0-aprims.lisp
+++ b/level-0/l0-aprims.lisp
@@ -194,7 +194,7 @@ synchronization between threads."
 (defun %make-semaphore-ptr (&key (count 0))
   (let* ((p (ff-call (%kernel-import target::kernel-import-new-semaphore)
 	     :signed-fullword count
-	       :address)))
+             :address)))
     (if (%null-ptr-p p)
       (error "Can't create semaphore.")
       (record-system-lock

--- a/level-0/l0-aprims.lisp
+++ b/level-0/l0-aprims.lisp
@@ -194,7 +194,7 @@ synchronization between threads."
 (defun %make-semaphore-ptr (&key (count 0))
   (let* ((p (ff-call (%kernel-import target::kernel-import-new-semaphore)
 	     :signed-fullword count
-	     :address)))
+	       :address)))
     (if (%null-ptr-p p)
       (error "Can't create semaphore.")
       (record-system-lock

--- a/level-0/l0-aprims.lisp
+++ b/level-0/l0-aprims.lisp
@@ -193,10 +193,10 @@ synchronization between threads."
 
 (defun %make-semaphore-ptr (&key (count 0))
   (let* ((p (ff-call (%kernel-import target::kernel-import-new-semaphore)
-		     :signed-fullword count
-		     :address)))
+	     :signed-fullword count
+	     :address)))
     (if (%null-ptr-p p)
-	(error "Can't create semaphore.")
+      (error "Can't create semaphore.")
       (record-system-lock
        (%setf-macptr
 	(make-gcable-macptr $flags_DisposeSemaphore)


### PR DESCRIPTION
The make-semaphore function in ccl doesn't have a count argument.
This whenever someone makes a semaphore, they have to call signal
n times to get a positive count.
Count is a field on new_semaphore so just use it...