### PR TITLE
Add error-handling, whitespace-safety, and Rosetta support to scripts/ccl & scripts/ccl64

### DIFF
--- a/scripts/ccl
+++ b/scripts/ccl
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 # Change the definition of CCL_DEFAULT_DIRECTORY below to refer to
 # your Clozure CL installation directory.  The lisp will use this
 # environment variable to set up translations for the CCL: logical
@@ -8,43 +10,45 @@
 # Any definition of CCL_DEFAULT_DIRECTORY already present in the
 # environment takes precedence over definition made below.
 
-if [ -z "$CCL_DEFAULT_DIRECTORY" ]; then
+if [ -z "${CCL_DEFAULT_DIRECTORY:-}" ]; then
   CCL_DEFAULT_DIRECTORY=/usr/local/src/ccl
 fi
 
-# If you don't want to guess the name of the lisp kernel on
+# If you don't want to guess the name of the OpenMCL kernel on
 # every invocation (or if you want to use a kernel with a
 # non-default name), you might want to uncomment and change
 # the following line:
 #OPENMCL_KERNEL=some_name
 
-if [ -z "$OPENMCL_KERNEL" ]; then
-  case `uname -s` in
-    Darwin) case `arch` in
-              ppc*) OPENMCL_KERNEL=dppccl ;;
-              i386) OPENMCL_KERNEL=dx86cl ;;
-            esac ;;
-    Linux) case `uname -m` in
-              ppc*) OPENMCL_KERNEL=ppccl ;;
-              *86*) OPENMCL_KERNEL=lx86cl ;;
-              *arm*) OPENMCL_KERNEL=armcl ;;
-	      *aarch64*) OPENMCL_KERNEL=armcl ;;
-           esac ;;
+if [ -z "${OPENMCL_KERNEL:-}" ]; then
+  case "$(uname -s)" in
+    Darwin) case "$(arch)" in
+      ppc*) OPENMCL_KERNEL=dppccl ;;
+      i386) OPENMCL_KERNEL=dx86cl ;;
+      *)
+        echo "Unsupported architecture"
+        exit 1 ;;
+      esac ;;
+    Linux)
+      case "$(uname -m)" in
+        ppc*) OPENMCL_KERNEL=ppccl ;;
+        *86*) OPENMCL_KERNEL=lx86cl ;;
+        *arm*) OPENMCL_KERNEL=armcl ;;
+        *aarch64*) OPENMCL_KERNEL=armcl ;;
+        *)
+          echo "Unsupported architecture"
+          exit 1 ;;
+      esac ;;
+    FreeBSD) OPENMCL_KERNEL=fx86cl ;;
+    SunOS) OPENMCL_KERNEL=sx86cl ;;
     CYGWIN*)
        OPENMCL_KERNEL=wx86cl.exe
-       CCL_DEFAULT_DIRECTORY="C:/cygwin$CCL_DEFAULT_DIRECTORY"
-    ;;
-    SunOS) OPENMCL_KERNEL=sx86cl
-    ;;
-    FreeBSD) OPENMCL_KERNEL=fx86cl
-    ;;
+       CCL_DEFAULT_DIRECTORY="C:/cygwin$CCL_DEFAULT_DIRECTORY" ;;
     *)
-    echo "Can't determine host OS.  Fix this."
-    exit 1
-    ;;
+      echo "Can't determine host OS."
+      exit 1 ;;
   esac
 fi
 
 export CCL_DEFAULT_DIRECTORY
-exec ${CCL_DEFAULT_DIRECTORY}/${OPENMCL_KERNEL} "$@"
-
+exec "${CCL_DEFAULT_DIRECTORY}/${OPENMCL_KERNEL}" "$@"

--- a/scripts/ccl64
+++ b/scripts/ccl64
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+set -eu
+
 #
 # Change the definition of CCL_DEFAULT_DIRECTORY below to refer to
 # your Clozure CL installation directory.  The lisp will use this
@@ -8,7 +11,7 @@
 # Any definition of CCL_DEFAULT_DIRECTORY already present in the
 # environment takes precedence over definition made below.
 
-if [ -z "$CCL_DEFAULT_DIRECTORY" ]; then
+if [ -z "${CCL_DEFAULT_DIRECTORY:-}" ]; then
   CCL_DEFAULT_DIRECTORY=/usr/local/src/ccl
 fi
 
@@ -18,65 +21,43 @@ fi
 # the following line:
 #OPENMCL_KERNEL=some_name
 
-if [ -z "$OPENMCL_KERNEL" ]; then
-  case `uname -s` in
-    Darwin)
-    case `arch` in
-      ppc*)
-      OPENMCL_KERNEL=dppccl64
-      ;;
-      i386|x86_64)
-      OPENMCL_KERNEL=dx86cl64
-      ;;
-    esac
-    ;;
-    Linux)
-    case `uname -m` in
-      ppc64)
-      OPENMCL_KERNEL=ppccl64
-      ;;
-      x86_64)
-      OPENMCL_KERNEL=lx86cl64
-      ;;
+if [ -z "${OPENMCL_KERNEL:-}" ]; then
+  case "$(uname -s)" in
+    Darwin) case "$(arch)" in
+      ppc*) OPENMCL_KERNEL=dppccl64 ;;
+      i386|x86_64) OPENMCL_KERNEL=dx86cl64 ;;
+      arm64) OPENMCL_KERNEL=dx86cl64 ;;  # Run under Rosetta, for now
       *)
-      echo "Can't determine machine architecture.  Fix this."
-      exit 1
-      ;;
-    esac
-    ;;
-    FreeBSD)
-    case `uname -m` in
-      amd64)
-      OPENMCL_KERNEL=fx86cl64
-      ;;
+        echo "Unsupported architecture"
+        exit 1 ;;
+      esac ;;
+    Linux) case "$(uname -m)" in
+      ppc64) OPENMCL_KERNEL=ppccl64 ;;
+      x86_64) OPENMCL_KERNEL=lx86cl64 ;;
       *)
-      echo "unsupported architecture"
-      exit 1
-      ;;
-    esac
-    ;;
-    SunOS)
-    case `uname -m` in
-      i86pc)
-      OPENMCL_KERNEL=sx86cl64
-      ;;
+        echo "Unsupported architecture"
+        exit 1 ;;
+      esac ;;
+    FreeBSD) case "$(uname -m)" in
+      amd64) OPENMCL_KERNEL=fx86cl64 ;;
       *)
-      echo "unsupported architecture"
-      exit 1
-      ;;
-    esac
-    ;;
+        echo "Unsupported architecture"
+        exit 1 ;;
+    esac ;;
+    SunOS) case "$(uname -m)" in
+      i86pc) OPENMCL_KERNEL=sx86cl64 ;;
+      *)
+        echo "Unsupported architecture"
+        exit 1 ;;
+    esac ;;
     CYGWIN*)
-    OPENMCL_KERNEL=wx86cl64.exe
-    CCL_DEFAULT_DIRECTORY="C:/cygwin$CCL_DEFAULT_DIRECTORY"
-    ;;
+      OPENMCL_KERNEL=wx86cl64.exe
+      CCL_DEFAULT_DIRECTORY="C:/cygwin$CCL_DEFAULT_DIRECTORY" ;;
     *)
-    echo "Can't determine host OS.  Fix this."
-    exit 1
-    ;;
+      echo "Can't determine host OS."
+      exit 1 ;;
   esac
 fi
 
 export CCL_DEFAULT_DIRECTORY
-exec ${CCL_DEFAULT_DIRECTORY}/${OPENMCL_KERNEL} "$@"
-
+exec "${CCL_DEFAULT_DIRECTORY}/${OPENMCL_KERNEL}" "$@"

--- a/scripts/ccl64
+++ b/scripts/ccl64
@@ -2,7 +2,6 @@
 
 set -eu
 
-#
 # Change the definition of CCL_DEFAULT_DIRECTORY below to refer to
 # your Clozure CL installation directory.  The lisp will use this
 # environment variable to set up translations for the CCL: logical
@@ -26,7 +25,14 @@ if [ -z "${OPENMCL_KERNEL:-}" ]; then
     Darwin) case "$(arch)" in
       ppc*) OPENMCL_KERNEL=dppccl64 ;;
       i386|x86_64) OPENMCL_KERNEL=dx86cl64 ;;
-      arm64) OPENMCL_KERNEL=dx86cl64 ;;  # Run under Rosetta, for now
+      arm64)
+        if [ "${CCL_USE_ROSETTA:-0}" = 1 ]; then
+          # Run under the MacOS Rosetta binary translator
+          OPENMCL_KERNEL=dx86cl64
+        else
+          echo "Unsupported architecture"
+          exit 1
+        fi ;;
       *)
         echo "Unsupported architecture"
         exit 1 ;;


### PR DESCRIPTION
I noticed that on my ARM Mac system, the `ccl64` script had a fall-through case, which led to un-set shell parameters and eventually a confusing error message.

This PR patches the `ccl` and `ccl64` scripts to avoid such errors.

I also hard-coded Rosetta support into the `case` tree by using the x86-64 settings when ARM64 is detected and the environment variable `CCL_USE_ROSETTA=1`. I thought it was safer to require "opt-in" than "opt-out" given that there are apparently some problems running CCL under Rosetta (e.g. https://github.com/Clozure/ccl/issues/356).