### PR TITLE
Support for musl libc under Linux

### DIFF
--- a/library/leaks.lisp
+++ b/library/leaks.lisp
@@ -214,7 +214,11 @@
     res))
 
 ;; Linux-only malloc leak finding
-#+(and linux-target (not android-target))
+;;
+;; mtrace is glibc-specific, so on non-glibc Linux systems, start-mtrace and
+;; stop-mtrace will fail at runtime when looking up mtrace or muntrace. Since we
+;; have no glibc feature, failing at runtime is just about all we can do anyway.
+#+linux-target
 (progn
 
 ;; (ccl::start-mtrace LOGFILE)

--- a/lisp-kernel/arm-exceptions.c
+++ b/lisp-kernel/arm-exceptions.c
@@ -28,7 +28,6 @@
 #include <strings.h>
 #include <sys/mman.h>
 #ifndef ANDROID
-#include <fpu_control.h>
 #include <linux/prctl.h>
 #endif
 #endif

--- a/lisp-kernel/lisp-debug.c
+++ b/lisp-kernel/lisp-debug.c
@@ -1153,7 +1153,15 @@ debug_show_fpu(ExceptionInformation *xp, siginfo_t *info, int arg)
 #endif
 #ifdef X8664
 #ifdef LINUX
-  struct _libc_xmmreg * xmmp = NULL;
+  struct xmm {
+    char fpdata[16];
+  };
+  struct xmm *xmmp;
+  if (xp->uc_mcontext.fpregs)
+    xmmp = (struct xmm *)&(xp->uc_mcontext.fpregs->_xmm[0]);
+  else
+    /* no fp state, apparently */
+    return debug_continue;
 #endif
 #ifdef DARWIN
   struct xmm {
@@ -1174,14 +1182,6 @@ debug_show_fpu(ExceptionInformation *xp, siginfo_t *info, int arg)
   upad128_t *xmmp = xpXMMregs(xp);
 #endif
   float *sp;
-
-#ifdef LINUX
-  if (xp->uc_mcontext.fpregs)
-    xmmp = &(xp->uc_mcontext.fpregs->_xmm[0]);
-  else
-    /* no fp state, apparently */
-    return debug_continue;
-#endif
 
   for (i = 0; i < 16; i++, xmmp++) {
     sp = (float *) xmmp;

--- a/lisp-kernel/pmcl-kernel.c
+++ b/lisp-kernel/pmcl-kernel.c
@@ -35,7 +35,7 @@
 #endif
 
 #ifdef LINUX
-#ifndef ANDROID
+#ifdef __GLIBC__
 #include <mcheck.h>
 #endif
 #include <dirent.h>
@@ -1704,11 +1704,20 @@ check_arm_cpu()
 #include <asm/prctl.h>
 #include <sys/prctl.h>
 
+#ifdef __GLIBC__
+#include <gnu/libc-version.h>
+#else
+static const char *
+gnu_get_libc_version(void)
+{
+  return "(unknown)";
+}
+#endif
+
 void
 ensure_gs_available(char *progname)
 {
   LispObj fs_addr = 0L, gs_addr = 0L, cur_thread = (LispObj)pthread_self();
-  char *gnu_get_libc_version(void);
   /*
    * According arch_prctl(2), there's no function prototype for
    * arch_prctl().  Thus, we have to declare it ourselves.

--- a/lisp-kernel/ppc-exceptions.c
+++ b/lisp-kernel/ppc-exceptions.c
@@ -27,13 +27,11 @@
 #ifdef LINUX
 #include <strings.h>
 #include <sys/mman.h>
-#include <fpu_control.h>
 #include <linux/prctl.h>
 #endif
 
 #ifdef DARWIN
 #include <sys/mman.h>
-#define _FPU_RESERVED 0xffffff00
 #ifndef SA_NODEFER
 #define SA_NODEFER 0
 #endif
@@ -41,6 +39,10 @@
 
 /* a distinguished UUO at a distinguished address */
 extern void pseudo_sigreturn(ExceptionInformation *);
+#endif
+
+#ifndef _FPU_RESERVED
+#define _FPU_RESERVED 0xffffff00
 #endif
 
 

--- a/lisp-kernel/unix-calls.c
+++ b/lisp-kernel/unix-calls.c
@@ -25,8 +25,8 @@
    conventions (e.g., return -1 or NULL and set errno on error.)
 */
 
-#ifndef _LARGEFILE64_SOURCE_
-#define _LARGEFILE64_SOURCE_
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
 #endif
 #include <errno.h>
 #include <unistd.h>

--- a/lisp-kernel/x86-exceptions.c
+++ b/lisp-kernel/x86-exceptions.c
@@ -29,7 +29,6 @@
 #ifdef LINUX
 #include <strings.h>
 #include <sys/mman.h>
-#include <fpu_control.h>
 #include <linux/prctl.h>
 #endif
 #ifdef DARWIN


### PR DESCRIPTION
I hope the commit messages explain the exact changes well enough.

I'm not super happy with the solution for `mcheck.h`, but as I understand it, `start-mtrace` and `stop-mtrace` are intended to be called manually for debugging purposes anyway, so it's not a big deal if the functions exist but fail.