### PR TITLE
Preserve Linux xstate in exception contexts

### DIFF
--- a/lisp-kernel/pmcl-kernel.c
+++ b/lisp-kernel/pmcl-kernel.c
@@ -1184,10 +1184,8 @@ usage_exit(char *herald, int exit_status, char* other_args)
   fprintf(dbgout, "\t--debug : try to ensure that kernel debugger uses a TTY for I/O\n");
 #ifdef LINUX
 #ifdef X86
-#if WORD_SIZE==64
-  fprintf(dbgout,  "\t--avx :signal handlers preserve AVX(YMM) registers on x8664 Linux.  This the default on Linux >=3.0\n");
- fprintf(dbgout,  "\t--no-avx :signal handler don't preserve AVX(YMM) registers on x8664 Linux, This the default on Linux <3.0\n");
-#endif
+  fprintf(dbgout,  "\t--avx : signal handlers preserve AVX (YMM) registers on x86 Linux.  This is the default on Linux >= 3.0\n");
+  fprintf(dbgout,  "\t--no-avx : signal handlers do not preserve AVX (YMM) registers on x86 Linux.  This is the default on Linux < 3.0\n");
 #endif
 #endif
   fprintf(dbgout, "\t-I, --image-name <image-name>\n");
@@ -1921,7 +1919,7 @@ main
 
   check_os_version(argv[0]);
 #ifdef LINUX
-#if WORD_SIZE==64
+#ifdef X86
   if (os_major_version >= 3) {
     copy_exception_avx_state = true;
   }

--- a/lisp-kernel/x86-asmutils32.s
+++ b/lisp-kernel/x86-asmutils32.s
@@ -279,5 +279,11 @@ _exportfn(C(ensure_safe_for_string_operations))
 _endfn                                       
         __endif
 
-        _endfile
+        __ifndef(`WIN_32')
+_exportfn(C(ensure_safe_for_string_operations))
+        __(cld)
+	__(ret)
+_endfn
+        __endif
 
+        _endfile

--- a/lisp-kernel/x86-exceptions.c
+++ b/lisp-kernel/x86-exceptions.c
@@ -1522,6 +1522,47 @@ signal_handler(int signum, siginfo_t *info, ExceptionInformation  *context
 /* type of pointer to saved fp state */
 #ifdef X8664
 typedef fpregset_t FPREGS;
+
+#define CCL_FP_XSTATE_MAGIC1 0x46505853U
+#define CCL_FP_XSTATE_MAGIC2 0x46505845U
+#define CCL_MAX_XSTATE_SIZE (1024U * 1024U)
+#define CCL_FP_XSTATE_SW_BYTES_OFFSET 464U
+#define CCL_FP_XSTATE_EXTENDED_SIZE_OFFSET 468U
+#define CCL_FP_XSTATE_XSTATE_SIZE_OFFSET 480U
+
+static size_t
+linux_fpregs_size_in_bytes(FPREGS state, Boolean *extended_p)
+{
+  const BytePtr bytes = (BytePtr)state;
+  uint32_t magic1, extended_size, xstate_size;
+  uint32_t magic2;
+
+  memcpy(&magic1,
+         bytes + CCL_FP_XSTATE_SW_BYTES_OFFSET,
+         sizeof(magic1));
+  memcpy(&extended_size,
+         bytes + CCL_FP_XSTATE_EXTENDED_SIZE_OFFSET,
+         sizeof(extended_size));
+  memcpy(&xstate_size,
+         bytes + CCL_FP_XSTATE_XSTATE_SIZE_OFFSET,
+         sizeof(xstate_size));
+
+  *extended_p = false;
+  if ((magic1 == CCL_FP_XSTATE_MAGIC1) &&
+      (extended_size >= (sizeof(*state) + sizeof(magic2))) &&
+      (extended_size <= CCL_MAX_XSTATE_SIZE) &&
+      (xstate_size >= sizeof(*state)) &&
+      (xstate_size == (extended_size - sizeof(magic2)))) {
+    memcpy(&magic2,
+           bytes + extended_size - sizeof(magic2),
+           sizeof(magic2));
+    if (magic2 == CCL_FP_XSTATE_MAGIC2) {
+      *extended_p = true;
+      return extended_size;
+    }
+  }
+  return sizeof(*state);
+}
 #else
 typedef struct _fpstate *FPREGS;
 #endif
@@ -1531,8 +1572,31 @@ copy_fpregs(ExceptionInformation *xp, LispObj *current, FPREGS *destptr)
   FPREGS src = (FPREGS)(xp->uc_mcontext.fpregs), dest;
   
   if (src) {
+#ifdef X8664
+    extern void ensure_safe_for_string_operations(void);
+    Boolean extended = false;
+    size_t nbytes;
+    BytePtr destination;
+
+    ensure_safe_for_string_operations();
+    nbytes = sizeof(*src);
+    if (copy_exception_avx_state) {
+      nbytes = linux_fpregs_size_in_bytes(src, &extended);
+    }
+    destination =
+      (BytePtr)truncate_to_power_of_2((BytePtr)current - nbytes, 6);
+    dest = (FPREGS)destination;
+    memcpy(dest, src, nbytes);
+    if (!extended) {
+      uint32_t no_magic = 0;
+      memcpy(destination + CCL_FP_XSTATE_SW_BYTES_OFFSET,
+             &no_magic,
+             sizeof(no_magic));
+    }
+#else
     dest = ((FPREGS)current)-1;
     *dest = *src;
+#endif
     *destptr = dest;
     current = (LispObj *) dest;
   }

--- a/lisp-kernel/x86-exceptions.c
+++ b/lisp-kernel/x86-exceptions.c
@@ -1523,6 +1523,14 @@ signal_handler(int signum, siginfo_t *info, ExceptionInformation  *context
 #ifdef X8664
 typedef fpregset_t FPREGS;
 
+/* These magic words and offsets come from the Linux x86 signal-frame ABI in
+   <asm/sigcontext.h>.  Its struct _fpx_sw_bytes occupies bytes 464..511 of
+   the 512-byte FXSAVE frame: magic1 is at 464, extended_size at 468, and
+   xstate_size at 480.  MAGIC2 is the final word of the extended state area.
+   Keep private definitions here rather than including kernel UAPI types that
+   overlap the sigcontext types exposed by libc.  CCL_MAX_XSTATE_SIZE is not
+   part of the ABI; it is a defensive bound on the size copied from a signal
+   frame. */
 #define CCL_FP_XSTATE_MAGIC1 0x46505853U
 #define CCL_FP_XSTATE_MAGIC2 0x46505845U
 #define CCL_MAX_XSTATE_SIZE (1024U * 1024U)

--- a/lisp-kernel/x86-exceptions.c
+++ b/lisp-kernel/x86-exceptions.c
@@ -1522,21 +1522,32 @@ signal_handler(int signum, siginfo_t *info, ExceptionInformation  *context
 /* type of pointer to saved fp state */
 #ifdef X8664
 typedef fpregset_t FPREGS;
+#define CCL_FP_XSTATE_FXSAVE_OFFSET 0U
+#else
+typedef struct _fpstate *FPREGS;
+#define CCL_FP_XSTATE_FXSAVE_OFFSET offsetof(struct _fpstate, _fxsr_env)
+#endif
 
 /* These magic words and offsets come from the Linux x86 signal-frame ABI in
-   <asm/sigcontext.h>.  Its struct _fpx_sw_bytes occupies bytes 464..511 of
+   <asm/sigcontext.h>.
+
+   Its struct _fpx_sw_bytes occupies bytes 464..511 of
    the 512-byte FXSAVE frame: magic1 is at 464, extended_size at 468, and
    xstate_size at 480.  MAGIC2 is the final word of the extended state area.
-   Keep private definitions here rather than including kernel UAPI types that
-   overlap the sigcontext types exposed by libc.  CCL_MAX_XSTATE_SIZE is not
-   part of the ABI; it is a defensive bound on the size copied from a signal
-   frame. */
+   The i386 _fpstate has a legacy x87 prefix before that FXSAVE frame, while
+   the x86-64 _fpstate begins with the frame; CCL_FP_XSTATE_FXSAVE_OFFSET
+   accounts for that difference. */
 #define CCL_FP_XSTATE_MAGIC1 0x46505853U
 #define CCL_FP_XSTATE_MAGIC2 0x46505845U
+#define CCL_FP_XSTATE_SW_BYTES_OFFSET \
+  (CCL_FP_XSTATE_FXSAVE_OFFSET + 464U)
+#define CCL_FP_XSTATE_EXTENDED_SIZE_OFFSET \
+  (CCL_FP_XSTATE_FXSAVE_OFFSET + 468U)
+#define CCL_FP_XSTATE_XSTATE_SIZE_OFFSET \
+  (CCL_FP_XSTATE_FXSAVE_OFFSET + 480U)
+
+/* A defensive bound on the size copied from a signal frame. */
 #define CCL_MAX_XSTATE_SIZE (1024U * 1024U)
-#define CCL_FP_XSTATE_SW_BYTES_OFFSET 464U
-#define CCL_FP_XSTATE_EXTENDED_SIZE_OFFSET 468U
-#define CCL_FP_XSTATE_XSTATE_SIZE_OFFSET 480U
 
 static size_t
 linux_fpregs_size_in_bytes(FPREGS state, Boolean *extended_p)
@@ -1559,8 +1570,9 @@ linux_fpregs_size_in_bytes(FPREGS state, Boolean *extended_p)
   if ((magic1 == CCL_FP_XSTATE_MAGIC1) &&
       (extended_size >= (sizeof(*state) + sizeof(magic2))) &&
       (extended_size <= CCL_MAX_XSTATE_SIZE) &&
-      (xstate_size >= sizeof(*state)) &&
-      (xstate_size == (extended_size - sizeof(magic2)))) {
+      (xstate_size >= (sizeof(*state) - CCL_FP_XSTATE_FXSAVE_OFFSET)) &&
+      (xstate_size == (extended_size - CCL_FP_XSTATE_FXSAVE_OFFSET -
+                       sizeof(magic2)))) {
     memcpy(&magic2,
            bytes + extended_size - sizeof(magic2),
            sizeof(magic2));
@@ -1571,16 +1583,12 @@ linux_fpregs_size_in_bytes(FPREGS state, Boolean *extended_p)
   }
   return sizeof(*state);
 }
-#else
-typedef struct _fpstate *FPREGS;
-#endif
 LispObj *
 copy_fpregs(ExceptionInformation *xp, LispObj *current, FPREGS *destptr)
 {
   FPREGS src = (FPREGS)(xp->uc_mcontext.fpregs), dest;
   
   if (src) {
-#ifdef X8664
     extern void ensure_safe_for_string_operations(void);
     Boolean extended = false;
     size_t nbytes;
@@ -1591,8 +1599,10 @@ copy_fpregs(ExceptionInformation *xp, LispObj *current, FPREGS *destptr)
     if (copy_exception_avx_state) {
       nbytes = linux_fpregs_size_in_bytes(src, &extended);
     }
-    destination =
-      (BytePtr)truncate_to_power_of_2((BytePtr)current - nbytes, 6);
+    destination = (BytePtr)
+      (truncate_to_power_of_2((BytePtr)current - nbytes +
+                              CCL_FP_XSTATE_FXSAVE_OFFSET, 6) -
+       CCL_FP_XSTATE_FXSAVE_OFFSET);
     dest = (FPREGS)destination;
     memcpy(dest, src, nbytes);
     if (!extended) {
@@ -1601,10 +1611,6 @@ copy_fpregs(ExceptionInformation *xp, LispObj *current, FPREGS *destptr)
              &no_magic,
              sizeof(no_magic));
     }
-#else
-    dest = ((FPREGS)current)-1;
-    *dest = *src;
-#endif
     *destptr = dest;
     current = (LispObj *) dest;
   }


### PR DESCRIPTION
Hi guys,

this is my first time contributing to Clozure, so I am not sure if there is a process I am forgetting.

I am submitting a (maybe a little opinionated) small fix for xstate handling.

On x86-64, the interrupted CPU register is carried by signals in a signal frame, and modern CPUs have AVX/other extended register state stored in the XSAVE area (see https://criu.org/Xsave, https://www.kernel.org/doc/html/latest/arch/x86/xstate.html, https://github.com/torvalds/linux/blob/master/arch/x86/include/uapi/asm/sigcontext.h).

Atm, when relocating a signal context, CCL copies only the old fixed-size FP/SSE portion of the frame. The copy can still advertise an extended XSAVE area that it does not contain, causing AVX and other extended register state to be discarded on signal return.

This should not break anything, if the extended metadata is missing or invalid, we copy the fp/sse portion and clear the marker so linux treats it as legacy.

I believe this is tangentially related to #85 which shows a bad frame crash as well. This should probably be fixed on x86-32 as well, I can do it if yall want.

Thank you for your time