### PR TITLE
Report erroneous commas in #A, #C or #S literals.

### DIFF
--- a/level-1/l1-reader.lisp
+++ b/level-1/l1-reader.lisp
@@ -2802,7 +2802,7 @@ initially NIL.")
  #'(lambda (stream char arg)
      (require-no-numarg char arg)
      (let ((*backquote-stack* (when *backquote-stack* "complex")))
-     (multiple-value-bind (form note) (read-internal stream t nil t)
+       (multiple-value-bind (form note) (read-internal stream t nil t)
          (values (unless *read-suppress* (apply #'complex form)) (and note (list note)))))))
 
 (set-dispatch-macro-character 

--- a/level-1/l1-reader.lisp
+++ b/level-1/l1-reader.lisp
@@ -2800,9 +2800,10 @@ initially NIL.")
  #\# 
  #\C
  #'(lambda (stream char arg)
-     (require-no-numarg char arg )
+     (require-no-numarg char arg)
+     (let ((*backquote-stack* (when *backquote-stack* "complex")))
      (multiple-value-bind (form note) (read-internal stream t nil t)
-       (values (unless *read-suppress* (apply #'complex form)) (and note (list note))))))
+         (values (unless *read-suppress* (apply #'complex form)) (and note (list note)))))))
 
 (set-dispatch-macro-character 
  #\#

--- a/lib/backquote.lisp
+++ b/lib/backquote.lisp
@@ -371,7 +371,7 @@
 (defun backq-form (form constantp)
   (if (and constantp (not (self-evaluating-p form))) (list 'quote form) form))
 
-(defparameter *backquote-stack* ())
+(defparameter *backquote-stack* () "A stack of spliced triples or a string naming an excluded literal type.")
 
 (set-macro-character 
  #\`

--- a/lib/backquote.lisp
+++ b/lib/backquote.lisp
@@ -393,8 +393,9 @@
  (nfunction
   |, reader| 
   (lambda (stream char &aux (stack *backquote-stack*))
-    (when (null stack)
-      (signal-reader-error stream "Comma not inside backquote"))
+    (typecase stack
+      (null (signal-reader-error stream "Comma not inside backquote"))
+      (string (signal-reader-error stream "Comma inside ~A literal" stack)))
     (let ((*backquote-stack* (cdddr stack)))
       (setq char (tyi stream))
       (cond ((eq char #\@)

--- a/lib/backquote.lisp
+++ b/lib/backquote.lisp
@@ -371,7 +371,7 @@
 (defun backq-form (form constantp)
   (if (and constantp (not (self-evaluating-p form))) (list 'quote form) form))
 
-(defparameter *backquote-stack* () "A stack of spliced triples or a string naming an excluded literal type.")
+(defparameter *backquote-stack* () "A stack of spliced triples or strings naming excluded literal types.")
 
 (set-macro-character 
  #\`

--- a/lib/read.lisp
+++ b/lib/read.lisp
@@ -81,49 +81,49 @@
  (qlfun |#A-reader| (stream ignore dimensions)
    (declare (ignore ignore))
    (let ((*backquote-stack* (when *backquote-stack* "array")))
-   (cond (*read-suppress*
-          (read stream () () t)
-          nil)
-         ((not dimensions)
-          (signal-reader-error stream "reader macro #A used without a rank integer"))
-         ((eql dimensions 0) ;0 dimensional array
-          (make-array nil :initial-contents (read-internal stream t nil t)))
-         ((and (integerp dimensions) (> dimensions 0)) 
-          (let ((initial-contents (read-internal stream t nil t)))
-            (cond ((not (typep initial-contents 'sequence))
-                   (signal-reader-error stream "The form following a #~SA reader macro should have been a sequence, but it was: ~S" dimensions initial-contents))
-                  ((= (length initial-contents) 0)
-                   (make-array (make-list dimensions :initial-element 0)))
-                  ((= dimensions 1)
-                   (make-array (length initial-contents) :initial-contents initial-contents))
-                  (t
-                   (let ((dlist (make-list dimensions)))
-                     (do ((dl dlist (cdr dl))
-                          (il initial-contents (if (> (length il) 0)
-                                                 (etypecase il
-                                                   (list (car il))
-                                                   (vector (aref il 0))))))
-                         ((null dl))
-                       (rplaca dl (length il)))
-                     (make-array dlist :initial-contents initial-contents))))))
+     (cond (*read-suppress*
+            (read stream () () t)
+            nil)
+           ((not dimensions)
+            (signal-reader-error stream "reader macro #A used without a rank integer"))
+           ((eql dimensions 0)		;0 dimensional array
+            (make-array nil :initial-contents (read-internal stream t nil t)))
+           ((and (integerp dimensions) (> dimensions 0)) 
+            (let ((initial-contents (read-internal stream t nil t)))
+              (cond ((not (typep initial-contents 'sequence))
+                     (signal-reader-error stream "The form following a #~SA reader macro should have been a sequence, but it was: ~S" dimensions initial-contents))
+                    ((= (length initial-contents) 0)
+                     (make-array (make-list dimensions :initial-element 0)))
+                    ((= dimensions 1)
+                     (make-array (length initial-contents) :initial-contents initial-contents))
+                    (t
+                     (let ((dlist (make-list dimensions)))
+                       (do ((dl dlist (cdr dl))
+                            (il initial-contents (if (> (length il) 0)
+                                                     (etypecase il
+                                                       (list (car il))
+                                                       (vector (aref il 0))))))
+                           ((null dl))
+			 (rplaca dl (length il)))
+                       (make-array dlist :initial-contents initial-contents))))))
            (t (signal-reader-error stream "Dimensions argument to #A not a non-negative integer: ~S" dimensions))))))
 
 (set-dispatch-macro-character #\# #\S
   (qlfun |#S-reader| (input-stream sub-char int &aux list sd)
      (declare (ignore sub-char int))
      (let ((*backquote-stack* (when *backquote-stack* "structure")))
-     (setq list (read-internal input-stream t nil t))
-     (unless *read-suppress*
-       (unless (and (consp list)
-                    (symbolp (%car list))
-                    (setq sd (gethash (%car list) %defstructs%))
-		    (setq sd (sd-constructor sd)))
-         (error "Can't initialize structure from ~S." list))
-       (let ((args ()) (plist (cdr list)))
-         (unless (plistp plist) (report-bad-arg plist '(satisfies plistp)))
-         (while plist
-           (push (make-keyword (pop plist)) args)
-           (push (pop plist) args))
+       (setq list (read-internal input-stream t nil t))
+       (unless *read-suppress*
+	 (unless (and (consp list)
+                      (symbolp (%car list))
+                      (setq sd (gethash (%car list) %defstructs%))
+		      (setq sd (sd-constructor sd)))
+           (error "Can't initialize structure from ~S." list))
+	 (let ((args ()) (plist (cdr list)))
+           (unless (plistp plist) (report-bad-arg plist '(satisfies plistp)))
+           (while plist
+             (push (make-keyword (pop plist)) args)
+             (push (pop plist) args))
            (apply sd (nreverse args)))))))
 
 ;;;from slisp reader2.lisp, and apparently not touched in 20 years.

--- a/lib/read.lisp
+++ b/lib/read.lisp
@@ -80,6 +80,7 @@
 (set-dispatch-macro-character #\# #\A
  (qlfun |#A-reader| (stream ignore dimensions)
    (declare (ignore ignore))
+   (let ((*backquote-stack* (when *backquote-stack* "array")))
    (cond (*read-suppress*
           (read stream () () t)
           nil)
@@ -105,11 +106,12 @@
                          ((null dl))
                        (rplaca dl (length il)))
                      (make-array dlist :initial-contents initial-contents))))))
-         (t (signal-reader-error stream "Dimensions argument to #A not a non-negative integer: ~S" dimensions)))))
+           (t (signal-reader-error stream "Dimensions argument to #A not a non-negative integer: ~S" dimensions))))))
 
 (set-dispatch-macro-character #\# #\S
   (qlfun |#S-reader| (input-stream sub-char int &aux list sd)
      (declare (ignore sub-char int))
+     (let ((*backquote-stack* (when *backquote-stack* "structure")))
      (setq list (read-internal input-stream t nil t))
      (unless *read-suppress*
        (unless (and (consp list)
@@ -122,7 +124,7 @@
          (while plist
            (push (make-keyword (pop plist)) args)
            (push (pop plist) args))
-         (apply sd (nreverse args))))))
+           (apply sd (nreverse args)))))))
 
 ;;;from slisp reader2.lisp, and apparently not touched in 20 years.
 (defun parse-integer (string &key (start 0) end (radix 10) junk-allowed)


### PR DESCRIPTION
```lisp
before	? `#C(0 ,1)	> Error: The value (#:|`,| . 1) is not of the expected type REAL.
after	? `#C(0 ,1)	> Error: … Comma inside complex literal
;;; Oops, forgot to re-indent, thus the second (all whitespace) commit