### PR TITLE
Update "block" to new "text-block"

### DIFF
--- a/doc/manual/ffi.ccldoc
+++ b/doc/manual/ffi.ccldoc
@@ -1213,7 +1213,7 @@ uc_uc_test(unsigned char data)
       gcc -dynamiclib -Wall -o libtypetest.dylib typetest.c \\
       -install_name ./libtypetest.dylib
     ")
-    (block "Tip"
+    (text-block "Tip"
       (para #:|Users of 64-bit platforms may need to pass options such
         as "-m64" to gcc, may need to give the output library a different
         extension (such as ".so"), and may need to user slightly different

--- a/doc/manual/hemlock.ccldoc
+++ b/doc/manual/hemlock.ccldoc
@@ -2525,7 +2525,7 @@ This is the prompt string to display.
 This is similar to :prompt, except that it is displayed when the help
 command is typed during input.
                         "))
-      (block nil
+      (text-block nil
 	(para "This may also be a function.  When called with no arguments, it
 should either return a string which is the help text or perform some
 action to help the user, returning nil.


### PR DESCRIPTION
Sun Oct 18 17:28:23 BST 2020

Attempting to build the documentation was failing with:
```lisp
? (defparameter *d* (ccldoc:load-document "ccl:doc;manual;ccl.ccldoc"))
> Error: Unknown form (BLOCK "Tip" (PARA #:|Users of 64-bit platforms may need to pass options such
>                as "-m64" to gcc, may need to give the output library a different
>                extension (such as ".so"), and may need to user slightly different
>                values for other options in order to create an equivalent test
>                library.|))
> While executing: (:INTERNAL CCLDOC::FORM-CLAUSE), in process listener(1).
> Type :GO to continue, :POP to abort, :R for a list of available restarts.
> If continued: Output error text into document and continue
> Type :? for other options.
```

Investigation revealed `block` was changed to `text-block`: https://github.com/Clozure/ccldoc/commit/7c5dcf1513a4e8826718a70df8cfb7415401900e

This PR updates the manual for the above.