### PR TITLE
Add missing restart-failure condition

### DIFF
--- a/level-1/l1-error-system.lisp
+++ b/level-1/l1-error-system.lisp
@@ -775,6 +775,12 @@
 	    (t				; with-simple-restart
 	     (throw tag (values nil t)))))))
 
+(define-condition restart-failure (control-error)
+  ((restart :initarg :restart :reader restart-failure-restart))
+  (:report (lambda (c s)
+             (format s "The ~a restart failed to transfer control dynamically as expected."
+                     (restart-name (restart-failure-restart c))))))
+
 (defun invoke-restart-no-return (restart &rest values)
   (declare (dynamic-extent values))
   (apply #'invoke-restart restart values)


### PR DESCRIPTION
Looking back at the commit history I don't see that this condition was ever defined. Followed the convention used by ABCL, CMUCL, ECL and SBCL in making this condition a control-error subclass.