### PR TITLE
Add :IEEE-FLOATING-POINT to *FEATURES*

### DIFF
--- a/level-0/l0-init.lisp
+++ b/level-0/l0-init.lisp
@@ -40,6 +40,7 @@
     :clozure
     :clozure-common-lisp
     :ansi-cl
+    :ieee-floating-point
     #-windows-target :unix
     :openmcl-unicode-strings
     :ipv6


### PR DESCRIPTION
This commit address the issue [reported here](https://github.com/Clozure/ccl/issues/355).

I wanted to place this in l0-float.lisp, but the PUSHNEW macro seemed to fail. l0-init.lisp is the second most natural spot I can think of adding this feature.