### PR TITLE
Patch #'find-definition-sources. Fixes #450.

### DIFF
--- a/lib/source-files.lisp
+++ b/lib/source-files.lisp
@@ -462,7 +462,11 @@ The returned list is guaranteed freshly consed (ie suitable for nconc'ing)."
              (if (and (find-class 'xref-entry nil)
                       (xref-entry-p name))
                (setq implicit-type (xref-entry-type name) implicit-name (xref-entry-full-name name))
-               (setq implicit-type t implicit-name name)))))
+               (setq implicit-type t implicit-name
+                     (if (and (consp name) ; ensure things work for functions internal to methods and functions
+                              (eql :INTERNAL (car name)))
+                         (car (last name)) ; handles anonymous :INTERNAL as well as named :INTERNAL (i.e. flet and labels)
+                         name))))))
         (setq implicit-dt-class (class-of (definition-type-instance implicit-type)))
         (with-lock-grabbed (*source-files-lock*)
           (loop for (nil . dt) in *definition-types*


### PR DESCRIPTION
This seems to fix the issue but I'm not sure it's the best way. For example it might be better to modify the "Show Callers" dialog so that double-clicking on an item in it always sends a data item to #'find-definition-sources that it knows how to deal with -- that's a less kludgy version of what I'm doing here.

This patch stops the error and the source file opens in the editor, but it doesn't put the cursor on the actual line where the internal definition occurs. You still have to look for that inside the toplevel function where it appears. It would be nice to fix that, but I have a feeling it might require modifications to the source-notes mechanism. 