### PR TITLE
lib/backquote.lisp: fix (list `(foo . ,nil))

### DIFF
--- a/lib/backquote.lisp
+++ b/lib/backquote.lisp
@@ -404,7 +404,8 @@
              (cons (%cadr stack) (read stream t nil t)))
             (t
              (untyi char stream)
-             (cons (%car stack) (read stream t nil t))))))))
+             (cons (%car stack) (or (read stream t nil t)
+				    (list 'quote nil)))))))))
 )
 
 (provide 'backquote)


### PR DESCRIPTION
Fix erroring out on forms like (list `(foo . ,nil))
