### PR TITLE
Fix access to iobuf internals on Windows

### DIFF
--- a/lisp-kernel/lisp-debug.c
+++ b/lisp-kernel/lisp-debug.c
@@ -115,7 +115,7 @@ open_debug_output(int fd)
     if (setvbuf(f, NULL, _IONBF, 0) == 0) {
 #ifdef WINDOWS
       if (fileno(stdin) < 0) {
-        stdin->_file = 0;
+        freopen("CONIN$", "r", stdin);      
       }
 #endif
       dbgout = f;


### PR DESCRIPTION
Compiling with the latest mingw-w64-ucrt_x86_64 this failed to compile as it tries to access the internals of the FILE structure which have been made opaque.

This is my suggested fix.