### PR TITLE
Don't use the type of checked TYPED-FORMs to rewrite acode

### DIFF
--- a/compiler/acode-rewrite.lisp
+++ b/compiler/acode-rewrite.lisp
@@ -638,7 +638,7 @@
   (rewrite-acode-form form type))
 
 (def-acode-rewrite rewrite-typed-form typed-form asserted-type (&whole w type form &optional check)
-  (rewrite-acode-form form (if (or check *acode-rewrite-trust-declarations*) type t)))
+  (rewrite-acode-form form (if (and (not check) *acode-rewrite-trust-declarations*) type t)))
 
 (def-acode-rewrite rewrite-trivial-unary (fixnum immediate simple-function closed-function lexical-reference bound-special-ref special-ref local-go %function global-ref free-reference inherited-arg) asserted-type (&whole w val)
   (declare (ignore val)))


### PR DESCRIPTION
Optimizations that rely on ASSERTED-TYPE might change the value (hence type) of the inner form if it isn't actually of the given type, which would defeat the point of typechecking.

This looks like it may hurt the performance of code that both trusts declarations and generates checked TYPED-FORMs, but this can only happen when the user provides a compiler policy that has both TRUST-DECLARATIONS and DECLARATIONS-TYPECHECK enabled; in the default policy, they're mutually exclusive.

For an example of how this can cause issues, consider the following:
```
>>> (let ((f (compile nil '(lambda (x)
                            (declare (optimize safety)
                                     (type fixnum x))
                            (the fixnum (ash x 1))))))
      (funcall f most-positive-fixnum))
;; TYPE-ERROR: The value 2305843009213693950 is not of the expected type FIXNUM.
>>> (let ((f (compile nil '(lambda (x)
                            (declare (optimize safety)
                                     (type fixnum x))
                            (the fixnum (ash (the fixnum x) 1))))))
      (funcall f most-positive-fixnum))
-2
```
`(the fixnum x)` is necessary to make the acode rewriter for ASH trust that it's working on a fixnum and rewrite to %ILSL; on high safety, it won't trust the unchecked TYPED-FORM generated by the type declaration.