### PR TITLE
Remove altivec from arm-exceptions.h

### DIFF
--- a/lisp-kernel/arm-exceptions.h
+++ b/lisp-kernel/arm-exceptions.h
@@ -115,15 +115,6 @@ handle_error(ExceptionInformation *, unsigned, unsigned, int*);
 
 typedef char* vector_buf;
 
-void put_altivec_registers(vector_buf);
-void get_altivec_registers(vector_buf);
-
-
-int altivec_available;
-
-
-
-
 #ifdef DARWIN
 #define SIGNAL_FOR_PROCESS_INTERRUPT SIGUSR1
 #endif


### PR DESCRIPTION
Bullseye introduced a linking error for multiple definitions of
altivec_available. As far as I can remember altivec is a power pc thing
and not available on arm.

Removing these definitions from the header file fixes the build on
bullseye and continues to work on buster.