### PR TITLE
Fixes #415: provide implementation type in implementation version string

### DIFF
--- a/level-1/l1-boot-1.lisp
+++ b/level-1/l1-boot-1.lisp
@@ -68,7 +68,8 @@
     (format nil "~a~a~d" (string-capitalize os) cpu bits)))
 
 (defun lisp-implementation-version ()
-  (%str-cat "Version " (format nil *openmcl-version* (platform-description))))
+  (%str-cat (format nil "~A Version " (lisp-implementation-type))
+            (format nil *openmcl-version* (platform-description))))
 
 
 

--- a/level-1/l1-boot-lds.lisp
+++ b/level-1/l1-boot-lds.lisp
@@ -68,8 +68,7 @@ Licence, Version 2.0.
 
 (defun listener-function ()
   (unless (or *inhibit-greeting* *quiet-flag*)
-    (format t "~&~A ~A~%"
-	    (lisp-implementation-type)
+    (format t "~&~A~%"
 	    (lisp-implementation-version))
     (unless *did-show-marketing-blurb*
       (write-string *marketing-blurb* t)


### PR DESCRIPTION
This allows the version string to display the lisp implementation type.
```
 % ./dx86cl64 --version
Clozure Common Lisp Version 1.12.1 (v1.12.1-13-g0f6d38ec) DarwinX8664
```