### PR TITLE
fix missing close paren in hemlock unused

### DIFF
--- a/cocoa-ide/hemlock/unused/archive/spell/spell-aug.lisp
+++ b/cocoa-ide/hemlock/unused/archive/spell/spell-aug.lisp
@@ -92,7 +92,7 @@
                                  :flags (word-flags line word-end))))
     (add-flags desc-ptr+2 line word-end)
     (string-table-replace line string-ptr word-end))
-  t)
+  t))
 
 ;;; SPELL-REMOVE-ENTRY destructively uppercases entry in removing it from
 ;;; the dictionary.  First entry is looked up, and if it is found due to a


### PR DESCRIPTION
spell-aug.lisp: defun spell-add-entry was missing a close paren