### PR TITLE
Rebind the NFP depth in X862-LET and ARM2-LAMBDA-BIND

### DIFF
--- a/compiler/ARM/arm2.lisp
+++ b/compiler/ARM/arm2.lisp
@@ -8691,6 +8691,7 @@ v idx-reg constidx val-reg (arm2-unboxed-reg-for-aset seg type-keyword val-reg s
 
 (defarm2 arm2-lambda-bind lambda-bind (seg vreg xfer vals req rest keys-p auxen body p2decls)
   (let* ((old-stack (arm2-encode-stack))
+         (*arm2-nfp-depth* *arm2-nfp-depth*)
          (nreq (list-length req))
          (rest-arg (nthcdr nreq vals))
          (apply-body (arm2-eliminate-&rest body rest keys-p auxen rest-arg)))

--- a/compiler/X86/x862.lisp
+++ b/compiler/X86/x862.lisp
@@ -9951,6 +9951,7 @@
   
   (setq vals (copy-list vals))
   (let* ((old-stack (x862-encode-stack))
+         (*x862-nfp-depth* *x862-nfp-depth*)
          (val nil)
          (bits nil)
          (valcopy vals))


### PR DESCRIPTION
Fixes an oversight in cb1dded and 62c5caf respectively. The following code
returns 2000.0 instead of 1255.0 on x86-64 if the binding is missing:

```
(funcall (lambda ()
           (+ 255e0 (the single-float
                         (let ((foo (the single-float (+ 1000e0 (random 1))))
                               (bar 0))
                           (declare (ignore bar))
                           foo)))))
```

I couldn't find an example for the ARM backend since it rebinds the NFP depth
much more aggressively, but if rebinding is required for `lambda-bind` on x86, it
stands to reason that it's required on ARM as well.