### PR TITLE
Fix issue 326 by treating "the" in ccl::conditional-store

### DIFF
--- a/lib/macros.lisp
+++ b/lib/macros.lisp
@@ -3642,6 +3642,10 @@ element-type is numeric."
       (if struct-transform
         (setq place (defstruct-ref-transform struct-transform (cdr place) env)
               sym (car place)))
+      ;;; https://github.com/Clozure/ccl/issues/326
+      (if (eq (car place) 'the)
+          (setq place (caddr place)
+                sym (car place)))
       (if (member  sym '(svref ccl::%svref ccl::struct-ref))
         (let* ((v (gensym)))
           `(let* ((,v ,(cadr place)))


### PR DESCRIPTION
* fixes #326 
* code from the issue by eugeneia
* test in ccl
```lisp
(defstruct af
  (value 0 :type fixnum))

(defun af-cas (af old new)
  (declare (type af af)
           (type fixnum old new)
           (optimize (safety 0) (speed 3)))
  (ccl::conditional-store (af-value af) old new))

? (setq *foo* (make-af :value 23))
#S(AF :VALUE 23)
? (af-cas *foo* 23 42)
T
? *foo*
#S(AF :VALUE 42)
````

* did also run the regression-tests
```lisp
karsten-poecks-macbook-pro:ccl-tests karstenpoeck$ ../ccl-git-karsten/dx86cl64 -n -l load.lisp
Clozure Common Lisp Version 1.12 (v1.12-dev.3-125-g595a5cf4) DarwinX8664

For more information about CCL, please see http://ccl.clozure.com.

CCL is free software.  It is distributed under the terms of the Apache
Licence, Version 2.0.
? (run-tests)
Doing 21909 pending tests of 21909 tests total.
Invoking restart: #<RESTART CL-TEST::FOO #x1D8912D>
Invoking restart: #<RESTART CL-TEST::FOO #x1D8912D>
Invoking restart: #<RESTART CL-TEST::FOO #x1D8912D>
Invoking restart: #<RESTART CL-TEST::FOO #x1D8912D>
Invoking restart: #<RESTART CL-TEST::FOO #x1D8912D>

=============== All tests succeeded ===============

(FUNCALL DO-TESTS :COMPILE COMPILE :VERBOSE VERBOSE :CATCH-ERRORS T)
took 160,596,058 microseconds (160.596070 seconds) to run.
       2,596,799 microseconds (  2.596799 seconds, 1.62%) of which was spent in GC.
During that period, and with 8 available CPU cores,
     149,971,134 microseconds (149.971130 seconds) were spent in user mode
       9,939,213 microseconds (  9.939213 seconds) were spent in system mode
 7,716,017,728 bytes of memory allocated.
 22,836 minor page faults, 3 major page faults, 0 swaps.
NIL
````
