### PR TITLE
Fix https://github.com/Clozure/ccl/issues/350 : set lfun-bits inside set-funcallable-instance-function

### DIFF
--- a/level-1/l1-clos.lisp
+++ b/level-1/l1-clos.lisp
@@ -1822,6 +1822,9 @@ changing its name to ~s may have serious consequences." class new))
     (error "~S is not a funcallable instance" funcallable-instance))
   (unless (functionp function)
     (error "~S is not a function" function))
+  (lfun-bits funcallable-instance
+             (logior (lfun-bits funcallable-instance)
+                     (logand (lfun-bits function) (1- (expt 2 16)))))
   (setf (%gf-dcode funcallable-instance) function))
 
 (defmethod reinitialize-instance ((slotd slot-definition) &key &allow-other-keys)


### PR DESCRIPTION
Please review if the bits set in the commit are the relevant ones. 

- I can load [dense-arrays](https://github.com/digikar99/dense-arrays) without excessive notes. This uses [adhoc-polymorphic-functions](https://github.com/digikar99/adhoc-polymorphic-functions/) which in turn uses custom function class underneath.
- The example given in #350 itself works.