### PR TITLE
Use `%uvector-replace` in `replace` even when subseqs differ in length

### DIFF
--- a/lib/sequences.lisp
+++ b/lib/sequences.lisp
@@ -326,13 +326,13 @@
   (setq source-end (check-sequence-bounds source-sequence source-start
                                           source-end))
   (locally (declare (fixnum target-start target-end source-start source-end))
-    (let* ((typecode (typecode source-sequence))
-           (n (- source-end source-start)))
-      (if (and (not (listp source-sequence))
-               (simple-array-p source-sequence)
-               (= (the fixnum (- target-end target-start)) n)
+    (let ((typecode (typecode source-sequence)))
+      (if (and (simple-array-p source-sequence)
                (= typecode (typecode target-sequence)))
-        (%uvector-replace target-sequence target-start source-sequence source-start n typecode)
+        (%uvector-replace target-sequence target-start source-sequence source-start
+                          (min (the fixnum (- source-end source-start))
+                               (the fixnum (- target-end target-start)))
+                          typecode)
         
     (seq-dispatch 
      target-sequence


### PR DESCRIPTION
This significantly speeds up code that relies on the way `replace` implicitly intersects sequence bounds. For example, the `replace` calls below take about 150ms & 3ms respectively before the patch; both take about 3ms afterwards.
```
(let ((buf  (make-array 100000000 :element-type '(unsigned-byte 8)))
      (buf2 (make-array 10000000  :element-type '(unsigned-byte 8) :initial-element 1)))
  (time (replace buf buf2))
  (time (replace buf buf2 :start1 0 :end1 (length buf2)))
  nil)
```
Originally found by Gilbert Baumann a while ago.