### PR TITLE
Add open-p slot to FUNDAMENTAL-STREAM and update default methods

### DIFF
--- a/level-1/l1-streams.lisp
+++ b/level-1/l1-streams.lisp
@@ -3483,13 +3483,21 @@
 ;;;  Fundamental streams.
 
 (defclass fundamental-stream (stream)
-    ())
+    ((open-p :initform t :accessor fundamental-stream-open-p)))
 
 (defclass fundamental-input-stream (fundamental-stream input-stream)
     ((shared-resource :initform nil :accessor input-stream-shared-resource)))
 
 (defclass fundamental-output-stream (fundamental-stream output-stream)
     ())
+
+(defmethod open-stream-p ((stream fundamental-stream))
+  (fundamental-stream-open-p stream))
+
+(defmethod close ((stream fundamental-stream) &key abort)
+  (declare (ignore abort))
+  (prog1 (open-stream-p stream)
+    (setf (fundamental-stream-open-p stream) nil)))
 
 (defmethod input-stream-p ((x t))
   (report-bad-arg x 'stream))


### PR DESCRIPTION
Currently the CLOSE and OPEN-STREAM-P implementations do not conform to the Gray stream proposal. Specifically, the Gray stream proposal states the following for CLOSE and OPEN-STREAM-P:

```
  CLOSE  stream &key abort			[Generic Function]

    The existing function CLOSE is redefined to be a generic function, but
    otherwise behaves the same.  The default method provided by class
    FUNDAMENTAL-STREAM sets a flag for OPEN-STREAM-P.  The value returned
    by CLOSE will be as specified by the issue CLOSED-STREAM-OPERATIONS.

  OPEN-STREAM-P stream				[Generic Function]

    This function [from proposal STREAM-ACCESS] is made generic.  A
    default method is provided by class FUNDAMENTAL-STREAM which returns
    true if CLOSE has not been called on the stream.
```

I've added a slot OPEN-P to FUNDAMENTAL-STREAM and added the needed default methods.