### PR TITLE
arm64: interim port series from a parallel Linux/arm64 build (54 commits, based at 9c61574)

### DIFF
--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -185,6 +185,8 @@
 (defconstant no-thread-local-binding-marker subtag-no-thread-local-binding)
 (define-subtag lisp-frame-marker fulltag-imm-1 5)
 (defconstant lisp-frame-marker subtag-lisp-frame-marker)
+(define-subtag stack-alloc-marker fulltag-imm-1 6)
+(defconstant stack-alloc-marker subtag-stack-alloc-marker)
 
 ;;; Extended type codes ("xtypes") for wrong-type UUOs.  The 8-bit
 ;;; expected-type field of a wrong-type UUO holds either a lisptag, a

--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -1290,3 +1290,102 @@
 (defparameter *image-abi-version* 1046)
 
 (provide "ARM64-ARCH")
+
+;;; ------------------------------------------------------------------
+;;; Subprimitives the linuxarm64 port adds to the table above.  This must
+;;; sit AFTER *arm64-target-arch*, because it refreshes the arch struct's
+;;; captured table as well as the variable: subprim-name->offset resolves
+;;; through the struct (compiler/subprims.lisp:53), so extending only the
+;;; variable gives ".SPRPLACD not found" while the variable plainly holds it.
+;;; ------------------------------------------------------------------
+;;; SPDX-License-Identifier: Apache-2.0
+;;;
+;;; PROPOSED (ratify with Matt): extend arm64-arch.lisp's *subprims*
+;;; vector (his :359-377 ends with ";; ..." -- knowingly incomplete)
+;;; with the subprimitives the level-0 drafts and our kernel spentry
+;;; drafts reference.  Offsets continue his vector's numbering (same
+;;; *subprims-base* / *subprims-shift* arithmetic); the ORDER below is
+;;; the proposal.  Kernel-side bodies for every entry exist in
+;;; upstream-port/lisp-kernel/spentry-{A..E}.s.
+;;;
+;;; Loaded by tools/upstream-assemble-test.lisp after Matt's LAP layer.
+
+
+(let ((offset (+ *subprims-base* (* (length *subprims*) (ash 1 *subprims-shift*))))
+      (step (ash 1 *subprims-shift*)))
+  (flet ((define-subprim (name)
+           (ccl::make-subprimitive-info :name (string name)
+                                        :offset (prog1 offset (incf offset step)))))
+    (macrolet ((defsubprim (name)
+                 `(define-subprim ',name)))
+      (setq *subprims*
+            (concatenate 'vector
+                         *subprims*
+                         (vector
+                          ;; multiple values (spentry-C)
+                          ;; boxing/unboxing (spentry-A)
+                          ;; special variables (spentry-A/C)
+                          ;; EGC-barrier stores (spentry-B)
+                          ;; arrays (spentry-B)
+                          ;; lexpr / rest args (spentry-D/E)
+                          ;; error signalling / dispatch (spentry-D)
+                          ;; FFI (spentry-E)
+                          (defsubprim .SPffcall-return-registers)
+                          ;; vinsn wave V1 demands (U4 in
+                          ;; arm64-vinsns-additions-w1-report.md);
+                          ;; lambda-binding subprims (spentry-D bodies)
+                          ;; call dispatch (spentry-D: funcall@145,
+                          ;; tfuncallgen@662, tfuncallslide@689) —
+                          ;; gate-26 funcall demand (w4 call cluster)
+                          (defsubprim .SPtfuncallvsp)
+                          ;; generic uvector element access (spentry-B:
+                          ;; misc_ref@588, misc_set@819) — w3a misc-ref/
+                          ;; misc-set vinsns resolve these by name (U2a)
+                          ;; gate-27 definitive referenced-vs-registered
+                          ;; scan: barrier'd cons/gvector mutation
+                          ;; (rplaca@D:181, rplacd@D:228, gvset@B:81)
+                          ;; and builtin tail (logior@D:1270, ash@D:1298)
+                          ;; make-closure cluster (gate-33): stack
+                          ;; gvector builder (spentry-B stkgvector@769)
+                          ;; %gvector handler (w5): heap gvector builder
+                          ;; (spentry-B gvector@564-584, verified body)
+                          ;; MV-pass + known-tail-call family (gate-34
+                          ;; sibling sweep; PPC64 vinsns 3947-3957;
+                          ;; spentry-D bodies 279/1581/720/751/772/780)
+                          ;; builtin-call dispatch (gate-35; spentry-D
+                          ;; bodies 1160/1174/1186/1198/1210)
+                          (defsubprim .SPcallbuiltin)
+                          (defsubprim .SPcallbuiltin0)
+                          (defsubprim .SPcallbuiltin1)
+                          (defsubprim .SPcallbuiltin2)
+                          (defsubprim .SPcallbuiltin3)
+                          ;; variable-size uvector alloc (gate-36;
+                          ;; spentry-A misc_alloc@450 / _init@679)
+                          ;; MV fit (gate-37; spentry-D fitvals@300)
+                          ;; checked special-ref (demand-scan wave;
+                          ;; spentry-A specrefcheck@372)
+                          ;; &optional defaulting (cut-3 wave;
+                          ;; spentry-D default_optional_args@357)
+                          ;; lexpr entry + MV slide (cut-5 wave;
+                          ;; spentry-E lexpr_entry@604, spentry-D
+                          ;; mvslide@1532)
+                          (defsubprim .SPlexpr-entry)
+                          ;; stack/list allocation family (gate-39
+                          ;; sibling sweep; PPC64 vinsns 3983-3999;
+                          ;; spentry-A 504/579/619/705/736,
+                          ;; spentry-B 371/386/449)
+                          ;; nth-value (w9; spentry-D nthvalue@317)
+                          ;; integer-sign (w9; spentry-A integer_sign@399)
+                          ;; catch/throw/unwind-protect/progv cluster (w10;
+                          ;; spentry-C-bind-catch-throw.s:319/326/334/1663/
+                          ;; 343/440/550, spentry-B:478/1044)
+                          (defsubprim .SPnmkunwind)))))))
+
+;;; The extension above rebinds the arm64::*subprims* VARIABLE, but
+;;; ccl::subprim-name->offset resolves through the arch STRUCT's
+;;; captured table (compiler/subprims.lisp:53 -> arch::target-subprims-
+;;; table of backend-target-arch), which *arm64-target-arch* filled at
+;;; its own load time (arm64-arch.lisp:987 :subprims-table) — gate-28:
+;;; ".SPRPLACD not found" while the variable held it.  Refresh the
+;;; struct so both lookup paths see the extended vector.
+(setf (arch::target-subprims-table *arm64-target-arch*) *subprims*)

--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -1268,6 +1268,8 @@
 (defconstant fasl-version #x1)
 (defconstant fasl-max-version #x1)
 (defconstant fasl-min-version #x1)
-(defparameter *image-abi-version* #x1)
+;; Next free after ARM32's 1045; the placeholder #x1 fails every
+;; kernel's "image too old" minimum check (image.h ABI_VERSION).
+(defparameter *image-abi-version* 1046)
 
 (provide "ARM64-ARCH")

--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -620,16 +620,22 @@
   flags
   link)
 
-;;; XXX no idea about this for ARM64 right now
-;;; Catch frames go on the cstack, below a lisp frame whose savelr
-;;; field references the catch exit point/unwind-protect cleanup code.
+;;; Kernel ground truth (lisp-kernel _structf catch_frame + mkcatch):
+;;; PPC64's layout with nsaveregs=4.  Catch frames are misc-tagged
+;;; uvectors on the temp stack; the caller's continuation lives in a
+;;; control-stack lisp_frame referenced by the csp slot.  regs[] holds
+;;; save0..save3 in ascending order (str save0 at regs+0).
 (define-fixedsized-object catch-frame ()
+  catch-tag            ;#<unbound> -> unwind-protect, else catch
   link                 ;tagged pointer to next older catch frame
   mvflag               ;0 if single-value, 1 if uwp or multiple-value
-  catch-tag            ;#<unbound> -> unwind-protect, else catch
+  csp                  ;saved control-stack lisp_frame pointer
   db-link              ;value of dynamic-binding link on thread entry.
+  save-save0           ;saved registers, save0 first
+  save-save1
+  save-save2
+  save-save3
   xframe               ;exception-frame link
-  last-lisp-frame
   nfp)
 
 (define-fixedsized-object lock ()

--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -68,7 +68,8 @@
 (defconstant fulltag-misc         #b1100) ;uvector/miscobj (see note below)
 (defconstant fulltag-immheader-2  #b1101)
 (defconstant fulltag-nodeheader-1 #b1110)
-(defconstant fulltag-function     #b1111)
+;; #b1111 free: fulltag-function removed -- a function is an ordinary
+;; miscobj (fulltag-misc + subtag-function); functionp checks the subtag.
 
 ;;; Note on fulltag-misc: the value (12) was selected deliberately.
 ;;; This allows us to branch directly to a tagged code-vector pointer:
@@ -231,6 +232,14 @@
 (defconstant xtype-array3d #x40)
 (defconstant xtype-null #x50)
 
+;;; Kernel error number for funcalling a macro/special-operator name
+;;; (the fcell simple-vector's %macro-code% UUO).  Canonical homes:
+;;; compiler/arch.lisp + lisp-kernel/errors.s + lisp-kernel/lisp-errors.h
+;;; (all in this patch).  Duplicated here because a frozen cross-host
+;;; image bakes arch.lisp, so a NEW arch.lisp constant is invisible to a
+;;; cross compile; this file is (re)loaded by every backend load.
+(defconstant error-apply-macro-or-special 20)
+
 ;;; A sanity check: no synthetic xtype may collide with a real subtag
 ;;; byte or with a bare tag code (#x00-#x0f).
 (eval-when (:compile-toplevel)
@@ -256,7 +265,7 @@
 (defconstant misc-dfloat-offset misc-data-offset)
 
 (defconstant misc-symbol-offset (- node-size fulltag-symbol))
-(defconstant misc-function-offset (- node-size fulltag-function))
+(defconstant misc-function-offset (- node-size fulltag-misc)) ; = misc-data-offset
 
 ;;; There is a pad word after the uvector header so that the
 ;;; complex-double-float elements are 16-byte aligned.
@@ -673,7 +682,7 @@
   plist
   binding-index)
 
-(define-fixedsized-object function (fulltag-function)
+(define-fixedsized-object function (fulltag-misc)
   code-vector
   constants
   ;; constants and metadata follow
@@ -1134,8 +1143,8 @@
    :null-tag fulltag-nil
    :symbol-tag fulltag-symbol
    :symbol-tag-is-subtag nil
-   :function-tag fulltag-function
-   :function-tag-is-subtag nil
+   :function-tag subtag-function
+   :function-tag-is-subtag t
    :big-endian nil
    :misc-subtag-offset misc-subtag-offset
    :car-offset cons.car

--- a/compiler/ARM64/arm64-asm.lisp
+++ b/compiler/ARM64/arm64-asm.lisp
@@ -12,6 +12,22 @@
 (defvar *constants* ())
 (defvar *instructions* ())
 
+;;; Map a subprim name (a symbol or string, e.g. '.SPgvset) to its byte
+;;; offset in the per-thread subprim table, or NIL if there is no such
+;;; subprim.  arm642.lisp already calls this at five sites -- e.g.
+;;; (! call-subprim-3 arg_z (arm64-subprimitive-offset '.SPgvset) ...) in
+;;; arm642-%gvset and the %rplaca/%rplacd pair -- so a cross-compile of
+;;; level-0 dies in l0-array with "Undefined function
+;;; ARM64::ARM64-SUBPRIMITIVE-OFFSET called with arguments (.SPGVSET)".
+;;; Same body and same home as ARM32's arm-subprimitive-offset
+;;; (compiler/ARM/arm-asm.lisp:52), over ARM64's own *subprims* vector.
+(defun arm64-subprimitive-offset (x)
+  (if (and x (or (symbolp x) (stringp x)))
+    (let* ((info (find x arm64::*subprims* :test #'string-equal
+                       :key #'ccl::subprimitive-info-name)))
+      (when info
+        (ccl::subprimitive-info-offset info)))))
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
 
 (defstruct register

--- a/compiler/ARM64/arm64-asm.lisp
+++ b/compiler/ARM64/arm64-asm.lisp
@@ -490,6 +490,9 @@
    ;; the emit site MUST follow it with (uuo-extra-registers index dest),
    ;; which the handler reads as data before resuming past both words.
    (def uuo-error-slot-unbound ((:ruuo :x)) (logior (ash 6 7) 1) #xffffff83)
+   ;; Funcalled a macro/special-operator name (reg = fname); the kernel
+   ;; routes it to error_apply_macro_or_special -> $XNOTFUN.
+   (def uuo-error-apply-macro ((:ruuo :x)) (logior (ash 7 7) 1) #xffffff83)
 
    ;; wrong_type UUOs (uuo format #b011)
    ;; arm64-uuo.s:57-64.  reg in 6:2, continuable flag in 7, expected type

--- a/compiler/ARM64/arm64-asm.lisp
+++ b/compiler/ARM64/arm64-asm.lisp
@@ -432,16 +432,16 @@
 
 (defparameter *instruction-templates*
   (vector
-   ;; nullary UUOs (uuo format #b111)
-   (def uuo-alloc-trap () (logior (ash 0 3) #x7) #xffffffff)
-   (def uuo-error-wrong-nargs () (logior (ash 1 3) #x7)  #xffffffff)
-   (def uuo-gc-trap () (logior (ash 2 3) #x7) #xffffffff)
-   (def uuo-debug-trap () (logior (ash 3 3) #x7) #xffffffff)
+   ;; misc-format UUOs (arm64-uuo.s: udf #((info << 2) | uuo_format_misc))
+   (def uuo-alloc-trap () (ash 1 2) #xffffffff)
+   (def uuo-error-wrong-nargs () (ash 8 2) #xffffffff)
+   (def uuo-gc-trap () (ash 2 2) #xffffffff)
+   (def uuo-debug-trap () (ash 3 2) #xffffffff)
 
-   ;; unary UUOs (uuo format #b001)
-   (def uuo-error-too-few-args () (logior (ash 0 3) #x1)  #xffffffff)
-   (def uuo-error-too-many-args () (logior (ash 1 3) #x1)  #xffffffff)
-   (def uuo-error-wrong-number-of-args () (logior (ash 2 3) #x1) #xffffffff)
+   ;; nargs-check UUOs (misc infos 6/7/8, arm64-uuo.s renumber)
+   (def uuo-error-too-few-args () (ash 6 2) #xffffffff)
+   (def uuo-error-too-many-args () (ash 7 2) #xffffffff)
+   (def uuo-error-wrong-number-of-args () (ash 8 2) #xffffffff)
 
    ;; binary UUOs (uuo format #b010)
 

--- a/compiler/ARM64/arm64-asm.lisp
+++ b/compiler/ARM64/arm64-asm.lisp
@@ -459,7 +459,43 @@
    (def uuo-error-too-many-args () (ash 7 2) #xffffffff)
    (def uuo-error-wrong-number-of-args () (ash 8 2) #xffffffff)
 
+   ;; the last misc-format UUO with no template (arm64-uuo.s:82-84).
+   ;; The kernel synthesizes this same word for a deferred process interrupt
+   ;; (DEFERRED_INTERRUPT_INSTRUCTION), and lisp's trap dispatcher tests for
+   ;; it before anything else, so the interrupt-poll sites need to emit it.
+   (def uuo-interrupt-now () (ash 4 2) #xffffffff)
+
    ;; binary UUOs (uuo format #b010)
+   ;; arm64-uuo.s:42-55.  ra in 6:2, rb in 11:7, 4 bits of info in 15:12;
+   ;; the mask covers the info and the format but not the register fields.
+   (def uuo-error-vector-bounds ((:ruuo :x) (:ruuo2 :x)) (logior (ash 0 12) 2) #xfffff003)
+   (def uuo-error-array-bounds ((:ruuo :x) (:ruuo2 :x)) (logior (ash 1 12) 2) #xfffff003)
+   (def uuo-error-integer-divide-by-zero ((:ruuo :x) (:ruuo2 :x)) (logior (ash 2 12) 2) #xfffff003)
+   (def uuo-error-eep-unresolved ((:ruuo :x) (:ruuo2 :x)) (logior (ash 3 12) 2) #xfffff003)
+   (def uuo-error-fpu-exception ((:ruuo :x) (:ruuo2 :x)) (logior (ash 4 12) 2) #xfffff003)
+   (def uuo-error-array-rank ((:ruuo :x) (:ruuo2 :x)) (logior (ash 5 12) 2) #xfffff003)
+   (def uuo-error-array-flags ((:ruuo :x) (:ruuo2 :x)) (logior (ash 6 12) 2) #xfffff003)
+   (def uuo-extra-registers ((:ruuo :x) (:ruuo2 :x)) (logior (ash 7 12) 2) #xfffff003)
+
+   ;; unary UUOs (uuo format #b001)
+   ;; arm64-uuo.s:29-40.  reg in 6:2, 9 bits of info in 15:7.
+   (def uuo-error-reg-not-callable ((:ruuo :x)) (logior (ash 0 7) 1) #xffffff83)
+   (def uuo-error-no-throw-tag ((:ruuo :x)) (logior (ash 1 7) 1) #xffffff83)
+   (def uuo-error-unbound ((:ruuo :x)) (logior (ash 2 7) 1) #xffffff83)
+   (def uuo-error-udf ((:ruuo :x)) (logior (ash 3 7) 1) #xffffff83)
+   (def uuo-error-udf-call ((:ruuo :x)) (logior (ash 4 7) 1) #xffffff83)
+   (def uuo-error-tlb-too-small ((:ruuo :x)) (logior (ash 5 7) 1) #xffffff83)
+
+   ;; wrong_type UUOs (uuo format #b011)
+   ;; arm64-uuo.s:57-64.  reg in 6:2, continuable flag in 7, expected type
+   ;; code in 15:8.  uuo_error_reg_not_lisptag / _not_fulltag / _not_xtype
+   ;; are all this one encoding with a different kind of code, so the
+   ;; operand is just the code: pass a lisptag, a fulltag or an xtype as
+   ;; the situation requires.  The cerror form asks the handler to make the
+   ;; error continuable by writing the user's value back into the trapping
+   ;; register.
+   (def uuo-error-reg-not-xtype ((:ruuo :x) :uuo-xtype) 3 #xffff0083)
+   (def uuo-cerror-reg-not-xtype ((:ruuo :x) :uuo-xtype) #x83 #xffff0083)
 
    ;;; C4.1.1  Reserved
 
@@ -1256,6 +1292,8 @@
     :tbit-w        ;tbz/tbnz bit number 0..31 (W); b5 is always 0
     :exc16         ;16-bit exception immediate @ 20:5 (brk/hlt/svc)
     :udf16         ;16-bit undefined immediate @ 15:0 (udf)
+    :uuo-xtype     ;wrong_type UUO expected-type code @ 15:8: a lisptag, a
+                   ; fulltag or an xtype (arm64-uuo.s:57-60)
     :baropt        ;4-bit barrier option (CRm) @ 11:8 (dmb/dsb)
                    ;  15 = full system
     :sysreg        ;named system register, 15-bit op0:op1:CRn:CRm:op2 @ 19:5
@@ -1755,6 +1793,9 @@
         ((:immr-w :imms-w :tbit-w) (and (eql shift 0)
                                         (typep value '(integer 0 31))))
         ((:exc16 :udf16) (and (eql shift 0) (typep value '(unsigned-byte 16))))
+        ;; wrong_type UUO expected-type code: a lisptag, a fulltag or an
+        ;; xtype, all of which fit 8 bits (arm64-uuo.s:57-60).
+        (:uuo-xtype (and (eql shift 0) (typep value '(unsigned-byte 8))))
         (:baropt (and (eql shift 0) (typep value '(unsigned-byte 4))))
         (:imm5 (and (eql shift 0) (typep value '(unsigned-byte 5))))
         (:nzcv (and (eql shift 0) (typep value '(unsigned-byte 4))))
@@ -1895,7 +1936,10 @@
  `((:rd . ,(byte 5 0)) (:rt . ,(byte 5 0))
    (:rn . ,(byte 5 5)) (:base . ,(byte 5 5))
    (:ra . ,(byte 5 10)) (:rt2 . ,(byte 5 10))
-   (:rm . ,(byte 5 16)) (:rs . ,(byte 5 16))))
+   (:rm . ,(byte 5 16)) (:rs . ,(byte 5 16))
+   ;; UUO operand registers (arm64-uuo.s): the unary and wrong_type formats
+   ;; put a register in 6:2, and the binary format puts a second one in 11:7.
+   (:ruuo . ,(byte 5 2)) (:ruuo2 . ,(byte 5 7))))
 
 (defun register-field (role)
   (or (cdr (assoc role *register-fields*))
@@ -1927,7 +1971,7 @@
 ;;; is what distinguishes the two forms).
 (defun encode-register-operand (insn operand role class)
   (ecase role
-    ((:rd :rt :rn :base :rm :rs :ra :rt2)
+    ((:rd :rt :rn :base :rm :rs :ra :rt2 :ruuo :ruuo2)
      (insert-register insn role operand))
     (:rn+rm
      (insert-register insn :rn operand)
@@ -2100,6 +2144,7 @@
     (:imms-w ,(byte 6 10))
     (:exc16 ,(byte 16 5))
     (:udf16 ,(byte 16 0))
+    (:uuo-xtype ,(byte 8 8))
     (:baropt ,(byte 4 8))
     (:imm5 ,(byte 5 16))
     (:nzcv ,(byte 4 0))
@@ -2452,6 +2497,7 @@
     ((:imms-x :imms-w) "#imms")
     ((:tbit-x :tbit-w) "#bit")
     ((:exc16 :udf16) "#imm16")
+    (:uuo-xtype "#type")
     (:baropt "#option")
     (:sysreg "sysreg")
     (:imm5 "#imm5")

--- a/compiler/ARM64/arm64-asm.lisp
+++ b/compiler/ARM64/arm64-asm.lisp
@@ -485,6 +485,11 @@
    (def uuo-error-udf ((:ruuo :x)) (logior (ash 3 7) 1) #xffffff83)
    (def uuo-error-udf-call ((:ruuo :x)) (logior (ash 4 7) 1) #xffffff83)
    (def uuo-error-tlb-too-small ((:ruuo :x)) (logior (ash 5 7) 1) #xffffff83)
+   ;; Three-register error (arm64-uuo.s, doc/porting/arm64.md "Errors that
+   ;; need three registers").  The register named here is the slot vector;
+   ;; the emit site MUST follow it with (uuo-extra-registers index dest),
+   ;; which the handler reads as data before resuming past both words.
+   (def uuo-error-slot-unbound ((:ruuo :x)) (logior (ash 6 7) 1) #xffffff83)
 
    ;; wrong_type UUOs (uuo format #b011)
    ;; arm64-uuo.s:57-64.  reg in 6:2, continuable flag in 7, expected type

--- a/compiler/ARM64/arm64-backend.lisp
+++ b/compiler/ARM64/arm64-backend.lisp
@@ -234,6 +234,7 @@
                 :target-foreign-type-data nil
                 :target-arch arm64::*arm64-target-arch*))
 
+#+(or darwinarm64-target (not arm64-target))
 (pushnew *darwinarm64-backend* *known-arm64-backends*)
 
 (defvar *arm64-backend* (car *known-arm64-backends*))

--- a/compiler/ARM64/arm64-disassemble.lisp
+++ b/compiler/ARM64/arm64-disassemble.lisp
@@ -534,3 +534,23 @@
          (di-vector (make-di-vector code-vector)))
     (resolve-labels di-vector)
     (print-di-vector di-vector stream)))
+
+;;; The CCL-facing entry point.  lib/misc.lisp's DISASSEMBLE dispatches to a
+;;; per-backend <arch>-xdisassemble (ppc-xdisassemble, x86-xdisassemble,
+;;; arm-xdisassemble); arm64 had the machinery above but no such entry, so
+;;; DISASSEMBLE signalled "Undefined function CCL::ARM64-XDISASSEMBLE".
+;;;
+;;; Modelled on arm-disassemble.lisp:540.  Two details are load-bearing:
+;;;
+;;;   * the stream is *STANDARD-OUTPUT*, not this file's *debug-io* default,
+;;;     matching every other backend's entry point -- CL:DISASSEMBLE is
+;;;     specified to write to *standard-output*, and that is what a caller
+;;;     binding it (WITH-OUTPUT-TO-STRING) can capture;
+;;;   * FUNCTION-TO-FUNCTION-VECTOR, not the raw function.  ARM32 hands the
+;;;     function straight to its xfunction printer, which UVREFs it; on arm64
+;;;     the function-vector view is the defined way to index a function as a
+;;;     uvector (the archmacro is in arm64-arch.lisp), and it stays correct
+;;;     whether or not functions carry a dedicated pointer tag.
+(defun ccl::arm64-xdisassemble (function)
+  (ccl::arm64-disassemble-xfunction (ccl::function-to-function-vector function)
+                                    *standard-output*))

--- a/compiler/ARM64/arm64-lap.lisp
+++ b/compiler/ARM64/arm64-lap.lisp
@@ -117,7 +117,15 @@
           (setf (uvref constants-vector (1+ k)) imm)))
       (setf (uvref constants-vector (1- constants-size)) lfbits
             (uvref constants-vector 0) code-vector)
-      constants-vector)))
+      ;; ARM64-DEVIATION (resident retag, 16m23): %alloc-misc returns a
+      ;; misc-tagged vector; Matt's fulltag_function(15) is distinct from
+      ;; fulltag_misc(12), so the resident (non-cross) path must retag it
+      ;; to a real callable function (passes require-function checks, e.g.
+      ;; %defun).  Cross-compile keeps the raw subtag-xfunction vector (the
+      ;; image writer tags it).  Mirrors $fasl-clfun's retag.
+      (if cross-compiling
+        constants-vector
+        (function-vector-to-function constants-vector)))))
 
 (defun arm64-lap-pseudo-op (directive arg current)
   (ecase directive

--- a/compiler/ARM64/arm64-lap.lisp
+++ b/compiler/ARM64/arm64-lap.lisp
@@ -67,10 +67,13 @@
   (terpri))
 
 (defun %define-arm64-lap-function (name body &optional (bits 0))
-  (declare (ignore bits))
   (with-dll-node-freelist (elements arm64::*instruction-freelist*)
     (let* ((arm64::*labels* ())
            (arm64::*constants* ())
+           ;; Per-function, from BITS, exactly as ppc-lap.lisp:92 does.  Left
+           ;; global, an (:arglist ...) pseudo-op leaks its encoding into every
+           ;; LAP function assembled afterwards.
+           (*arm64-lap-lfun-bits* bits)
            (name-cell (list name))
            (section-size -1)
            (current elements))

--- a/compiler/ARM64/arm64-lapmacros.lisp
+++ b/compiler/ARM64/arm64-lapmacros.lisp
@@ -54,7 +54,10 @@
 (defarm64lapmacro check-nargs (min &optional (max min))
   (let ((ok1 (gensym "@"))
         (ok2 (gensym "@")))
-    (if (= max min)
+    ;; EQ, not =: MAX may be NIL ("no maximum"), and `=' signals a
+    ;; TYPE-ERROR on it before the (null max) branch below is reached.
+    ;; ppc-lapmacros.lisp:220 and arm-lapmacros.lisp:31 both use EQ.
+    (if (eq max min)
       `(progn
          (cmp nargs (:$ (ash ,min arm64::fixnumshift)))
          (b.eq ,ok1)

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -426,7 +426,7 @@
                                                       (x :imm))
                                                      ((temp (:u64 #.arm64::imm0))))
   (movz temp (:$ spno))
-  (ldr temp (:@ rnil temp))
+  (ldr temp (:@ rcontext temp))
   (blr temp))
 
 (define-arm64-vinsn (call-subprim-2 :call :subprim) (((dest :imm))
@@ -435,7 +435,7 @@
                                                       (y :imm))
                                                      ((temp (:u64 #.arm64::imm0))))
   (movz temp (:$ spoffset))
-  (ldr temp (:@ rnil temp))
+  (ldr temp (:@ rcontext temp))
   (blr temp))
 
 (define-arm64-vinsn (jump :jump) (()

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -91,10 +91,9 @@
 (define-arm64-vinsn (nfp-store-single-float-nested :nfp :set)
     (()
      ((val :single-float)
-      (offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (str val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+      (offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (str val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 (define-arm64-vinsn (nfp-load-single-float :nfp :ref)
     (((val :single-float))
@@ -103,10 +102,9 @@
 
 (define-arm64-vinsn (nfp-load-single-float-nested :nfp :ref)
     (((val :single-float))
-     ((offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (ldr val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+     ((offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (ldr val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 ;;; NFP double-float access.  Identical to the single-float forms except the
 ;;; datum is a D-view FP register, so the scaled STR/LDR offset is by 8.  (NFP
@@ -121,10 +119,9 @@
 (define-arm64-vinsn (nfp-store-double-float-nested :nfp :set)
     (()
      ((val :double-float)
-      (offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (str val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+      (offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (str val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 (define-arm64-vinsn (nfp-load-double-float :nfp :ref)
     (((val :double-float))
@@ -133,10 +130,9 @@
 
 (define-arm64-vinsn (nfp-load-double-float-nested :nfp :ref)
     (((val :double-float))
-     ((offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (ldr val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+     ((offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (ldr val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 ;;; NFP unboxed-word (natural) access.  An unboxed natural is a full 64-bit
 ;;; machine word, so a plain integer STR/LDR (the :x template) does it -- same
@@ -150,10 +146,9 @@
 (define-arm64-vinsn (nfp-store-unboxed-word-nested :nfp :set)
     (()
      ((val :u64)
-      (offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (str val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+      (offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (str val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 (define-arm64-vinsn (nfp-load-unboxed-word :nfp :ref)
     (((val :u64))
@@ -162,10 +157,9 @@
 
 (define-arm64-vinsn (nfp-load-unboxed-word-nested :nfp :ref)
     (((val :u64))
-     ((offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (ldr val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+     ((offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (ldr val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 ;;; NFP complex-single-float access.  A complex-single-float is two packed
 ;;; single-floats = 64 bits, held in the low (D) half of an FP register, so it
@@ -183,10 +177,9 @@
 (define-arm64-vinsn (nfp-store-complex-single-float-nested :nfp :set)
     (()
      ((val :complex-single-float)
-      (offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (str val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+      (offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (str val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 (define-arm64-vinsn (nfp-load-complex-single-float :nfp :ref)
     (((val :complex-single-float))
@@ -195,10 +188,9 @@
 
 (define-arm64-vinsn (nfp-load-complex-single-float-nested :nfp :ref)
     (((val :complex-single-float))
-     ((offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (ldr val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+     ((offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (ldr val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 ;;; NFP complex-double-float access.  A complex-double-float is two
 ;;; doubles = 128 bits, a full Q register, so it occupies a 16-byte
@@ -217,10 +209,9 @@
 (define-arm64-vinsn (nfp-store-complex-double-float-nested :nfp :set :uses-frame-pointer)
     (()
      ((val :complex-double-float)
-      (offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (stur val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+      (offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (stur val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 (define-arm64-vinsn (nfp-load-complex-double-float :nfp :ref :uses-frame-pointer)
     (((val :complex-double-float))
@@ -229,10 +220,9 @@
 
 (define-arm64-vinsn (nfp-load-complex-double-float-nested :nfp :ref :uses-frame-pointer)
     (((val :complex-double-float))
-     ((offset :u16const))
-     ((nfp :imm)))
-  (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))
-  (ldur val (:@ nfp (:$ (:apply + arm64::dnode-size offset)))))
+     ((offset :u16const)))
+  (ldr temp5 (:@ rcontext (:$ arm64::tcr.nfp)))
+  (ldur val (:@ temp5 (:$ (:apply + arm64::dnode-size offset)))))
 
 ;;; Return from function: restore context and return.
 (define-arm64-vinsn (popj :lispcontext :pop :lrRestore :jumpLR)

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -10,10 +10,10 @@
 
 (define-arm64-vinsn misc-ref-c-node (((dest :lisp))
                                      ((v :lisp)
-                                      (idx :u32))
+                                      (idx :s16const))
                                      ())
   ;; this range is limited
-  (ldur dest (:@ v (:$ (:apply + arm64::misc-data-offset idx)))))
+  (ldur dest (:@ v (:$ (:apply + arm64::misc-data-offset (:apply ash idx 3))))))
 
 (define-arm64-vinsn check-exact-nargs (()
                                        ((n :u16const)))

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -531,6 +531,63 @@
    (fmov (:d dest) r))
   (ins (:d dest 1) (:d i 0)))
 
+;;; FPR-to-FPR copies, for arm642-copy-register and arm642-copy-fpr.
+;;; PPC64 (ppc64-vinsns.lisp:2047) covers the same ground with three
+;;; vinsns, and its dest-eq-src guard is kept verbatim here: the emit
+;;; sites do not all promise distinct registers.
+;;;
+;;; PPC64 needs no single<->double copy because a PPC FPR holds a single
+;;; in double format, so its copy-fpr serves both modes; AArch64 keeps
+;;; the two in genuinely different formats, hence the fcvt pair below.
+(define-arm64-vinsn copy-single-float (((dest :single-float))
+                                       ((src :single-float)))
+  ((:not (:pred =
+                (:apply %hard-regspec-value dest)
+                (:apply %hard-regspec-value src)))
+   (fmov dest src)))
+
+(define-arm64-vinsn copy-double-float (((dest :double-float))
+                                       ((src :double-float)))
+  ((:not (:pred =
+                (:apply %hard-regspec-value dest)
+                (:apply %hard-regspec-value src)))
+   (fmov dest src)))
+
+;;; Not guarded: an in-place precision conversion is not a no-op, so
+;;; dest eq src still has to emit the fcvt.
+(define-arm64-vinsn copy-double-to-single (((dest :single-float))
+                                           ((src :double-float)))
+  (fcvt dest src))
+
+(define-arm64-vinsn copy-single-to-double (((dest :double-float))
+                                           ((src :single-float)))
+  (fcvt dest src))
+
+;;; A complex-single-float is one D register (two S lanes), so a single
+;;; D-view fmov copies both parts.  PPC64 and ARM32 both need two moves
+;;; here because they hold a complex float in a register PAIR; doing that
+;;; on AArch64 would clobber an unrelated register.
+(define-arm64-vinsn copy-complex-single-float (((dest :complex-single-float))
+                                               ((src :complex-single-float)))
+  ((:not (:pred =
+                (:apply %hard-regspec-value dest)
+                (:apply %hard-regspec-value src)))
+   (fmov (:d dest) (:d src))))
+
+;;; A complex-double-float is a full 128-bit vector register.  There is
+;;; no register-to-register move for one: :q appears only in the
+;;; str/ldr/stur/ldur templates, and no template takes a vector
+;;; arrangement pair.  Copy it the same way %make-complex-double-float
+;;; builds it -- fmov of lane 0 (which zeroes bits 127:64), then ins of
+;;; lane 1.
+(define-arm64-vinsn copy-complex-double-float (((dest :complex-double-float))
+                                               ((src :complex-double-float)))
+  ((:not (:pred =
+                (:apply %hard-regspec-value dest)
+                (:apply %hard-regspec-value src)))
+   (fmov (:d dest) (:d src))
+   (ins (:d dest 1) (:d src 1))))
+
 ;;; There's no popcount for a GPR, but there is on SIMD registers.
 (define-arm64-vinsn u64-popcount (((dest :u64))
                                   ((src :u64))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -3245,7 +3245,20 @@
                             (let* ((copy (! copy-gpr popped-reg pushed-reg)))
                               (remove-dll-node copy)
                               (if pushed-reg-is-set
-                                (insert-dll-node-after copy push-vinsn)
+                                ;; PUSHED-REG is assigned later in the
+                                ;; sequence, so the copy has to happen
+                                ;; before that assignment.  It also has to
+                                ;; happen after the last reference to
+                                ;; POPPED-REG, whose value we are about to
+                                ;; overwrite; the test above has already
+                                ;; established that that last reference
+                                ;; precedes the first assignment, so there
+                                ;; is a slot between them.  Inserting after
+                                ;; PUSH-VINSN instead clobbers POPPED-REG
+                                ;; ahead of its own uses.
+                                (insert-dll-node-after copy
+                                                       (or popped-reg-is-reffed
+                                                           push-vinsn))
                                 (insert-dll-node-before copy pop-vinsn))))
                           (elide-vinsn push-vinsn)
                           (elide-vinsn pop-vinsn)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -2193,7 +2193,9 @@
                          (t
                           (if (typep constval '(unsigned-byte 32))
                             (arm642-lri seg reg constval)
-                            (! unbox-u32 reg result-reg))))
+                            (if *arm642-reckless*
+                              (! %unbox-u32 reg result-reg)
+                              (! unbox-u32 reg result-reg)))))
                    reg)))
               (is-16-bit
                (if is-signed

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -3181,12 +3181,10 @@
   ;; src and dest are distinct FPRs with the same mode.
   (with-arm64-local-vinsn-macros (seg)
     (case (fpr-mode-value-name (get-regspec-mode src))
-      (:single-float (! single-to-single dest src))
-      (:double-float (! double-to-double dest src))
-      (:complex-single-float (! complex-single-float-to-complex-single-float
-                                dest src))
-      (:complex-double-float (! complex-double-float-to-complex-double-float
-                                dest src)))))
+      (:single-float (! copy-single-float dest src))
+      (:double-float (! copy-double-float dest src))
+      (:complex-single-float (! copy-complex-single-float dest src))
+      (:complex-double-float (! copy-complex-double-float dest src)))))
 
 (defun arm642-elide-pushes (seg push-vinsn pop-vinsn)
   (with-arm64-local-vinsn-macros (seg)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -574,9 +574,9 @@
            *arm642-recorded-symbols*
            (*arm642-emitted-source-notes* '())
            (*arm642-gpr-locations-valid-mask* 0)
-           (*arm642-gpr-locations* (make-array 16 :initial-element nil))
+           (*arm642-gpr-locations* (make-array 32 :initial-element nil))
            (*arm642-gpr-constants-valid-mask* 0)
-           (*arm642-gpr-constants* (make-array 16 :initial-element nil))
+           (*arm642-gpr-constants* (make-array 32 :initial-element nil))
            (*arm642-nfp-depth* 0)
            (*arm642-max-nfp-depth* ())
            (*arm642-all-nfp-pushes* ())

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1722,15 +1722,25 @@
                 (<- temp)))))
           (is-128-bit
               (with-fp-target () (fp-val :complex-double-float)
-                (if (and (eql vreg-class hard-reg-class-fpr)
-                         (eql vreg-mode hard-reg-class-fpr-mode-complex-double-float))
-                  (setq fp-val vreg)
+                ;; ppc2.lisp:1434 -- picking VREG as the destination is a
+                ;; one-armed IF, not the alternative to loading.  Making the
+                ;; load the ELSE of this test skipped it entirely whenever VREG
+                ;; was already a complex-double-float FPR.
+                (when (and (eql vreg-class hard-reg-class-fpr)
+                           (eql vreg-mode hard-reg-class-fpr-mode-complex-double-float))
+                  (setq fp-val vreg))
+                (if (and index-known-fixnum
+                         (<= index-known-fixnum
+                             (- (ash arm64::max-64-bit-constant-index -1) 4)))
+                  (! misc-ref-c-complex-double-float fp-val src index-known-fixnum)
                   (with-imm-target () idx-reg
                     (if index-known-fixnum
-                      (unless unscaled-idx
-                        (setq unscaled-idx idx-reg)
-                        (arm642-absolute-natural seg unscaled-idx nil (ash index-known-fixnum arm64::fixnumshift))))
-                    (! misc-ref-complex-double-float fp-val src unscaled-idx)))
+                      (arm642-absolute-natural
+                       seg idx-reg nil
+                       (+ arm64::complex-double-float.realpart
+                          (ash index-known-fixnum 4)))
+                      (! scale-128bit-misc-index idx-reg unscaled-idx))
+                    (! misc-ref-complex-double-float fp-val src idx-reg)))
                 (if (and (eql vreg-class hard-reg-class-fpr)
                          (eql vreg-mode hard-reg-class-fpr-mode-complex-double-float))
                   (<- fp-val)
@@ -2326,12 +2336,24 @@
             (t
              (cond
                (is-128-bit
-                (with-imm-target () scaled-idx
-                  (if index-known-fixnum
-                    (unless unscaled-idx
-                      (setq unscaled-idx scaled-idx)
-                      (arm642-absolute-natural seg unscaled-idx nil (ash index-known-fixnum arm64::fixnumshift))))
-                  (! misc-set-complex-double-float unboxed-val-reg src unscaled-idx)))
+                ;; ppc2.lisp:2046.  NB ppc2 emits `scale-misc-128-bit-index'
+                ;; here, which PPC defines nowhere -- only the vref spelling
+                ;; scale-128bit-misc-index exists (ppc64-vinsns.lisp:68).  Use
+                ;; the defined name.
+                (if (and index-known-fixnum
+                         (<= index-known-fixnum
+                             (- (ash arm64::max-64-bit-constant-index -1) 4)))
+                  (! misc-set-c-complex-double-float unboxed-val-reg src
+                     index-known-fixnum)
+                  (with-imm-target () scaled-idx
+                    (if index-known-fixnum
+                      (arm642-absolute-natural
+                       seg scaled-idx nil
+                       (+ arm64::complex-double-float.realpart
+                          (ash index-known-fixnum 4)))
+                      (! scale-128bit-misc-index scaled-idx unscaled-idx))
+                    (! misc-set-complex-double-float unboxed-val-reg src
+                       scaled-idx))))
                (is-64-bit
                 ;; Dispatch on the element type.  This used to emit
                 ;; misc-set-{c-,}double-float unconditionally, so every INTEGER

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -2820,6 +2820,14 @@
             (! load-nil arm64::arg_x)
             (! misc-set-c-node arm64::arg_x dest cell)
             (! misc-set-c-node arm64::arg_y dest (1+ cell))))
+        ;; Both legs above build the closure through the MISC allocator
+        ;; (%alloc-misc-fixed / .SPstkgvector), so DEST is fulltag-misc
+        ;; even though its header subtag is subtag-function.  arm64 has a
+        ;; dedicated fulltag-function, so the finished closure has to be
+        ;; retagged before it escapes -- otherwise every require-function
+        ;; check on it fails (%defun's did, at cold load).  The cell
+        ;; stores above are misc-relative, so this must come last.
+        (! tag-as-function dest dest)
         dest))))
 
 (defun arm642-symbol-entry-locative (sym)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -6302,13 +6302,11 @@
                (eql (get-regspec-mode vreg)
                     hard-reg-class-fpr-mode-complex-single-float))
         (setq target vreg))
-      (arm642-two-targeted-reg-forms seg
-                                   r ($ (* 2 (%hard-regspec-value target))
-                                        :class :fpr
-                                        :mode :single-float)
-                                   i ($ (1+ (* 2 (%hard-regspec-value target)))
-                                        :class :fpr
-                                        :mode :single-float))
+      (let* ((rreg (make-unwired-lreg target
+                                      :mode hard-reg-class-fpr-mode-single)))
+        (with-fp-target (rreg) (ireg :single-float)
+          (arm642-two-targeted-reg-forms seg r rreg i ireg)
+          (! %make-complex-single-float target rreg ireg)))
       (<- target)
       (^))))
 
@@ -6323,13 +6321,11 @@
                (eql (get-regspec-mode vreg)
                     hard-reg-class-fpr-mode-complex-double-float))
         (setq target vreg))
-      (arm642-two-targeted-reg-forms seg
-                                     r ($ (%hard-regspec-value target)
-                                          :class :fpr
-                                          :mode :double-float)
-                                     i ($ (1+ (%hard-regspec-value target))
-                                          :class :fpr
-                                          :mode :double-float))
+      (let* ((rreg (make-unwired-lreg target
+                                      :mode hard-reg-class-fpr-mode-double)))
+        (with-fp-target (rreg) (ireg :double-float)
+          (arm642-two-targeted-reg-forms seg r rreg i ireg)
+          (! %make-complex-double-float target rreg ireg)))
       (<- target)
       (^))))
 

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1761,15 +1761,13 @@
                                     new val-reg)
       (when safe
         (when (typep safe 'fixnum)
-          (with-node-target (src unscaled-i unscaled-j val-reg) expected
-            (if simple
-              (progn
-                (! lri expected
-                   (ash (dpb safe target::arrayH.flags-cell-subtag-byte
-                             (ash 1 $arh_simple_bit))
-                        arm64::fixnumshift))
-                (! trap-unless-simple-array-2 src expected))
-              (! trap-unless-typed-array-2 src safe))))
+          (if simple
+            (! trap-unless-simple-array-2
+               src
+               (dpb safe target::arrayH.flags-cell-subtag-byte
+                    (ash 1 $arh_simple_bit))
+               (nx-error-for-simple-2d-array-type type-keyword))
+            (! trap-unless-typed-array-2 src safe)))
         (unless i-known-fixnum
           (! trap-unless-fixnum unscaled-i))
         (unless j-known-fixnum
@@ -1831,15 +1829,13 @@
                     (use-imm-temp (hard-regspec-value val-reg)))
                   (when safe
                     (when (typep safe 'fixnum)
-                      (with-node-target (src node-val unscaled-i unscaled-j) expected
-                        (if simple
-                          (progn
-                            (! lri expected
-                               (ash (dpb safe target::arrayH.flags-cell-subtag-byte
-                                         (ash 1 $arh_simple_bit))
-                                    arm64::fixnumshift))
-                            (! trap-unless-simple-array-2 src expected))
-                          (! trap-unless-typed-array-2 src safe))))
+                      (if simple
+                        (! trap-unless-simple-array-2
+                           src
+                           (dpb safe target::arrayH.flags-cell-subtag-byte
+                                (ash 1 $arh_simple_bit))
+                           (nx-error-for-simple-2d-array-type type-keyword))
+                        (! trap-unless-typed-array-2 src safe)))
                     (unless i-known-fixnum
                       (! trap-unless-fixnum unscaled-i))
                     (unless j-known-fixnum
@@ -1912,15 +1908,11 @@
           (when safe
             (when (typep safe 'fixnum)
               (if simple
-                (let* ((expected (if constidx
-                                   (with-node-target (src val-reg) expected
-                                     expected)
-                                   (with-node-target (src unscaled-i unscaled-j unscaled-k val-reg) expected
-                                     expected))))
-                  (! lri expected (ash (dpb safe target::arrayH.flags-cell-subtag-byte
-                                            (ash 1 $arh_simple_bit))
-                                       arm64::fixnumshift))
-                  (! trap-unless-simple-array-3 src expected))
+                (! trap-unless-simple-array-3
+                   src
+                   (dpb safe target::arrayH.flags-cell-subtag-byte
+                        (ash 1 $arh_simple_bit))
+                   (nx-error-for-simple-3d-array-type type-keyword))
                 (! trap-unless-typed-array-3 src safe)))
             (unless i-known-fixnum
               (! trap-unless-fixnum unscaled-i))
@@ -1976,15 +1968,11 @@
       (when safe
         (when (typep safe 'fixnum)
           (if simple
-            (let* ((expected (if constidx
-                               (with-node-target (src) expected
-                                 expected)
-                               (with-node-target (src unscaled-i unscaled-j unscaled-k) expected
-                                 expected))))
-              (! lri expected (ash (dpb safe target::arrayH.flags-cell-subtag-byte
-                                        (ash 1 $arh_simple_bit))
-                                   arm64::fixnumshift))
-              (! trap-unless-simple-array-3 src expected))
+            (! trap-unless-simple-array-3
+               src
+               (dpb safe target::arrayH.flags-cell-subtag-byte
+                    (ash 1 $arh_simple_bit))
+               (nx-error-for-simple-3d-array-type typekeyword))
             (! trap-unless-typed-array-3 src safe)))
         (unless i-known-fixnum
           (! trap-unless-fixnum unscaled-i))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1087,7 +1087,9 @@
     (declare (type (unsigned-byte 16) nargs))
     (with-arm64-local-vinsn-macros (seg)
       (unless *arm642-reckless*
-        (! check-exact-nargs nargs))
+        (if (arm642-aimm-p (ash nargs arm64::fixnumshift))
+          (! check-exact-nargs nargs)
+          (! check-exact-nargs-large nargs)))
       (arm642-argregs-entry seg rev-fixed-args))))
 
 ;;; No more than three &optional args; all default to NIL and none have
@@ -5593,21 +5595,31 @@
           (if (not (or opt rest keys))
             (progn
               (setq arg-regs (arm642-req-nargs-entry seg rev-fixed)))
+            ;; simple-opt-entry and the default-N-args vinsns it emits
+            ;; compare the BOXED count against an add/sub immediate, so
+            ;; a boxed max past imm12 must take the general path below,
+            ;; whose checks have -large fallbacks.
             (if (and (not (or hardopt rest keys))
-                     (<= num-opt $numarm64argregs))
+                     (<= num-opt $numarm64argregs)
+                     (arm642-aimm-p (ash (+ num-fixed num-opt)
+                                         arm64::fixnumshift)))
               (setq arg-regs (arm642-simple-opt-entry seg rev-opt rev-fixed))
               (progn
                 ;; If the minumum acceptable number of args is
                 ;; non-zero, ensure that at least that many were
                 ;; received.  If there's an upper bound, enforce it.
 
+                ;; aimm-p must see the BOXED count: the check vinsns
+                ;; compare (ash n fixnumshift).  (ARM32's raw-value test
+                ;; was sound only because its rotated-immediate encoder
+                ;; makes "raw encodable => boxed encodable" true.)
                 (when rev-fixed
-                  (if (arm642-aimm-p num-fixed)
+                  (if (arm642-aimm-p (ash num-fixed arm64::fixnumshift))
                     (! check-min-nargs num-fixed)
                     (! check-min-nargs-large num-fixed)))
                 (unless (or rest keys)
                   (let* ((max (+ num-fixed num-opt)))
-                    (if (arm642-aimm-p max)
+                    (if (arm642-aimm-p (ash max arm64::fixnumshift))
                       (! check-max-nargs max)
                       (! check-max-nargs-large max))))
                 (unless lexprp

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1638,10 +1638,12 @@
                   (! misc-ref-c-double-float fp-val src index-known-fixnum)
                   (with-imm-target () idx-reg
                     (if index-known-fixnum
-                      (unless unscaled-idx
-                        (setq unscaled-idx idx-reg)
-                        (arm642-absolute-natural seg unscaled-idx nil (ash index-known-fixnum arm64::fixnumshift))))
-                    (! misc-ref-double-float fp-val src unscaled-idx)))
+                      (arm642-absolute-natural
+                       seg idx-reg nil
+                       (+ (arch::target-misc-data-offset arch)
+                          (ash index-known-fixnum arm64::word-shift)))
+                      (! scale-64bit-misc-index idx-reg unscaled-idx))
+                    (! misc-ref-double-float fp-val src idx-reg)))
                 (if (eq vreg-class hard-reg-class-fpr)
                   (<- fp-val)
                   (ensuring-node-target (target vreg)
@@ -1655,15 +1657,69 @@
                   (! misc-ref-c-double-float fp-val src index-known-fixnum)
                   (with-imm-target () idx-reg
                     (if index-known-fixnum
-                      (unless unscaled-idx
-                        (setq unscaled-idx idx-reg)
-                        (arm642-absolute-natural seg unscaled-idx nil (ash index-known-fixnum arm64::fixnumshift))))
-                    (! misc-ref-double-float fp-val src unscaled-idx)))
+                      (arm642-absolute-natural
+                       seg idx-reg nil
+                       (+ (arch::target-misc-data-offset arch)
+                          (ash index-known-fixnum arm64::word-shift)))
+                      (! scale-64bit-misc-index idx-reg unscaled-idx))
+                    (! misc-ref-double-float fp-val src idx-reg)))
                 (if (and (eql vreg-class hard-reg-class-fpr)
                          (eql vreg-mode hard-reg-class-fpr-mode-complex-single-float))
                   (<- fp-val)
                   (ensuring-node-target (target vreg)
-                    (! complex-single-float->node target fp-val)))))))
+                    (! complex-single-float->node target fp-val)))))
+             ;; The integer 64-bit element types.  Without these the CASE fell
+             ;; off the end and emitted NOTHING, so a compiled AREF on a
+             ;; (simple-array (signed-byte 64)) left VREG holding whatever was
+             ;; already there -- in practice the index, so (aref a i) returned i.
+             ;; PPC64 ppc2.lisp:1410-1432 has the shape; the index plumbing here
+             ;; is the double-float arm's, not PPC's scale-64bit-misc-index,
+             ;; because low-tag fixnumshift=3 already makes a boxed fixnum index
+             ;; equal to the byte offset of an 8-byte element.
+             ((:signed-64-bit-vector :fixnum-vector)
+              (with-imm-target () (temp :s64)
+                (if (and (eql vreg-class hard-reg-class-gpr)
+                         (eql vreg-mode hard-reg-class-gpr-mode-s64))
+                  (setq temp vreg))
+                (if (and index-known-fixnum
+                         (<= index-known-fixnum
+                             (arch::target-max-64-bit-constant-index arch)))
+                  (! misc-ref-c-s64 temp src index-known-fixnum)
+                  ;; TEMP is an imm GPR here, so it must be excluded from the
+                  ;; index temp's candidates -- unlike the float arms above,
+                  ;; where FP-VAL is an FPR and cannot alias.
+                  (with-imm-target (temp) idx-reg
+                    (if index-known-fixnum
+                      (arm642-absolute-natural
+                       seg idx-reg nil
+                       (+ (arch::target-misc-data-offset arch)
+                          (ash index-known-fixnum arm64::word-shift)))
+                      (! scale-64bit-misc-index idx-reg unscaled-idx))
+                    (! misc-ref-s64 temp src idx-reg)))
+                ;; arm642-copy-register boxes s64 -> node via arm642-box-s64,
+                ;; which has both the inline s64->integer path and the
+                ;; .SPmakes64 subprim path, so the bignum case is covered.
+                (<- temp)))
+             (t
+              ;; :unsigned-64-bit-vector -- the only remaining 64-bit ivector
+              ;; type (arm64-arch.lisp:1121 lists exactly five).
+              (with-imm-target () (temp :u64)
+                (if (and (eql vreg-class hard-reg-class-gpr)
+                         (eql vreg-mode hard-reg-class-gpr-mode-u64))
+                  (setq temp vreg))
+                (if (and index-known-fixnum
+                         (<= index-known-fixnum
+                             (arch::target-max-64-bit-constant-index arch)))
+                  (! misc-ref-c-u64 temp src index-known-fixnum)
+                  (with-imm-target (temp) idx-reg
+                    (if index-known-fixnum
+                      (arm642-absolute-natural
+                       seg idx-reg nil
+                       (+ (arch::target-misc-data-offset arch)
+                          (ash index-known-fixnum arm64::word-shift)))
+                      (! scale-64bit-misc-index idx-reg unscaled-idx))
+                    (! misc-ref-u64 temp src idx-reg)))
+                (<- temp)))))
           (is-128-bit
               (with-fp-target () (fp-val :complex-double-float)
                 (if (and (eql vreg-class hard-reg-class-fpr)
@@ -2157,6 +2213,29 @@
                     (when safe
                       (! trap-unless-typecode= result-reg arm64::subtag-complex-single-float))
                     (! get-complex-single-float reg result-reg)
+                    reg))
+                 ;; The integer 64-bit types.  This CASE had no default arm, so
+                 ;; it RETURNED NIL for them and that NIL travelled to
+                 ;; arm642-vset1 as UNBOXED-VAL-REG, where the first
+                 ;; %hard-regspec-value on it signalled "bad regspec: NIL".
+                 ;; Fixing vset1's own dispatch is not enough on its own --
+                 ;; there has to be an unboxed register to dispatch TO.
+                 ;; PPC64 ppc2.lisp:1908-1919 is the shape.
+                 ((:signed-64-bit-vector :fixnum-vector)
+                  (let* ((reg (make-unwired-lreg next-imm-target
+                                                 :mode hard-reg-class-gpr-mode-s64)))
+                    (if (eq type-keyword :fixnum-vector)
+                      (progn
+                        (when safe
+                          (! trap-unless-fixnum result-reg))
+                        (! fixnum->signed-natural reg result-reg))
+                      (! unbox-s64 reg result-reg))
+                    reg))
+                 (t
+                  ;; :unsigned-64-bit-vector
+                  (let* ((reg (make-unwired-lreg next-imm-target
+                                                 :mode hard-reg-class-gpr-mode-u64)))
+                    (! unbox-u64 reg result-reg)
                     reg))))
               (is-32-bit
                (if is-signed
@@ -2254,17 +2333,40 @@
                       (arm642-absolute-natural seg unscaled-idx nil (ash index-known-fixnum arm64::fixnumshift))))
                   (! misc-set-complex-double-float unboxed-val-reg src unscaled-idx)))
                (is-64-bit
+                ;; Dispatch on the element type.  This used to emit
+                ;; misc-set-{c-,}double-float unconditionally, so every INTEGER
+                ;; 64-bit store handed an imm GPR to a vinsn declaring an FPR
+                ;; operand and died in %HARD-REGSPEC-VALUE with "bad regspec:
+                ;; NIL" -- (setf (aref a n) v) on a (simple-array (signed-byte
+                ;; 64)) at speed 3 / safety 0 would not compile at all.
+                ;; PPC64 ppc2.lisp:2024-2045 is the shape.  A complex-single-float
+                ;; deliberately keeps the double-float vinsns: it is two S lanes
+                ;; in one 64-bit slot, so a D-form store moves it bit-for-bit.
                 (with-imm-target (arm64::imm0 arm64::imm1) scaled-idx
                   (if (and index-known-fixnum
                            (<= index-known-fixnum
                                (arch::target-max-64-bit-constant-index arch)))
-                    (! misc-set-c-double-float unboxed-val-reg src index-known-fixnum)
+                    (case type-keyword
+                      ((:double-float-vector :complex-single-float-vector)
+                       (! misc-set-c-double-float unboxed-val-reg src index-known-fixnum))
+                      (t
+                       (if is-signed
+                         (! misc-set-c-s64 unboxed-val-reg src index-known-fixnum)
+                         (! misc-set-c-u64 unboxed-val-reg src index-known-fixnum))))
                     (progn
                       (if index-known-fixnum
-                        (unless unscaled-idx
-                          (setq unscaled-idx scaled-idx)
-                          (arm642-absolute-natural seg unscaled-idx nil (ash index-known-fixnum arm64::fixnumshift))))
-                      (! misc-set-double-float unboxed-val-reg src unscaled-idx)))))
+                        (arm642-absolute-natural
+                         seg scaled-idx nil
+                         (+ (arch::target-misc-data-offset arch)
+                            (ash index-known-fixnum arm64::word-shift)))
+                        (! scale-64bit-misc-index scaled-idx unscaled-idx))
+                      (case type-keyword
+                        ((:double-float-vector :complex-single-float-vector)
+                         (! misc-set-double-float unboxed-val-reg src scaled-idx))
+                        (t
+                         (if is-signed
+                           (! misc-set-s64 unboxed-val-reg src scaled-idx)
+                           (! misc-set-u64 unboxed-val-reg src scaled-idx))))))))
                (t
                 (with-imm-target (unboxed-val-reg) scaled-idx
                   (cond

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1447,6 +1447,26 @@
         (! call-subprim (subprim-name->offset '.SPmakeu64))
         (arm642-copy-register seg node-dest arg_z)))))
 
+;;; A u32 or an s32 always fits in a 61-bit fixnum, so boxing one is a
+;;; shift -- no subprim call, no bignum case, and nothing to condition on
+;;; *arm642-open-code-inline* (PPC64 makes exactly this distinction:
+;;; ppc2-box-u32/-box-s32 take the inline path unconditionally under
+;;; :ppc64 and only ppc32 can reach .SPmakeu32/.SPmakes32; ppc2.lisp:1188
+;;; and :1212).  u32->fixnum / s32->fixnum are the ubfiz/sbfiz forms of
+;;; PPC64's u32->integer / s32->integer (sldi, and extsw+sldi).
+;;;
+;;; arm642-vref1 calls both for :signed-32-bit-vector and for the default
+;;; 32-bit element case, so a cross-compile of level-0 stops in l0-array
+;;; with "Undefined function CCL::ARM642-BOX-U32".  arm642-box-u64 was
+;;; already here; these two are its missing siblings.
+(defun arm642-box-u32 (seg node-dest u32-src)
+  (with-arm64-local-vinsn-macros (seg)
+    (! u32->fixnum node-dest u32-src)))
+
+(defun arm642-box-s32 (seg node-dest s32-src)
+  (with-arm64-local-vinsn-macros (seg)
+    (! s32->fixnum node-dest s32-src)))
+
 (defun arm642-vref1 (seg vreg xfer type-keyword src unscaled-idx
                      index-known-fixnum)
   (with-arm64-local-vinsn-macros (seg vreg xfer)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -6505,6 +6505,82 @@
 ;;; The element count deliberately COVERS the reserved frame, so the GC skips
 ;;; its uninitialized words; the ff-call sequence builds the frame there and
 ;;; then shrinks the count by 4 to publish it.  See ALLOC-C-FRAME.
+;;; The four TYPED multi-dimensional acode handlers.  nx1.lisp:884 emits
+;;; simple-typed-aref2/aref3 (and the aset pair) whenever both the array
+;;; element type and the rank are known at compile time; with no handler for
+;;; the operator the compiler signals CCL::COMPILER-BUG, which is what
+;;; CCL.ISSUE#335 and CCL.BUG#620 report.  Only the DECLARED path was
+;;; affected -- an undeclared (aref a i j) routes through general-aref2 and
+;;; the .SParef2 subprim, which is why 2d arrays otherwise worked.
+;;;
+;;; Placement: these MUST sit after the defarm642 macro (defined at the
+;;; DEFPARAMETER block above, arm642.lisp:5671 at the pin).  Putting them next
+;;; to the arm642-aref2/aref3 helpers instead -- which reads better -- makes
+;;; each form compile as a FUNCTION CALL, so loading arm642 dies with
+;;; "Unbound variable: CCL::ARM642-%AREF2" and takes every arm642-additions
+;;; file down with it, because the aborted load never defines the macro.
+;;;
+;;; Adopted VERBATIM from upstream arm642.lisp @1db0ab68 (commit 41400d3c),
+;;; which adapts PPC64 ppc2.lisp:7615/7667/7724/7817.  Taking his text rather
+;;; than writing our own keeps the pin advance a no-op here instead of a
+;;; divergent shadow.  The helpers they call are his own arm642-aset2/aset3/
+;;; aref3 (this file) plus arm642-aref2, which he defines at tip and which our
+;;; compiler overlay supplies at this pin.
+;;;
+;;; TWO UPSTREAM NOTES, both preserved deliberately rather than fixed:
+;;;   * the eight vinsns these paths need -- 2d-dim1, 2d-unscaled-index,
+;;;     check-2d-bound, 3d-dims, 3d-unscaled-index, check-3d-bound,
+;;;     array-data-vector-ref, trap-unless-simple-array-2 -- are defined
+;;;     NOWHERE in his tree at pin or tip, so these handlers are dead code
+;;;     upstream until the vinsns land.  Ours come from the compiler overlay.
+;;;   * simple-typed-aref3's (if (null vreg) ...) has no else branch and falls
+;;;     through into the aref3 call, so a null-vreg 3d aref evaluates its
+;;;     subforms TWICE.  PPC64 has the same shape at ppc2.lisp:7667.  Kept
+;;;     byte-identical to upstream and reported rather than silently diverged.
+(defarm642 arm642-%aref2 simple-typed-aref2 (seg vreg xfer typename arr i j &optional dim0 dim1)
+  (if (null vreg)
+    (progn
+      (arm642-form seg nil nil arr)
+      (arm642-form seg nil nil i)
+      (arm642-form seg nil xfer j))
+    (let* ((type-keyword (acode-immediate-operand typename))
+           (fixtype (nx-lookup-target-uvector-subtag type-keyword))
+           (safe (unless *arm642-reckless* fixtype))
+           (dim0 (acode-fixnum-form-p dim0))
+           (dim1 (acode-fixnum-form-p dim1)))
+      (arm642-aref2 seg vreg xfer arr i j safe type-keyword dim0 dim1))))
+
+(defarm642 arm642-%aref3 simple-typed-aref3 (seg vreg xfer typename arr i j k &optional dim0 dim1 dim2)
+  (if (null vreg)
+    (progn
+      (arm642-form seg nil nil arr)
+      (arm642-form seg nil nil i)
+      (arm642-form seg nil nil j)
+      (arm642-form seg nil xfer k)))
+  (let* ((type-keyword (acode-immediate-operand typename))
+         (fixtype (nx-lookup-target-uvector-subtag type-keyword))
+         (safe (unless *arm642-reckless* fixtype))
+         (dim0 (acode-fixnum-form-p dim0))
+         (dim1 (acode-fixnum-form-p dim1))
+         (dim2 (acode-fixnum-form-p dim2)))
+    (arm642-aref3 seg vreg xfer arr i j k safe type-keyword dim0 dim1 dim2)))
+
+(defarm642 arm642-%aset2 simple-typed-aset2 (seg vreg xfer typename arr i j new &optional dim0 dim1)
+  (let* ((type-keyword (acode-immediate-operand typename))
+         (fixtype (nx-lookup-target-uvector-subtag type-keyword))
+         (safe (unless *arm642-reckless* fixtype))
+         (dim0 (acode-fixnum-form-p dim0))
+         (dim1 (acode-fixnum-form-p dim1)))
+    (arm642-aset2 seg vreg xfer arr i j new safe type-keyword dim0 dim1)))
+
+(defarm642 arm642-%aset3 simple-typed-aset3 (seg vreg xfer typename arr i j k new &optional dim0 dim1 dim2)
+  (let* ((type-keyword (acode-immediate-operand typename))
+         (fixtype (nx-lookup-target-uvector-subtag type-keyword))
+         (safe (unless *arm642-reckless* fixtype))
+         (dim0 (acode-fixnum-form-p dim0))
+         (dim1 (acode-fixnum-form-p dim1))
+         (dim2 (acode-fixnum-form-p dim2)))
+    (arm642-aset3 seg vreg xfer arr i j k new safe type-keyword dim0 dim1 dim2)))
 (defun arm642-c-frame-words (n-c-arg-words)
   (let ((words (+ 1                     ;header
                   1                     ;saved previous SP (element 0)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -657,7 +657,13 @@
     (arm642-fixup-fwd-refs f))
   (let ((fwd-refs (afunc-fwd-refs afunc)))
     (when fwd-refs
-      (let* ((v (afunc-lfun afunc))
+      ;; ARM64-DEVIATION (16m23): afunc-lfun is now fulltag_function on
+      ;; the resident path; %svref/uvsize below are misc accessors, so
+      ;; take a misc view.  Cross-compile (host != target) leaves it raw.
+      (let* ((v (let ((raw (afunc-lfun afunc)))
+                  (if (eq *host-backend* *target-backend*)
+                    (%function-to-function-vector raw)
+                    raw)))
              (vlen (uvsize v)))
         (declare (fixnum vlen))
         (dolist (ref fwd-refs)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -3101,6 +3101,9 @@
                                     pushed-reg-is-set
                                     (vinsn-sequence-sets-reg-p
                                      push-vinsn pop-vinsn popped-reg)))
+               (popped-reg-is-reffed (unless same-reg
+                                       (vinsn-sequence-refs-reg-p
+                                        push-vinsn pop-vinsn popped-reg)))
                (offset (svref operands 1))
                (nested ())
                (conflicts ())
@@ -3118,7 +3121,18 @@
                       (push element nested)))))))
           (cond
             (conflicts nil)
-            ((not (and pushed-reg-is-set popped-reg-is-set))
+            ((and (not (and pushed-reg-is-set popped-reg-is-set))
+                  ;; When PUSHED-REG is reassigned in the sequence the copy
+                  ;; has to be emitted before that assignment, and it must
+                  ;; still come after POPPED-REG's last reference -- we are
+                  ;; about to overwrite POPPED-REG.  Require such a point to
+                  ;; exist; the vsp leg below makes the identical test.
+                  ;; Falling through costs an elision, never correctness.
+                  (or (null popped-reg-is-reffed)
+                      (null pushed-reg-is-set)
+                      (vinsn-in-sequence-p pushed-reg-is-set
+                                           popped-reg-is-reffed
+                                           pop-vinsn)))
              (unless same-reg
                (let* ((copy (if (eq (hard-regspec-class pushed-reg)
                                     hard-reg-class-fpr)
@@ -3126,7 +3140,8 @@
                               (! copy-gpr popped-reg pushed-reg))))
                  (remove-dll-node copy)
                  (if pushed-reg-is-set
-                   (insert-dll-node-after copy push-vinsn)
+                   (insert-dll-node-after copy
+                                          (or popped-reg-is-reffed push-vinsn))
                    (insert-dll-node-before copy pop-vinsn))))
              (setq win t))
             ((eql (hard-regspec-class pushed-reg) hard-reg-class-fpr)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1501,7 +1501,7 @@
            (ensuring-node-target (target vreg)
              (if (and index-known-fixnum
                       (<= index-known-fixnum
-                          (arch::target-max-32-bit-constant-index arch)))
+                          (arch::target-max-64-bit-constant-index arch)))
                (! misc-ref-c-node target src index-known-fixnum)
                (with-imm-target () (idx-reg :u64)
                  (if index-known-fixnum
@@ -2245,7 +2245,7 @@
              (! call-subprim-3 val-reg (arm64::arm64-subprimitive-offset '.SPgvset) src unscaled-idx val-reg))
             (is-node
              (if (and index-known-fixnum (<= index-known-fixnum
-                                             (arch::target-max-32-bit-constant-index arch)))
+                                             (arch::target-max-64-bit-constant-index arch)))
                (! misc-set-c-node val-reg src index-known-fixnum)
                (with-imm-target () scaled-idx
                  (if index-known-fixnum

--- a/compiler/arch.lisp
+++ b/compiler/arch.lisp
@@ -67,6 +67,7 @@
 (defconstant error-cant-call 17)        ; Attempt to funcall something that is not a symbol or function.
 (defconstant error-allocate-list 18)
 (defconstant error-allocation-disabled 19)
+(defconstant error-apply-macro-or-special 20) ; funcalled a macro/special-operator name
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defconstant error-type-error 128)

--- a/compiler/reg.lisp
+++ b/compiler/reg.lisp
@@ -161,7 +161,7 @@
 (defparameter *encoded-reg-value-byte*
   #+x8664-target (byte 4 0)
   #+x8632-target (byte 3 0)
-  #+(or arm-target ppc-target) (byte 5 0))
+  #+(or arm-target ppc-target arm64-target) (byte 5 0))
 
 ; Return physical regspec's value:
 (defmacro hard-regspec-value (regspec)

--- a/level-0/ARM64/arm64-numbers.lisp
+++ b/level-0/ARM64/arm64-numbers.lisp
@@ -65,3 +65,103 @@
   (fcvtns imm0 s0)
   (box-fixnum arg_z imm0)
   (ret))
+
+;;; The out-of-line complex-float constructors.  COMPLEX calls these by name
+;;; (l0-numbers.lisp:1643-1654); the compiler open-codes the call when both
+;;; component types are known, so what is missing here is only the full-call
+;;; fallback -- which is nevertheless what every other port defines
+;;; (ppc-numbers.lisp:503/516, x86-numbers.lisp:306/324, arm-numbers.lisp:
+;;; 291/313).  PPC64 is the donor.
+;;;
+;;; The vinsns of the same name (arm64-vinsns.lisp:530/537) are NOT donors and
+;;; are not alternatives: they build the value in a register (an fmov plus an
+;;; `ins' into lane 1), which is the compiler's unboxed representation.  These
+;;; build the boxed heap object.
+;;;
+;;; Allocation follows the kernel's own Misc_Alloc_Fixed macro
+;;; (lisp-kernel/arm64-macros.s:64-70) instruction for instruction, which is
+;;; what replaces PPC's always-true conditional trap (twllt allocptr
+;;; allocbase):
+;;;
+;;;     sub allocptr, allocptr, #(size - fulltag_misc)
+;;;     cmp allocptr, allocbase
+;;;     b.hi 1f
+;;;     uuo_alloc
+;;;  1: str <header>, [allocptr, #misc_header_offset]
+;;;     mov <dest>, allocptr
+;;;     clear_allocptr_tag
+;;;
+;;; Note b.hi, not b.hs: the kernel traps when allocptr <= allocbase, so the
+;;; skip is taken only on a strict unsigned greater-than.  clear_allocptr_tag
+;;; is `bic allocptr, allocptr, #fulltagmask'; there is no bic-immediate
+;;; template in arm64-asm.lisp, so it is spelled as the equivalent `and' with
+;;; the complement (ldb-wrapped, because the encoder takes no negative
+;;; immediates).
+;;;
+;;; Object sizes are 32 and 16 bytes, both multiples of the 16-byte dnode, so
+;;; the new base inherits allocptr's dnode alignment -- which is what keeps
+;;; complex-double-float.realpart 16-aligned.
+;;;
+;;; Layouts, from (define-fixedsized-object complex-double-float () pad
+;;; realpart imagpart) and (define-fixedsized-object complex-single-float ()
+;;; value) at arm64-arch.lisp:604-608 and :599-601:
+;;;   complex-double-float: header @-12, pad @-4, realpart @+4, imagpart @+12
+;;;     (the pad word is there for natural alignment, exactly as on PPC64;
+;;;      realpart @+4 is the same displacement patch 0062 pinned down)
+;;;   complex-single-float: header @-12, value @-4, and
+;;;     complex-single-float.realpart = value = -4,
+;;;     complex-single-float.imagpart = value + 4 = 0.
+;;; Header element counts are in 32-bit units: 6 for the double (pad + two
+;;; doubles = 24 bytes) and 2 for the single, matching PPC64's own
+;;; #+ppc64-target arms at ppc:506 and ppc:519.
+
+(defarm64lapfunction %make-complex-double-float ((r arg_y) (i arg_z))
+  (get-double-float d0 r)                  ; ppc:504
+  (get-double-float d1 i)                  ; ppc:505 -- before arg_z is clobbered
+  ;; ppc:506 (li imm0 (logior (ash 6 8) subtag-complex-double-float))
+  (mov imm0 (:$ (logior (ash 6 arm64::num-subtag-bits)
+                        arm64::subtag-complex-double-float)))
+  ;; ppc:507-508 (subi/twllt) -> Misc_Alloc_Fixed, arm64-macros.s:64-70
+  (sub allocptr allocptr (:$ (- 32 arm64::fulltag-misc)))
+  (cmp allocptr allocbase)
+  (b.hi @no-trap)
+  (uuo-alloc-trap)
+  @no-trap
+  (stur imm0 (:@ allocptr (:$ arm64::misc-header-offset))) ; ppc:509
+  (mov arg_z allocptr)                     ; ppc:510
+  ;; ppc:511 (clrrri allocptr allocptr ntagbits) = clear_allocptr_tag
+  (and allocptr allocptr (:$ (ldb (byte 64 0) (lognot arm64::fulltagmask))))
+  ;; ppc:512-513 (stfd).  Both displacements are positive but not 8-scaled
+  ;; multiples of 8 from the TAGGED pointer, so unscaled stur.
+  (stur d0 (:@ arg_z (:$ arm64::complex-double-float.realpart)))
+  (stur d1 (:@ arg_z (:$ arm64::complex-double-float.imagpart)))
+  (ret))                                   ; ppc:514
+
+;;; ARM64-DEVIATION: PPC round-trips the two singles through FPRs (get-single-
+;;; float + stfs) because a PPC single-float store has to come from an FPR.
+;;; Here a single-float is immediate -- its IEEE bits sit in the tagged word --
+;;; so get-single-float-bits lands them in a GPR and a 32-bit W store writes
+;;; them out directly; the FPR hop would be two redundant fmovs.  Same bits.
+(defarm64lapfunction %make-complex-single-float ((r arg_y) (i arg_z))
+  (get-single-float-bits imm1 r)           ; ppc:517 (get-single-float fp0 r)
+  (get-single-float-bits imm2 i)           ; ppc:518 -- before arg_z is clobbered
+  ;; ppc:519 (li imm0 (logior (ash 2 8) subtag-complex-single-float))
+  (mov imm0 (:$ (logior (ash 2 arm64::num-subtag-bits)
+                        arm64::subtag-complex-single-float)))
+  ;; ppc:520-521 (subi/twllt) -> Misc_Alloc_Fixed
+  (sub allocptr allocptr (:$ (- 16 arm64::fulltag-misc)))
+  (cmp allocptr allocbase)
+  (b.hi @no-trap)
+  (uuo-alloc-trap)
+  @no-trap
+  (stur imm0 (:@ allocptr (:$ arm64::misc-header-offset))) ; ppc:522
+  (mov arg_z allocptr)                     ; ppc:523
+  (and allocptr allocptr (:$ (ldb (byte 64 0) (lognot arm64::fulltagmask)))) ; ppc:524
+  ;; ppc:525 (stfs fp0 complex-single-float.realpart arg_z).  realpart is -4,
+  ;; and str's 32-bit scaled form takes an UNSIGNED offset (:uoff2,
+  ;; arm64-asm.lisp:740), so this must be the unscaled stur (:680) -- the draft
+  ;; had `str' here and would not have assembled.
+  (stur (:w imm1) (:@ arg_z (:$ arm64::complex-single-float.realpart)))
+  ;; ppc:526.  imagpart is 0, so either form encodes; keep stur for symmetry.
+  (stur (:w imm2) (:@ arg_z (:$ arm64::complex-single-float.imagpart)))
+  (ret))                                   ; ppc:527

--- a/level-0/l0-array.lisp
+++ b/level-0/l0-array.lisp
@@ -850,6 +850,28 @@ minimum number of elements to add if it must be extended."
     (declare (fixnum ivector-class element-bit-shift total-bits))
     (ash (the fixnum (+ 7 total-bits)) -3)))
 
+#+arm64-target
+(defun subtag-bytes (subtag element-count)
+  ;; Must agree with misc-byte-count in compiler/ARM64/arm64-arch.lisp
+  ;; (the sizing the cross-dump used for every ivector in the image).
+  (declare (fixnum subtag element-count))
+  (unless (logbitp (the (mod 16) (logand subtag arm64::fulltagmask))
+                   (logior (ash 1 arm64::fulltag-immheader-0)
+                           (ash 1 arm64::fulltag-immheader-1)
+                           (ash 1 arm64::fulltag-immheader-2)))
+    (error "Not an ivector subtag: ~s" subtag))
+  (case (logand subtag arm64::fulltagmask)
+    (#.arm64::ivector-class-64-bit (ash element-count 3))
+    (#.arm64::ivector-class-32-bit (ash element-count 2))
+    (t
+     (if (= subtag arm64::subtag-bit-vector)
+       (ash (+ 7 element-count) -3)
+       (if (= subtag arm64::subtag-complex-double-float-vector)
+         (ash element-count 4)
+         (if (>= subtag arm64::min-8-bit-ivector-subtag)
+           element-count
+           (ash element-count 1)))))))
+
 (defun element-type-subtype (type)
   "Convert element type specifier to internal array subtype code"
   (ctype-subtype (specifier-type type)))

--- a/level-0/l0-array.lisp
+++ b/level-0/l0-array.lisp
@@ -170,6 +170,80 @@
     (signed-byte 64)
     (unsigned-byte 64)
     double-float))
+
+)
+
+;;; arm64's three ivector classes are slot-for-slot identical to x8664's
+;;; (verified against every define-subtag form in compiler/ARM64/arm64-arch.lisp:
+;;; 64-bit 11/12/13/14/15 = complex-single-float-vector/fixnum/s64/u64/
+;;; double-float-vector; 32-bit 12/13/14/15 = simple-base-string/s32/u32/
+;;; single-float-vector; other-bit 9/10/11/13/14/15 = complex-double-float-vector/
+;;; s16/u16/s8/u8/bit-vector), so these are x8664's tables unchanged.
+;;; Two slots are unreachable on arm64 and kept only for donor parity:
+;;; immheader-0 slot 12 (arm64 defines no other-bit subtag 12) and immheader-1
+;;; slot 6, which is arm64's code-vector -- not a CL array type, exactly as
+;;; x8664 treats its xcode-vector at 32-bit slot 3.
+#+arm64-target
+(progn
+(defconstant arm64::*immheader-0-array-types*
+  ;; ivector-class-other-bit
+  #(unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    (complex double-float)
+    (signed-byte 16)
+    (unsigned-byte 16)
+    character
+    (signed-byte 8)
+    (unsigned-byte 8)
+    bit
+    ))
+
+(defconstant arm64::*immheader-1-array-types*
+    ;; ivector-class-32-bit
+  #(
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    character
+    (signed-byte 32)
+    (unsigned-byte 32)
+    single-float))
+
+(defconstant arm64::*immheader-2-array-types*
+  ;; ivector-class-64-bit
+  #(
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    unused
+    (complex single-float)
+    fixnum
+    (signed-byte 64)
+    (unsigned-byte 64)
+    double-float))
     
 )
 
@@ -221,6 +295,16 @@
       #+arm-target
       (svref arm::*immheader-array-types*
              (ash (the fixnum (- subtag arm::min-cl-ivector-subtag)) -3))
+      #+arm64-target
+      (let* ((class (logand subtag arm64::fulltagmask))
+             (idx (ash subtag (- arm64::ntagbits))))
+        (declare (fixnum class idx))
+        (cond ((= class arm64::ivector-class-64-bit)
+               (%svref arm64::*immheader-2-array-types* idx))
+              ((= class arm64::ivector-class-32-bit)
+               (%svref arm64::*immheader-1-array-types* idx))
+              (t
+               (%svref arm64::*immheader-0-array-types* idx))))
       )))
 
 

--- a/level-0/l0-cfm-support.lisp
+++ b/level-0/l0-cfm-support.lisp
@@ -49,7 +49,10 @@
                       (if (< entry 0)
                         (logand entry (1- (ash 1 target::nbits-in-word)))
                         entry)))
-  #-(or ppc-target x86-target arm-target) (dbg "Fix entry->addr"))
+  ;; On ARM64, an "entry" is always a MACPTR (see foreign-symbol-entry).
+  #+arm64-target
+  (%setf-macptr addr entry)
+  #-(or ppc-target x86-target arm-target arm64-target) (dbg "Fix entry->addr"))
 
 
 
@@ -614,7 +617,19 @@ return a fixnum representation of that address, else return NIL."
                           :address handle
                           :address n
                           :unsigned-doubleword)))
-      (unless (eql 0 addr) addr))))
+      (unless (eql 0 addr) addr))
+    #+arm64-target
+    ;; On ARM64, an "entry" is always a MACPTR; no PPC64-style
+    ;; fixnum-packing trick (MACPTR->FIXNUM has no arm64 lap), and
+    ;; .SPffcall dereferences macptr entries directly.
+    (with-macptrs (addr)
+      (%setf-macptr addr
+                    (ff-call (%kernel-import target::kernel-import-FindSymbol)
+                             :address handle
+                             :address n
+                             :address))
+      (unless (%null-ptr-p addr)
+        (%inc-ptr addr 0)))))
 
 (defvar *statically-linked* nil)
 

--- a/level-0/l0-float.lisp
+++ b/level-0/l0-float.lisp
@@ -1148,7 +1148,34 @@
   "Return BASE raised to the POWER."
   (cond ((zerop e) (1+ (* b e)))
 	((integerp e)
-         (if (minusp e) (/ 1 (%integer-power b (- e))) (%integer-power b e)))
+         #-arm64-target
+         (if (minusp e) (/ 1 (%integer-power b (- e))) (%integer-power b e))
+         ;; arm64: an overflow in %INTEGER-POWER's repeated multiplication is
+         ;; invisible without a poll, so (expt x 2) quietly returns infinity
+         ;; where PPC and x86 signal.  Those two catch it with a HARDWARE trap
+         ;; -- PPC's %set-fpscr-control does `mtfsf #xff', putting the enable
+         ;; bits in the real FPSCR, and ppc-exceptions.c:1297 fields the
+         ;; SIGFPE.  AArch64 defines the same enables (FPCR.IOE/DZE/OFE/UFE/
+         ;; IXE) but implementing them is OPTIONAL, and they are RAZ/WI on the
+         ;; part this was measured on, so there is no trap to take.  Poll the
+         ;; cumulative FPSR flags instead -- the same checkpoint architecture
+         ;; the #_pow path already uses via %FFI-EXCEPTION-STATUS.
+         ;;
+         ;; Float bases only: integer and rational exponentiation cannot raise
+         ;; an fp exception and must not pay for the check.
+         #+arm64-target
+         (if (not (floatp b))
+           (if (minusp e) (/ 1 (%integer-power b (- e))) (%integer-power b e))
+           (progn
+             (%fp-begin-inline-check)
+             (let* ((result (if (minusp e)
+                              (/ 1 (%integer-power b (- e)))
+                              (%integer-power b e)))
+                    (status (%fp-inline-exception-status)))
+               ;; poll BEFORE signalling anything: an unwind is the one thing
+               ;; measured to lose the cumulative flags.
+               (%fp-check-inline-exception 'expt (list b e) status)
+               result))))
         ((zerop b)
          (if (plusp (realpart e)) (* b e) (report-bad-arg e '(satisfies plusp))))
         ((and (realp b) (plusp b) (realp e)

--- a/level-0/l0-hash.lisp
+++ b/level-0/l0-hash.lisp
@@ -1932,6 +1932,15 @@ before doing so.")
                      (ash 1 x8664::tag-imm-0)
                      (ash 1 x8664::tag-imm-1)))))
 
+#+arm64-target
+(defun immediate-p (thing)
+  (let* ((tag (lisptag thing)))
+    (declare (type (unsigned-byte 3) tag))
+    (logbitp tag
+             (logior (ash 1 arm64::tag-fixnum)
+                     (ash 1 arm64::tag-single-float)
+                     (ash 1 arm64::tag-imm)))))
+
 
 
 (defun %cons-nhash-vector (size &optional (flags 0))

--- a/level-0/l0-pred.lisp
+++ b/level-0/l0-pred.lisp
@@ -1054,6 +1054,10 @@
   (if thing
     (= (the fixnum (lisptag thing)) x8664::tag-symbol)
     t)
+  #+arm64-target
+  (if thing
+    (= (the fixnum (fulltag thing)) arm64::fulltag-symbol)
+    t)
   )
       
 (defun packagep (thing)

--- a/level-0/l0-pred.lisp
+++ b/level-0/l0-pred.lisp
@@ -1078,7 +1078,26 @@
 
 (let* ((fixnum (lambda (x) (declare (ignore x)) 'fixnum))
        (imm (lambda (x) (if (characterp x) 'character 'immediate)))
-       (bogus (lambda (x) (declare (ignore x)) 'bogus)))
+       (bogus (lambda (x) (declare (ignore x)) 'bogus))
+       (function-type-of
+        (lambda (thing)
+          (let ((bits (lfun-bits thing)))
+            (declare (fixnum bits))
+            (if (logbitp $lfbits-trampoline-bit bits)
+              (let ((inner-fn (closure-function thing)))
+                (if (neq inner-fn thing)
+                  (let ((inner-bits (lfun-bits inner-fn)))
+                    (if (logbitp $lfbits-method-bit inner-bits)
+                      'compiled-lexical-closure
+                      (if (logbitp $lfbits-gfn-bit inner-bits)
+                        'standard-generic-function ; not precisely - see class-of
+                        (if (logbitp  $lfbits-cm-bit inner-bits)
+                          'combined-method
+                          'compiled-lexical-closure))))
+                  'compiled-lexical-closure))
+              (if (logbitp  $lfbits-method-bit bits)
+                'method-function
+                'compiled-function))))))
   (setq *arm64-%type-of-functions*
         (vector
          fixnum                         ;0 fulltag-even-fixnum
@@ -1098,6 +1117,8 @@
                             (high4 (ash typecode (- arm64::ntagbits))))
                        (declare (type (unsigned-byte 8) typecode)
                                 (type (unsigned-byte 4) low4 high4))
+                       (if (= typecode arm64::subtag-function)
+                         (funcall function-type-of x)
                        (let* ((name
                                (cond ((= low4 arm64::fulltag-immheader-0)
                                       (%svref *immheader-0-types* high4))
@@ -1112,27 +1133,10 @@
                                      (t 'bogus))))
                          (or (and (eq name 'lock)
                                   (uvref x arm64::lock.kind-cell))
-                             name)))) ;12 fulltag-misc
+                             name))))) ;12 fulltag-misc
          bogus                          ;13 fulltag-immheader-2
          bogus                          ;14 fulltag-nodeheader-1
-         (lambda (thing)                ;15 fulltag-function
-           (let ((bits (lfun-bits thing)))
-             (declare (fixnum bits))
-             (if (logbitp $lfbits-trampoline-bit bits)
-               (let ((inner-fn (closure-function thing)))
-                 (if (neq inner-fn thing)
-                   (let ((inner-bits (lfun-bits inner-fn)))
-                     (if (logbitp $lfbits-method-bit inner-bits)
-                       'compiled-lexical-closure
-                       (if (logbitp $lfbits-gfn-bit inner-bits)
-                         'standard-generic-function ; not precisely - see class-of
-                         (if (logbitp  $lfbits-cm-bit inner-bits)
-                           'combined-method
-                           'compiled-lexical-closure))))
-                   'compiled-lexical-closure))
-               (if (logbitp  $lfbits-method-bit bits)
-                 'method-function
-                 'compiled-function)))))))
+         bogus)))                       ;15 (was fulltag-function; removed)
 
 (defun %type-of (thing)
   (let* ((f (fulltag thing)))

--- a/level-0/l0-pred.lisp
+++ b/level-0/l0-pred.lisp
@@ -975,6 +975,170 @@
         
 
 );#+x8664-target
+
+#+arm64-target
+(progn
+;;; Names per the x8664 tables (l0-pred.lisp #+x8664-target block); slot
+;;; assignments verified against compiler/ARM64/arm64-arch.lisp
+;;; define-subtag forms.  Sole deviation: immheader-1 slot 6 is
+;;; code-vector (arm64 keeps PPC-style code vectors; x8664 has bogus).
+(defparameter *nodeheader-0-types*
+  #(bogus
+    symbol-vector
+    catch-frame
+    hash-vector
+    pool
+    population
+    package
+    slot-vector
+    basic-stream
+    function-vector                                        ;9
+    array-header
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    ))
+
+(defparameter *nodeheader-1-types*
+  #(bogus
+    ratio
+    complex
+    structure
+    internal-structure
+    value-cell
+    xfunction
+    lock
+    instance
+    bogus
+    vector-header
+    simple-vector
+    bogus
+    bogus
+    bogus
+    bogus
+    ))
+
+(defparameter *immheader-0-types*
+  #(bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    simple-complex-double-float-vector
+    simple-signed-word-vector
+    simple-unsigned-word-vector
+    bogus
+    simple-signed-byte-vector
+    simple-unsigned-byte-vector
+    bit-vector))
+
+(defparameter *immheader-1-types*
+  #(bogus
+    bignum
+    double-float
+    xcode-vector
+    complex-single-float
+    complex-double-float
+    code-vector
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    simple-base-string
+    simple-signed-long-vector
+    simple-unsigned-long-vector
+    single-float-vector))
+
+(defparameter *immheader-2-types*
+  #(bogus
+    macptr
+    dead-macptr
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    bogus
+    simple-complex-single-float-vector
+    simple-fixnum-vector
+    simple-signed-doubleword-vector
+    simple-unsigned-doubleword-vector
+    double-float-vector))
+
+(defparameter *arm64-%type-of-functions* nil)
+
+(let* ((fixnum (lambda (x) (declare (ignore x)) 'fixnum))
+       (imm (lambda (x) (if (characterp x) 'character 'immediate)))
+       (bogus (lambda (x) (declare (ignore x)) 'bogus)))
+  (setq *arm64-%type-of-functions*
+        (vector
+         fixnum                         ;0 fulltag-even-fixnum
+         (lambda (x) (declare (ignore x)) 'short-float) ;1 fulltag-single-float
+         imm                            ;2 fulltag-imm-0 (characters)
+         (lambda (x) (declare (ignore x)) 'cons) ;3 fulltag-cons
+         bogus                          ;4 fulltag-immheader-0
+         bogus                          ;5 fulltag-immheader-1
+         bogus                          ;6 fulltag-nodeheader-0
+         (lambda (x) (declare (ignore x)) 'symbol) ;7 fulltag-symbol
+         fixnum                         ;8 fulltag-odd-fixnum
+         bogus                          ;9 fulltag-reserved
+         imm                            ;10 fulltag-imm-1 (markers)
+         (lambda (x) (declare (ignore x)) 'null) ;11 fulltag-nil
+         (lambda (x) (let* ((typecode (typecode x))
+                            (low4 (logand typecode arm64::fulltagmask))
+                            (high4 (ash typecode (- arm64::ntagbits))))
+                       (declare (type (unsigned-byte 8) typecode)
+                                (type (unsigned-byte 4) low4 high4))
+                       (let* ((name
+                               (cond ((= low4 arm64::fulltag-immheader-0)
+                                      (%svref *immheader-0-types* high4))
+                                     ((= low4 arm64::fulltag-immheader-1)
+                                      (%svref *immheader-1-types* high4))
+                                     ((= low4 arm64::fulltag-immheader-2)
+                                      (%svref *immheader-2-types* high4))
+                                     ((= low4 arm64::fulltag-nodeheader-0)
+                                      (%svref *nodeheader-0-types* high4))
+                                     ((= low4 arm64::fulltag-nodeheader-1)
+                                      (%svref *nodeheader-1-types* high4))
+                                     (t 'bogus))))
+                         (or (and (eq name 'lock)
+                                  (uvref x arm64::lock.kind-cell))
+                             name)))) ;12 fulltag-misc
+         bogus                          ;13 fulltag-immheader-2
+         bogus                          ;14 fulltag-nodeheader-1
+         (lambda (thing)                ;15 fulltag-function
+           (let ((bits (lfun-bits thing)))
+             (declare (fixnum bits))
+             (if (logbitp $lfbits-trampoline-bit bits)
+               (let ((inner-fn (closure-function thing)))
+                 (if (neq inner-fn thing)
+                   (let ((inner-bits (lfun-bits inner-fn)))
+                     (if (logbitp $lfbits-method-bit inner-bits)
+                       'compiled-lexical-closure
+                       (if (logbitp $lfbits-gfn-bit inner-bits)
+                         'standard-generic-function ; not precisely - see class-of
+                         (if (logbitp  $lfbits-cm-bit inner-bits)
+                           'combined-method
+                           'compiled-lexical-closure))))
+                   'compiled-lexical-closure))
+               (if (logbitp  $lfbits-method-bit bits)
+                 'method-function
+                 'compiled-function)))))))
+
+(defun %type-of (thing)
+  (let* ((f (fulltag thing)))
+    (funcall (%svref *arm64-%type-of-functions* f) thing)))
+
+);#+arm64-target
       
 
 ;;; real machine specific huh

--- a/level-0/l0-symbol.lisp
+++ b/level-0/l0-symbol.lisp
@@ -204,7 +204,7 @@
 
 (defun symbol-name (sym)
   "Return SYMBOL's name as a string."
-  #+(or ppc32-target x8632-target x8664-target arm-target)
+  #+(or ppc32-target x8632-target x8664-target arm-target arm64-target)
   (%svref (symptr->symvector (%symbol->symptr sym)) target::symbol.pname-cell)
   #+ppc64-target
   (if sym                               ;NIL's pname is implicit

--- a/level-0/nfasload.lisp
+++ b/level-0/nfasload.lisp
@@ -696,14 +696,22 @@
 
 (defun fasl-read-gvector (s subtype)
   (let* ((n (%fasl-read-count s))
-         (vector (%alloc-misc n subtype)))
+         (vector (%alloc-misc n subtype))
+         (result vector))
     (declare (fixnum n subtype))
-    (%epushval s vector)
+    ;; arm64 functions are fulltag-function POINTERS, distinct from the
+    ;; subtag-function VECTOR built here; the epushed value + faslval must
+    ;; be that pointer (funcall and self-reference need it), exactly as
+    ;; x86's $fasl-clfun does.  function-vector-to-function is a pure retag
+    ;; of the same object, so the slots are still filled through VECTOR.
+    #+arm64-target (when (= subtype arm64::subtag-function)
+                     (setq result (function-vector-to-function vector)))
+    (%epushval s result)
     (dotimes (i n)
       (setf (%svref vector i) (%fasl-expr s)))
     #+arm-target (when (= subtype arm::subtag-function)
                    (%fix-fn-entrypoint vector))
-    (setf (faslstate.faslval s) vector)))
+    (setf (faslstate.faslval s) result)))
 
 (deffaslop $fasl-vgvec (s)
   (let* ((subtype (%fasl-read-byte s)))

--- a/level-1/l1-aprims.lisp
+++ b/level-1/l1-aprims.lisp
@@ -700,6 +700,83 @@ terminate the list"
               (t 'bogus)))))
   )
 
+#+arm64-target
+(progn
+
+  ;;; other element types
+  (defparameter *immheader-0-array-element-types*
+    #(bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      (complex double-float)
+      (signed-byte 16)
+      (unsigned-byte 16)
+      bogus
+      (signed-byte 8)
+      (unsigned-byte 8)
+      bit))
+
+  ;;; 32-bit element types
+  (defparameter *immheader-1-array-element-types*
+    #(bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      base-char
+      (signed-byte 32)
+      (unsigned-byte 32)
+      single-float))
+
+  ;;; 64-bit element types
+  (defparameter *immheader-2-array-element-types*
+    #(bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      bogus
+      (complex single-float)
+      fixnum
+      (signed-byte 64)
+      (unsigned-byte 64)
+      double-float))
+
+
+  (defun element-subtype-type (subtype)
+    (declare (type (unsigned-byte 8) subtype))
+    (if (= subtype arm64::subtag-simple-vector)
+      t
+      (let* ((class (ash subtype (- arm64::ntagbits)))
+             (tag (logand subtype arm64::fulltagmask)))
+        (declare (type (unsigned-byte 4) class tag))
+        (cond ((= tag arm64::fulltag-immheader-0)
+               (%svref *immheader-0-array-element-types* class))
+              ((= tag arm64::fulltag-immheader-1)
+               (%svref *immheader-1-array-element-types* class))
+              ((= tag arm64::fulltag-immheader-2)
+               (%svref *immheader-2-array-element-types* class))
+              (t 'bogus)))))
+  )
+
 #+arm-target
 (progn
   (defparameter array-element-subtypes

--- a/level-1/l1-boot-2.lisp
+++ b/level-1/l1-boot-2.lisp
@@ -48,6 +48,8 @@
     (l1-load "x86-error-signal")
     #+arm-target
     (l1-load "arm-error-signal")
+    #+arm64-target
+    (l1-load "arm64-error-signal")
     (l1-load "l1-error-signal")
     (l1-load "l1-sockets")
     (setq *LEVEL-1-LOADED* t))

--- a/level-1/l1-boot-2.lisp
+++ b/level-1/l1-boot-2.lisp
@@ -242,13 +242,17 @@ present and false otherwise. This variable shouldn't be set by user code.")
       (bin-load-provide "X8664-ARCH" "x8664-arch")
       #+arm-target
       (bin-load-provide "ARM-ARCH" "arm-arch")
+      #+arm64-target
+      (bin-load-provide "ARM64-ARCH" "arm64-arch")
       (bin-load-provide "VREG" "vreg")
       
       #+ppc-target
       (bin-load-provide "PPC-ASM" "ppc-asm")
       #+arm-target
       (bin-load-provide "ARM-ASM" "arm-asm")
-      
+      #+arm64-target
+      (bin-load-provide "ARM64-ASM" "arm64-asm")
+
       (bin-load-provide "VINSN" "vinsn")
       (bin-load-provide "REG" "reg")
       
@@ -256,6 +260,8 @@ present and false otherwise. This variable shouldn't be set by user code.")
       (bin-load-provide "PPC-LAP" "ppc-lap")
       #+arm-target
       (bin-load-provide "ARM-LAP" "arm-lap")
+      #+arm64-target
+      (bin-load-provide "ARM64-LAP" "arm64-lap")
       (bin-load-provide "BACKEND" "backend")
       (bin-load-provide "NX2" "nx2")
      
@@ -266,7 +272,10 @@ present and false otherwise. This variable shouldn't be set by user code.")
       (provide "X862")
 
       #+arm-target
-      (provide "ARM2") 
+      (provide "ARM2")
+
+      #+arm64-target
+      (provide "ARM642")
       (bin-load-provide "ACODE-REWRITE" "acode-rewrite")
      
       (l1-load-provide "NX" "nx")
@@ -279,7 +288,10 @@ present and false otherwise. This variable shouldn't be set by user code.")
 
       #+arm-target
       (bin-load "arm2")
-      
+
+      #+arm64-target
+      (bin-load "arm642")
+
       (bin-load-provide "LEVEL-2" "level-2")
       (bin-load-provide "MACROS" "macros")
       (bin-load-provide "SETF" "setf")
@@ -313,6 +325,11 @@ present and false otherwise. This variable shouldn't be set by user code.")
       (progn
 	(bin-load-provide "ARM-DISASSEMBLE" "arm-disassemble")
 	(bin-load-provide "ARM-LAPMACROS" "arm-lapmacros"))
+
+      #+arm64-target
+      (progn
+	(bin-load-provide "ARM64-DISASSEMBLE" "arm64-disassemble")
+	(bin-load-provide "ARM64-LAPMACROS" "arm64-lapmacros"))
 
       (bin-load-provide "FOREIGN-TYPES" "foreign-types")
       (install-standard-foreign-types *host-ftd*)
@@ -351,6 +368,8 @@ present and false otherwise. This variable shouldn't be set by user code.")
       (bin-load-provide "FFI-ANDROIDARM" "ffi-androidarm")
       #+(and arm-target darwin-target)
       (bin-load-provide "FFI-DARWINARM" "ffi-darwinarm")
+      #+(and arm64-target linux-target)
+      (bin-load-provide "FFI-LINUXARM64" "ffi-linuxarm64")
 
 
       ;; Knock wood: all standard reader macros and no non-standard

--- a/level-1/l1-clos-boot.lisp
+++ b/level-1/l1-clos-boot.lisp
@@ -2475,8 +2475,7 @@ to replace that class with ~s" name old-class new-class)
           #+x8664-target (map-subtag x8664::subtag-symbol symbol-vector)
           #+x8664-target (map-subtag x8664::subtag-function function-vector)
           ;; arm64: the raw uvectors, reached via %symptr->symvector etc.
-          #+arm64-target (map-subtag arm64::subtag-symbol symbol-vector)
-          #+arm64-target (map-subtag arm64::subtag-function function-vector))
+          #+arm64-target (map-subtag arm64::subtag-symbol symbol-vector))
         (setf (%svref v target::subtag-arrayH)
               #'(lambda (x)
                   (if (logbitp $arh_simple_bit
@@ -2531,7 +2530,7 @@ to replace that class with ~s" name old-class new-class)
                       #+arm-target target::subtag-function
                       #+x8632-target target::subtag-function
                       #+x8664-target target::tag-function
-                      #+arm64-target arm64::fulltag-function)
+                      #+arm64-target arm64::subtag-function)
               class-of-function-function)
         (setf (%svref v target::subtag-vectorH)
               #'(lambda (v)

--- a/level-1/l1-clos-boot.lisp
+++ b/level-1/l1-clos-boot.lisp
@@ -1919,6 +1919,9 @@ to replace that class with ~s" name old-class new-class)
     (make-built-in-class 'complex-double-float-vector *vector-class*)
     )
 
+  ;; arm64 follows the x8664 model: symbols and functions are
+  ;; uvectors (subtag-symbol/subtag-function) reached through
+  ;; differently-tagged pointers.
   #+(or x8664-target arm64-target)
   (progn
     (make-built-in-class 'symbol-vector (find-class 'gvector))
@@ -2102,61 +2105,67 @@ to replace that class with ~s" name old-class new-class)
               (find-class 'unsigned-doubleword-vector)
               (find-class 'double-float-vector))))
 
+  ;; arm64: the three ivector header fulltags each get a 16-entry
+  ;; class vector indexed by the subtag's value field (subtag >>
+  ;; ntagbits), mirroring the x8664 scheme above.  Positions come from
+  ;; the define-subtag forms in compiler/ARM64/arm64-arch.lisp.
+  ;; Non-CL-vector subtags (macptr, bignum, code-vector, ...) can never
+  ;; reach the vectorH dispatch and map to *t-class*.
   #+arm64-target
   (progn
     (defparameter *immheader-0-classes*   ;ivector-class-other-bit
-      (vector *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              (find-class 'complex-double-float-vector)
-              (find-class 'word-vector)
-              (find-class 'unsigned-word-vector)
-              *t-class*
-              (find-class 'byte-vector)
-              (find-class 'unsigned-byte-vector)
-              (find-class 'bit-vector)))
+      (vector *t-class*                   ;0
+              *t-class*                   ;1
+              *t-class*                   ;2
+              *t-class*                   ;3
+              *t-class*                   ;4
+              *t-class*                   ;5
+              *t-class*                   ;6
+              *t-class*                   ;7
+              *t-class*                   ;8
+              (find-class 'complex-double-float-vector) ;9
+              (find-class 'word-vector)                 ;10 s16
+              (find-class 'unsigned-word-vector)        ;11 u16
+              *t-class*                   ;12
+              (find-class 'byte-vector)                 ;13 s8
+              (find-class 'unsigned-byte-vector)        ;14 u8
+              (find-class 'bit-vector)))                ;15
 
     (defparameter *immheader-1-classes*   ;ivector-class-32-bit
-      (vector *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              (find-class 'base-string)
-              (find-class 'long-vector)
-              (find-class 'unsigned-long-vector)
-              (find-class 'short-float-vector)))
+      (vector *t-class*                   ;0
+              *t-class*                   ;1 bignum
+              *t-class*                   ;2 double-float
+              *t-class*                   ;3 xcode-vector
+              *t-class*                   ;4 complex-single-float
+              *t-class*                   ;5 complex-double-float
+              *t-class*                   ;6 code-vector
+              *t-class*                   ;7
+              *t-class*                   ;8
+              *t-class*                   ;9
+              *t-class*                   ;10
+              *t-class*                   ;11
+              (find-class 'base-string)                 ;12
+              (find-class 'long-vector)                 ;13 s32
+              (find-class 'unsigned-long-vector)        ;14 u32
+              (find-class 'short-float-vector)))        ;15
 
     (defparameter *immheader-2-classes*   ;ivector-class-64-bit
-      (vector *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              *t-class*
-              (find-class 'complex-single-float-vector)
-              (find-class 'fixnum-vector)
-              (find-class 'doubleword-vector)
-              (find-class 'unsigned-doubleword-vector)
-              (find-class 'double-float-vector))))
+      (vector *t-class*                   ;0
+              *t-class*                   ;1 macptr
+              *t-class*                   ;2 dead-macptr
+              *t-class*                   ;3
+              *t-class*                   ;4
+              *t-class*                   ;5
+              *t-class*                   ;6
+              *t-class*                   ;7
+              *t-class*                   ;8
+              *t-class*                   ;9
+              *t-class*                   ;10
+              (find-class 'complex-single-float-vector) ;11
+              (find-class 'fixnum-vector)               ;12
+              (find-class 'doubleword-vector)           ;13 s64
+              (find-class 'unsigned-doubleword-vector)  ;14 u64
+              (find-class 'double-float-vector))))      ;15
 
   #+arm-target
   (defparameter *ivector-vector-classes*
@@ -2391,6 +2400,14 @@ to replace that class with ~s" name old-class new-class)
                 (%svref v (+ slice arm::fulltag-cons)) *cons-class*
                 (%svref v (+ slice arm::fulltag-nil)) *null-class*
                 (%svref v (+ slice arm::fulltag-imm)) *immediate-class*))
+        ;; arm64 U-RATIFY (class-of contract): the table is indexed by
+        ;; canonical TYPECODE — subtag byte for fulltag-misc, else the
+        ;; 4-bit fulltag.  The per-slice fills below additionally cover
+        ;; a raw-low-byte dispatch for the tags whose payload reaches
+        ;; the low byte (fixnums); the future arm64 class-of
+        ;; lapfunction must canonicalize anything else.  Immediates
+        ;; (characters, markers) and single-floats keep their payload
+        ;; above bit 7, so their low byte IS the canonical typecode.
         #+arm64-target
         (do* ((slice 0 (+ 16 slice)))
              ((= slice 256))
@@ -2399,8 +2416,7 @@ to replace that class with ~s" name old-class new-class)
                 (%svref v (+ slice arm64::fulltag-odd-fixnum))  *fixnum-class*
                 (%svref v (+ slice arm64::fulltag-cons)) *cons-class*
                 (%svref v (+ slice arm64::fulltag-nil)) *null-class*
-                (%svref v (+ slice arm64::fulltag-single-float)) (find-class
-                                                                  'short-float)
+                (%svref v (+ slice arm64::fulltag-single-float)) (find-class 'short-float)
                 (%svref v (+ slice arm64::fulltag-imm-0)) *immediate-class*
                 (%svref v (+ slice arm64::fulltag-imm-1)) *immediate-class*))
 
@@ -2458,6 +2474,7 @@ to replace that class with ~s" name old-class new-class)
           (map-subtag target::subtag-slot-vector slot-vector)
           #+x8664-target (map-subtag x8664::subtag-symbol symbol-vector)
           #+x8664-target (map-subtag x8664::subtag-function function-vector)
+          ;; arm64: the raw uvectors, reached via %symptr->symvector etc.
           #+arm64-target (map-subtag arm64::subtag-symbol symbol-vector)
           #+arm64-target (map-subtag arm64::subtag-function function-vector))
         (setf (%svref v target::subtag-arrayH)
@@ -2493,6 +2510,9 @@ to replace that class with ~s" name old-class new-class)
                       #+arm-target target::subtag-symbol
 		      #+x8632-target target::subtag-symbol
 		      #+x8664-target target::tag-symbol
+                      ;; arm64: symbol POINTERS have their own fulltag;
+                      ;; typecode canonicalizes to it (cf. x8664
+                      ;; tag-symbol).
                       #+arm64-target arm64::fulltag-symbol)
               #-ppc64-target
               #'(lambda (s) (if (eq (symbol-package s) *keyword-package*)
@@ -2542,6 +2562,7 @@ to replace that class with ~s" name old-class new-class)
                               ((= class x8664::fulltag-immheader-2)
                                (%svref *immheader-2-classes* idx))
                               (t *t-class*)))
+
                       #+arm64-target
                       (let* ((class (logand arm64::fulltagmask subtype))
                              (idx (ash subtype (- arm64::ntagbits))))
@@ -2714,6 +2735,17 @@ to replace that class with ~s" name old-class new-class)
            'slot-id-value
            nil				;method-function name
            (dpb 1 $lfbits-numreq (ash 1 $lfbits-method-bit))))
+  ;; arm64: ppc-shaped function vector (code-vector = element 0),
+  ;; built misc-tagged then retagged to a callable fulltag-function
+  ;; pointer (patch-0018 model).
+  #+arm64-target
+  (function-vector-to-function
+   (gvector :function
+            (uvref (function-to-function-vector *reader-method-function-proto*) 0)
+            (ensure-slot-id (%slot-definition-name dslotd))
+            'slot-id-value
+            nil                         ;method-function name
+            (dpb 1 $lfbits-numreq (ash 1 $lfbits-method-bit))))
   )
 
 (defmethod create-writer-method-function ((class slots-class)
@@ -2742,6 +2774,15 @@ to replace that class with ~s" name old-class new-class)
              'set-slot-id-value
              nil
              (dpb 2 $lfbits-numreq (ash 1 $lfbits-method-bit))))
+  ;; arm64: see create-reader-method-function.
+  #+arm64-target
+  (function-vector-to-function
+   (gvector :function
+            (uvref (function-to-function-vector *writer-method-function-proto*) 0)
+            (ensure-slot-id (%slot-definition-name dslotd))
+            'set-slot-id-value
+            nil
+            (dpb 2 $lfbits-numreq (ash 1 $lfbits-method-bit))))
   )
 
 

--- a/level-1/l1-clos.lisp
+++ b/level-1/l1-clos.lisp
@@ -369,6 +369,17 @@
                          (standard-effective-slot-definition.slot-id slotd)))
                   i))))
       (let* ((lookup-f
+              #+arm64-target
+              (function-vector-to-function
+               (gvector :function
+                        (uvref (function-to-function-vector
+                                (if small
+                                  #'%small-map-slot-id-lookup
+                                  #'%large-map-slot-id-lookup)) 0)
+                        map
+                        table
+                        (dpb 1 $lfbits-numreq
+                             (ash -1 $lfbits-noname-bit))))
               #+ppc-target
               (gvector :function
 				(%svref (if small
@@ -399,6 +410,20 @@
 				     (ash -1 $lfbits-noname-bit))))
 	     (class (%wrapper-class wrapper))
 	     (get-f
+              #+arm64-target
+              (function-vector-to-function
+               (gvector :function
+                        (uvref (function-to-function-vector
+                                (if small
+                                  #'%small-slot-id-value
+                                  #'%large-slot-id-value)) 0)
+                        map
+                        table
+                        class
+                        #'%maybe-std-slot-value-using-class
+                        #'%slot-id-ref-missing
+                        (dpb 2 $lfbits-numreq
+                             (ash -1 $lfbits-noname-bit))))
               #+ppc-target
               (gvector :function
                        (%svref (if small
@@ -437,6 +462,20 @@
                                    (dpb 2 $lfbits-numreq
                                         (ash -1 $lfbits-noname-bit))))
 	     (set-f
+              #+arm64-target
+              (function-vector-to-function
+               (gvector :function
+                        (uvref (function-to-function-vector
+                                (if small
+                                  #'%small-set-slot-id-value
+                                  #'%large-set-slot-id-value)) 0)
+                        map
+                        table
+                        class
+                        #'%maybe-std-setf-slot-value-using-class
+                        #'%slot-id-set-missing
+                        (dpb 3 $lfbits-numreq
+                             (ash -1 $lfbits-noname-bit))))
               #+ppc-target
               (gvector :function
                        (%svref (if small
@@ -1689,6 +1728,19 @@ governs whether DEFCLASS makes that distinction or not.")
 	 (dt (if gf-p (make-gf-dispatch-table)))
 	 (slots (allocate-typed-vector :slot-vector (1+ len) (%slot-unbound-marker)))
 	 (fn
+          ;; arm64: ppc shape + retag (patch-0018 model); *unset-fin-code*
+          ;; has an arm64 defvar in l1-dcode (patch 0018).
+          #+arm64-target
+           (function-vector-to-function
+            (gvector :function
+                     *unset-fin-code*
+                     wrapper
+                     slots
+                     dt
+                     #'false
+                     0
+                     (logior (ash 1 $lfbits-gfn-bit)
+                             (ash 1 $lfbits-aok-bit))))
           #+ppc-target
            (gvector :function
                     *unset-fin-code*

--- a/level-1/l1-dcode.lisp
+++ b/level-1/l1-dcode.lisp
@@ -402,18 +402,27 @@
 (defvar *fi-trampoline-code* (uvref #'funcallable-trampoline 0))
 #+arm-target
 (defvar *fi-trampoline-code* (uvref #'funcallable-trampoline 1))
+#+arm64-target
+(defvar *fi-trampoline-code*
+  (uvref (function-to-function-vector #'funcallable-trampoline) 0))
 
 
 #+ppc-target
 (defvar *unset-fin-code* (uvref #'unset-fin-trampoline 0))
 #+arm-target
 (defvar *unset-fin-code* (uvref #'unset-fin-trampoline 1))
+#+arm64-target
+(defvar *unset-fin-code*
+  (uvref (function-to-function-vector #'unset-fin-trampoline) 0))
 
 
 #+ppc-target
 (defvar *gf-proto-code* (uvref *gf-proto* 0))
 #+arm-target
 (defvar *gf-proto-code* (uvref *gf-proto* 1))
+#+arm64-target
+(defvar *gf-proto-code*
+  (uvref (function-to-function-vector *gf-proto*) 0))
 
 ;;; The "early" version of %ALLOCATE-GF-INSTANCE.
 (setf (fdefinition '%allocate-gf-instance)
@@ -440,6 +449,20 @@
 			      0
 			      (%ilogior (%ilsl $lfbits-gfn-bit 1)
 					(%ilogand $lfbits-args-mask 0))))
+                   ;; arm64: ppc-shaped function vector (code-vector =
+                   ;; element 0), built misc-tagged then retagged to a
+                   ;; callable fulltag-function pointer.
+                   #+arm64-target
+                   (function-vector-to-function
+                    (gvector :function
+                             *gf-proto-code*
+                             wrapper
+                             slots
+                             dt
+                             #'%%0-arg-dcode
+                             0
+                             (%ilogior (%ilsl $lfbits-gfn-bit 1)
+                                       (%ilogand $lfbits-args-mask 0))))
                    #+x86-target
                    (%clone-x86-function *gf-proto*
                                         wrapper
@@ -474,6 +497,9 @@
 
 #+arm-target
 (defvar *cm-proto-code* (uvref *cm-proto* 1))
+#+arm64-target
+(defvar *cm-proto-code*
+  (uvref (function-to-function-vector *cm-proto*) 0))
 
 (defun %cons-combined-method (gf thing dcode)
   ;; set bits and name = gf
@@ -490,6 +516,16 @@
            gf
            (%ilogior (%ilsl $lfbits-cm-bit 1)
                             (%ilogand $lfbits-args-mask (lfun-bits gf)))))
+  ;; arm64: same ppc-shaped build + retag as %allocate-gf-instance.
+  #+arm64-target
+  (function-vector-to-function
+   (gvector :function
+            *cm-proto-code*
+            thing
+            dcode
+            gf
+            (%ilogior (%ilsl $lfbits-cm-bit 1)
+                      (%ilogand $lfbits-args-mask (lfun-bits gf)))))
   #+x86-target
   (%clone-x86-function *cm-proto*
                        thing

--- a/level-1/l1-streams.lisp
+++ b/level-1/l1-streams.lisp
@@ -265,6 +265,11 @@
         #+arm-target
         (= (logand subtag arm::fulltagmask)
            arm::fulltag-immheader)
+        #+arm64-target
+        (logbitp (the (mod 16) (logand subtag arm64::fulltagmask))
+                 (logior (ash 1 arm64::fulltag-immheader-0)
+                         (ash 1 arm64::fulltag-immheader-1)
+                         (ash 1 arm64::fulltag-immheader-2)))
       (error "~s is not an ivector subtype." element-type))
     (let* ((size-in-octets (ccl::subtag-bytes subtag element-count)))
       (multiple-value-bind (vector pointer)

--- a/level-1/l1-typesys.lisp
+++ b/level-1/l1-typesys.lisp
@@ -4300,6 +4300,15 @@
       (%%typep thing #.(specifier-type t))))
 
 (defun make-simple-type-predicate (function datum)
+  ;; arm64: ppc-shaped function vector, patch-0018/0020 model.
+  #+arm64-target
+  (function-vector-to-function
+   (gvector :function
+            (uvref (function-to-function-vector *simple-predicate-function-prototype*) 0)
+            datum
+            function
+            nil
+            (dpb 1 $lfbits-numreq 0)))
   #+ppc-target
   (gvector :function
            (uvref *simple-predicate-function-prototype* 0)

--- a/level-1/level-1.lisp
+++ b/level-1/level-1.lisp
@@ -95,6 +95,8 @@
   (l1-load "x86-trap-support")
   #+arm-target
   (l1-load "arm-trap-support")
+  #+arm64-target
+  (l1-load "arm64-trap-support")
   (l1-load "l1-format")
   (l1-load "l1-sysio")
   (l1-load "l1-pathnames")

--- a/level-1/level-1.lisp
+++ b/level-1/level-1.lisp
@@ -77,6 +77,8 @@
   (l1-load "x86-threads-utils")
   #+arm-target
   (l1-load "arm-threads-utils")
+  #+arm64-target
+  (l1-load "arm64-threads-utils")
   (l1-load "l1-lisp-threads")
   (l1-load "l1-application")
   (l1-load "l1-processes")

--- a/level-1/level-1.lisp
+++ b/level-1/level-1.lisp
@@ -47,6 +47,8 @@
   (l1-load "x86-callback-support")
   #+arm-target
   (l1-load "arm-callback-support")
+  #+arm64-target
+  (l1-load "arm64-callback-support")
   (l1-load "l1-callbacks")
   (l1-load "l1-sort")
   (bin-load "lists")

--- a/lib/backtrace-lds.lisp
+++ b/lib/backtrace-lds.lisp
@@ -21,12 +21,12 @@
 
 
 (defparameter *saved-register-count*
-  #+(or x8632-target arm-target) 0
+  #+(or x8632-target arm-target arm64-target) 0
   #+x8664-target 4
   #+ppc-target 8)
 
 (defparameter *saved-register-names*
-  #+(or x8632-target arm-target) nil
+  #+(or x8632-target arm-target arm64-target) nil
   #+x8664-target #(save3 save2 save1 save0)
   #+ppc-target #(save7 save6 save5 save4 save3 save2 save1 save0))
 

--- a/lib/backtrace.lisp
+++ b/lib/backtrace.lisp
@@ -42,7 +42,7 @@
                         nil       ;; condition - not used
                         frame-ptr ;; current
                         #+ppc-target *fake-stack-frames*
-                        #+(or x86-target arm-target) frame-ptr
+                        #+(or x86-target arm-target arm64-target) frame-ptr
                         (%fixnum-ref tcr (- target::tcr.db-link
 					    target::tcr-bias))
                         0         ;; break level - not used

--- a/lib/backtrace.lisp
+++ b/lib/backtrace.lisp
@@ -22,6 +22,7 @@
 #+ppc-target (require "PPC-BACKTRACE")
 #+x86-target (require "X86-BACKTRACE")
 #+arm-target (require "ARM-BACKTRACE")
+#+arm64-target (require "ARM64-BACKTRACE")
 
 
 (defparameter *backtrace-show-internal-frames* nil)

--- a/lib/edit-callers.lisp
+++ b/lib/edit-callers.lisp
@@ -187,7 +187,7 @@
                ;; Don't count lfun-info  either
                (when (logbitp $lfbits-info-bit bits)
                  (decf end))
-               (loop for i from #+ppc-target 1 #+x86-target (%function-code-words fun) #+arm-target 2 below end
+               (loop for i from #+(or ppc-target arm64-target) 1 #+x86-target (%function-code-words fun) #+arm-target 2 below end
                      as im = (%svref lfv i)
                      when (or (eq function im)
                               (and cfun (eq cfun im)))
@@ -226,7 +226,7 @@
   (let* ((lfv (function-to-function-vector function-object))
          (n (- (uvsize lfv) 2)))
     (declare (fixnum n))
-    #+ppc-target
+    #+(or ppc-target arm64-target)
     (dotimes (i n)
       (funcall f (%svref lfv (%i+ 1 i))))
     #+x86-target

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -1,0 +1,351 @@
+;;;-*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; Copyright 2026 (CCL ARM64 port)
+;;; Based on vendor/ccl/lib/ffi-linuxppc64.lisp (Copyright 2007-2009 Clozure Associates)
+;;;
+;;; Licensed under the Apache License, Version 2.0 (the "License");
+;;; you may not use this file except in compliance with the License.
+;;; You may obtain a copy of the License at
+;;;
+;;;     http://www.apache.org/licenses/LICENSE-2.0
+;;;
+;;; Unless required by applicable law or agreed to in writing, software
+;;; distributed under the License is distributed on an "AS IS" BASIS,
+;;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;;; See the License for the specific language governing permissions and
+;;; limitations under the License.
+
+;;; PPC64 LINE-PORT (source: vendor/ccl/lib/ffi-linuxppc64.lisp)
+;;; Ported 2026-05-22.  Calling-convention details replaced with AAPCS64
+;;; (ARM Procedure Call Standard for the 64-bit Arm Architecture).
+;;; Deviations from the PPC64 source are tagged inline with
+;;;   ;;; ARM64-DEVIATION: <reason>
+;;;
+;;; AAPCS64 reference summary (per IHI 0055C, §5-§6):
+;;;   - X0..X7   : integer/pointer args (8 GPR slots); return in X0..X1
+;;;   - V0..V7   : SIMD&FP args (8 VFP slots); return in V0..V1
+;;;   - X8       : indirect-result-area pointer (caller-allocated buffer
+;;;                when return is a composite > 16 bytes)
+;;;   - X9..X15  : caller-save scratch
+;;;   - X16..X17 : ip0/ip1, intra-procedure-call scratch
+;;;   - X19..X28 : callee-save
+;;;   - X29      : frame pointer
+;;;   - X30      : link register
+;;;   - SP       : stack pointer (16-byte aligned at public boundaries)
+;;;
+;;; Composite (struct) argument rules (AAPCS64 §6.8):
+;;;   - HFAs/HVAs of 1-4 fundamental SIMD&FP elements: passed in V0..V7
+;;;     (not yet detected here; conservatively treated as general composite).
+;;;   - Composite size <= 16 bytes (128 bits): passed in GPRs (split across
+;;;     X0..X7 as 1-2 doublewords, left-justified — NOT right-justified
+;;;     like PowerOpen).
+;;;   - Composite size > 16 bytes: passed by reference to a caller-allocated
+;;;     copy (single :address slot pointing to the copy).
+;;;
+;;; Composite return rules (AAPCS64 §6.9):
+;;;   - Size <= 16 bytes (and not HFA): returned in X0/X1.
+;;;   - Size > 16 bytes (or HFA): caller allocates buffer, passes pointer
+;;;     in X8; function writes through X8 and returns void.
+;;;
+;;; HFA detection is a TODO; we conservatively use the size threshold only.
+;;; This is slightly pessimistic for HFA-eligible aggregates (which AAPCS64
+;;; allows in V-registers regardless of total size up to 4 elements) but is
+;;; never incorrect — pessimistic-but-correct over optimistic-but-wrong.
+
+(in-package "CCL")
+
+;;; The ARM64-LINUX64 package holds the four FTD callback entrypoints
+;;; consumed by foreign-types.lisp / nfcomp.lisp's
+;;; %with-cross-compilation-target.  Created here (not via defpackage in
+;;; level-0) because lib/ffi-*.lisp files are the canonical home for
+;;; per-OS FFI interface packages in vendor/ccl/.
+;;;
+;;; ARM64-DEVIATION: Clozure precedent for 64-bit OS interface packages
+;;; is arch-OS (X86-LINUX64, X86-DARWIN64, ARM-LINUX).  Following that
+;;; pattern we use ARM64-LINUX64 rather than the PPC64 odd-one-out name
+;;; LINUX64 (which doesn't include an arch prefix).
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (unless (find-package "ARM64-LINUX64")
+    (make-package "ARM64-LINUX64" :use '("CL" "CCL"))))
+
+
+;;;-----------------------------------------------------------------------
+;;; (1) record-type-returns-structure-as-first-arg
+;;;-----------------------------------------------------------------------
+;;; PPC64 source (lines 28-36): always returns T for foreign-record-type
+;;; (PowerOpen "all structures - of any size - are returned by passing a
+;;;  pointer in the first argument").
+;;;
+;;; ARM64-DEVIATION: AAPCS64 §6.9 returns composites <= 16 bytes (128
+;;; bits) in X0/X1 directly; only larger composites use the X8 indirect
+;;; result-area pointer.  We encode the size threshold explicitly.
+
+(defun arm64-linux64::record-type-returns-structure-as-first-arg (rtype)
+  (when (and rtype
+             (not (typep rtype 'unsigned-byte))
+             (not (member rtype *foreign-representation-type-keywords*
+                          :test #'eq)))
+    (let* ((ftype (if (typep rtype 'foreign-type)
+                    rtype
+                    (parse-foreign-type rtype))))
+      (when (typep ftype 'foreign-record-type)
+        (ensure-foreign-type-bits ftype)
+        ;;; ARM64-DEVIATION: > 128 bits (16 bytes) triggers X8 indirect
+        ;;; return per AAPCS64 §6.9.  PPC64 source returns T unconditionally.
+        (> (foreign-type-bits ftype) 128)))))
+
+
+;;;-----------------------------------------------------------------------
+;;; (2) expand-ff-call
+;;;-----------------------------------------------------------------------
+;;; PPC64 source (lines 38-79): for foreign-record-type args < 64 bits,
+;;; emits :unsigned-doubleword with the value right-justified via
+;;; (ash (%%get-unsigned-longlong arg 0) (- bits 64)).  For >= 64 bits,
+;;; emits ceiling(bits, 64) doublewords.  PowerOpen passes small structs
+;;; right-justified in the high bits of a register.
+;;;
+;;; ARM64-DEVIATION: AAPCS64 §6.8 passes composites <= 16 bytes
+;;; left-justified in 1-2 GPRs (X0..X7).  We:
+;;;   - For bits <= 64: emit :unsigned-doubleword with the raw value
+;;;     (NO ash) — load lands in X<n>[bits-1..0], high bits unspecified
+;;;     (callee reads only the meaningful bits).
+;;;   - For 64 < bits <= 128: emit 2 doublewords (ceiling bits 64).
+;;;   - For bits > 128: pass by reference (:address + pointer to copy).
+;;;     The caller is responsible for materialising the copy; here we
+;;;     pass the original arg-value-form as an address, matching how
+;;;     ffi-darwinarm.lisp handles foreign-record-type args (lines 71-75).
+;;;
+;;; The result-side foreign-record-type handling (lines 48-52 in PPC64
+;;; source) — "implicit first arg = result-form, return-type becomes
+;;; :void" — applies identically to AAPCS64 ONLY when the struct is
+;;; > 128 bits (size threshold from record-type-returns-structure-as-first-arg
+;;; above).  For smaller structs, AAPCS64 returns them in X0/X1 and the
+;;; coercion machinery handles the unpack — but expand-ff-call's contract
+;;; with the higher-level macro is shaped by what
+;;; record-type-returns-structure-as-first-arg said, so this code path
+;;; is only entered for > 128-bit return values (consistent).
+
+(defun arm64-linux64::expand-ff-call (callform args &key (arg-coerce #'null-coerce-foreign-arg) (result-coerce #'null-coerce-foreign-result))
+  (let* ((result-type-spec (or (car (last args)) :void)))
+    (multiple-value-bind (result-type error)
+        (ignore-errors (parse-foreign-type result-type-spec))
+      (if error
+        (setq result-type-spec :void result-type *void-foreign-type*)
+        (setq args (butlast args)))
+      (collect ((argforms))
+        (when (eq (car args) :monitor-exception-ports)
+          (argforms (pop args)))
+        (when (typep result-type 'foreign-record-type)
+          ;;; Reached only for > 128-bit returns (per AAPCS64 §6.9, gated
+          ;;; by arm64-linux64::record-type-returns-structure-as-first-arg).
+          ;;; Caller-allocated result buffer is passed as the first :address
+          ;;; arg; AAPCS64 wiring puts it in X8 at the call boundary.
+          (setq result-type *void-foreign-type*
+                result-type-spec :void)
+          (argforms :address)
+          (argforms (pop args)))
+        (unless (evenp (length args))
+          (error "~s should be an even-length list of alternating foreign types and values" args))
+        (do* ((args args (cddr args)))
+             ((null args))
+          (let* ((arg-type-spec (car args))
+                 (arg-value-form (cadr args)))
+            (if (or (member arg-type-spec *foreign-representation-type-keywords*
+                            :test #'eq)
+                    (typep arg-type-spec 'unsigned-byte))
+              (progn
+                (argforms arg-type-spec)
+                (argforms arg-value-form))
+              (let* ((ftype (parse-foreign-type arg-type-spec)))
+                (if (typep ftype 'foreign-record-type)
+                  (let* ((bits (ensure-foreign-type-bits ftype)))
+                    (cond
+                      ;;; ARM64-DEVIATION: <=64 bit struct passed
+                      ;;; left-justified (raw value, no ash).  PPC64
+                      ;;; source right-justified via (ash _ (- bits 64)).
+                      ((<= bits 64)
+                       (argforms :unsigned-doubleword)
+                       (argforms `(%%get-unsigned-longlong ,arg-value-form 0)))
+                      ;;; ARM64-DEVIATION: 65-128 bit struct passed as
+                      ;;; 2 doublewords in GPRs (X<n>..X<n+1>).  Matches
+                      ;;; the PPC64 source for the same size range but
+                      ;;; only applies up to 128 bits on AAPCS64.
+                      ((<= bits 128)
+                       (argforms (ceiling bits 64))
+                       (argforms arg-value-form))
+                      ;;; ARM64-DEVIATION: > 128 bit struct passed by
+                      ;;; reference (caller allocates copy, callee reads
+                      ;;; through pointer).  PPC64 source would emit
+                      ;;; (ceiling bits 64) doublewords here — AAPCS64
+                      ;;; never does that.
+                      (t
+                       (argforms :address)
+                       (argforms arg-value-form))))
+                  (progn
+                    (argforms (foreign-type-to-representation-type ftype))
+                    (argforms (funcall arg-coerce arg-type-spec arg-value-form))))))))
+        (argforms (foreign-type-to-representation-type result-type))
+        (funcall result-coerce result-type-spec `(,@callform ,@(argforms)))))))
+
+
+;;;-----------------------------------------------------------------------
+;;; (3) generate-callback-bindings
+;;;-----------------------------------------------------------------------
+;;; PPC64 LINE-PORT (vendor/ccl/lib/ffi-linuxppc64.lisp:81-175) against
+;;; the A1 callback-frame contract (arm64-arch.lisp callback-frame.*;
+;;; built by _spentry(eabi_callback), lisp-kernel/arm64-spentry.s).
+;;; stack-ptr = CBF: x0..x7 saves at +0..56, the C caller's stack args
+;;; CONTIGUOUS at +64, d0..d7 saves at -64..-8, saved LR at -152.
+;;;
+;;; ARM64-DEVIATIONs from the PPC64 source:
+;;;  - 8 FP arg regs (d0..d7), not PowerOpen's 13 (f1..f13).
+;;;  - an FP register arg consumes NO slot in the linear gpr/stack
+;;;    offset stream (PowerOpen reserved a param word per FP arg):
+;;;    delta = 0 when the arg lands in d0..d7.
+;;;  - little-endian: sub-word integers read at bias 0 (PPC64-BE biased
+;;;    7/6/4 toward the high end of the doubleword).
+;;;  - single-float args in registers were saved by the trampoline as
+;;;    the d-register's low 64 bits, so the float bits sit at the slot
+;;;    base: plain %get-single-float (PPC read a double and rounded via
+;;;    %get-single-float-from-double-ptr — PowerOpen carries singles
+;;;    double-extended; AAPCS64 does not).
+;;;  - records: <=64 bits arrive in one GPR slot, read low-justified
+;;;    (no BE (ash _ (- 64 bits)) re-justify); 65..128 bits inline in
+;;;    two slots (%inc-ptr, delta 16); >128 bits arrive BY REFERENCE in
+;;;    one GPR (AAPCS64 B.4) — read the pointer.  (PowerOpen passed any
+;;;    record inline at full size.)  KNOWN GAP, documented: a 9..16-byte
+;;;    record with exactly one GPR left goes wholly to the stack under
+;;;    AAPCS64 (no register/stack split); this generator would read it
+;;;    one slot early.  No boot-path callback has such a signature.
+;;;  - fp-regs-form is frame arithmetic (%inc-ptr CBF -64), not PPC's
+;;;    deref of a pointer the trampoline stored into its frame.
+(defun arm64-linux64::generate-callback-bindings (stack-ptr fp-args-ptr argvars argspecs result-spec struct-result-name)
+  (collect ((lets)
+            (rlets)
+            (inits)
+            (dynamic-extent-names))
+    (let* ((rtype (parse-foreign-type result-spec))
+           (fp-regs-form nil))
+      (flet ((set-fp-regs-form ()
+               (unless fp-regs-form
+                 (setq fp-regs-form `(%inc-ptr ,stack-ptr ,arm64::callback-frame.fp-save-offset)))))
+        (when (typep rtype 'foreign-record-type)
+          (setq argvars (cons struct-result-name argvars)
+                argspecs (cons :address argspecs)
+                rtype *void-foreign-type*))
+        (when (typep rtype 'foreign-float-type)
+          (set-fp-regs-form))
+        (do* ((argvars argvars (cdr argvars))
+              (argspecs argspecs (cdr argspecs))
+              (fp-arg-num 0)
+              (offset 0 (+ offset delta))
+              (delta 8 8)
+              (bias 0 0)
+              (use-fp-args nil nil))
+             ((null argvars)
+              (values (rlets) (lets) (dynamic-extent-names) (inits) rtype fp-regs-form
+                      arm64::callback-frame.savelr-offset))
+          (let* ((name (car argvars))
+                 (spec (car argspecs))
+                 (argtype (parse-foreign-type spec))
+                 (bits (ensure-foreign-type-bits argtype)))
+            (if (and (typep argtype 'foreign-record-type)
+                     (<= bits 64))
+              (progn
+                (when name (rlets (list name (foreign-record-type-name argtype))))
+                ;; ARM64-DEVIATION (LE): copy the slot verbatim — the value
+                ;; is low-justified in its doubleword.
+                (when name (inits `(setf (%%get-unsigned-longlong ,name 0)
+                                    (%%get-unsigned-longlong ,stack-ptr ,offset)))))
+              (let* ((access-form
+                      `(,(cond
+                          ((typep argtype 'foreign-single-float-type)
+                           (when (< (incf fp-arg-num) 9)
+                             (setq use-fp-args t
+                                   delta 0))
+                           '%get-single-float)
+                          ((typep argtype 'foreign-double-float-type)
+                           (when (< (incf fp-arg-num) 9)
+                             (setq use-fp-args t
+                                   delta 0))
+                           '%get-double-float)
+                          ((and (typep argtype 'foreign-integer-type)
+                                (= (foreign-integer-type-bits argtype) 64)
+                                (foreign-integer-type-signed argtype))
+                           '%%get-signed-longlong)
+                          ((and (typep argtype 'foreign-integer-type)
+                                (= (foreign-integer-type-bits argtype) 64)
+                                (not (foreign-integer-type-signed argtype)))
+                           '%%get-unsigned-longlong)
+                          ((or (typep argtype 'foreign-pointer-type)
+                               (typep argtype 'foreign-array-type))
+                           '%get-ptr)
+                          ((typep argtype 'foreign-record-type)
+                           (if (<= bits 128)
+                             (progn
+                               (setq delta 16)
+                               '%inc-ptr)
+                             ;; ARM64-DEVIATION: >128-bit records arrive
+                             ;; by reference (AAPCS64 B.4).
+                             '%get-ptr))
+                          (t
+                           (cond ((typep argtype 'foreign-integer-type)
+                                  (let* ((bits (foreign-integer-type-bits argtype))
+                                         (signed (foreign-integer-type-signed argtype)))
+                                    ;; ARM64-DEVIATION (LE): bias 0 for all
+                                    ;; sub-word widths.
+                                    (cond ((<= bits 8)
+                                           (if signed
+                                             '%get-signed-byte
+                                             '%get-unsigned-byte))
+                                          ((<= bits 16)
+                                           (if signed
+                                             '%get-signed-word
+                                             '%get-unsigned-word))
+                                          ((<= bits 32)
+                                           (if signed
+                                             '%get-signed-long
+                                             '%get-unsigned-long))
+                                          (t
+                                           (error "Don't know how to access foreign argument of type ~s" (unparse-foreign-type argtype))))))
+                                 (t
+                                  (error "Don't know how to access foreign argument of type ~s" (unparse-foreign-type argtype))))))
+                        ,(if use-fp-args fp-args-ptr stack-ptr)
+                        ,(if use-fp-args (* 8 (1- fp-arg-num))
+                             `(+ ,offset ,bias)))))
+                (when name (lets (list name access-form)))
+                (when use-fp-args (set-fp-regs-form))))))))))
+
+
+;;;-----------------------------------------------------------------------
+;;; (4) generate-callback-return-value
+;;;-----------------------------------------------------------------------
+;;; PPC64 LINE-PORT (vendor/ccl/lib/ffi-linuxppc64.lisp:180-199).
+;;; All structures are "returned" via the implicit first argument; the
+;;; binding generator already translated the return type to :void then.
+;;; The kernel trampoline reloads x0/x1 from CBF+0/+8 and d0 from CBF-64
+;;; on exit, so the value is written into the argument save area
+;;; (exactly PPC's gp_save reuse).
+;;;
+;;; ARM64-DEVIATION: a :single-float result is written as FLOAT BITS
+;;; (%get-single-float setf, low 32 bits of the d0 reload slot) — the C
+;;; caller reads s0.  PPC coerced to double ((float result 0.0d0)) and
+;;; wrote a double because PowerOpen returns singles double-extended in
+;;; f1; AAPCS64 does not.
+(defun arm64-linux64::generate-callback-return-value (stack-ptr fp-args-ptr result return-type struct-return-arg)
+  (declare (ignore struct-return-arg))
+  (unless (eq return-type *void-foreign-type*)
+    (let* ((return-type-keyword (foreign-type-to-representation-type return-type)))
+      (case return-type-keyword
+        (:single-float
+         `(setf (%get-single-float ,fp-args-ptr 0) ,result))
+        (:double-float
+         `(setf (%get-double-float ,fp-args-ptr 0) ,result))
+        (:address
+         `(setf (%get-ptr ,stack-ptr 0) ,result))
+        (:signed-doubleword
+         `(setf (%%get-signed-longlong ,stack-ptr 0) ,result))
+        (:unsigned-doubleword
+         `(setf (%%get-unsigned-longlong ,stack-ptr 0) ,result))
+        (t
+         `(setf (%%get-signed-longlong ,stack-ptr 0) ,result))))))

--- a/lib/foreign-types.lisp
+++ b/lib/foreign-types.lisp
@@ -104,7 +104,9 @@
                         (:freebsdx8632 "ccl:freebsd-headers;")
                         (:linuxarm "ccl:arm-headers;")
                         (:darwinarm "ccl:darwin-arm-headers;")
-                       (:androidarm "ccl:android-headers;"))
+                       (:androidarm "ccl:android-headers;")
+                        (:linuxarm64 "ccl:arm64-headers64;")
+                        (:darwinarm64 "ccl:darwin-arm64-headers;"))
                     :interface-package-name
                     #.(ftd-interface-package-name *target-ftd*)
                     :attributes

--- a/lib/format.lisp
+++ b/lib/format.lisp
@@ -351,7 +351,7 @@ and (nthcdr *format-arguments-variance* *format-arguments*)")
       (with-output-to-string (s stream)
 	(apply #'format s control-string format-arguments))
       (let ((*format-top-level* t))
-	(when (xp-structure-p stream)
+	(when (and (fboundp 'xp-structure-p) (xp-structure-p stream))
 	  (setq stream (xp-stream-stream stream))) ; for xp tests only! They call format on a structure
 	(setq stream (if (eq stream t)
 		       *standard-output*

--- a/lib/misc.lisp
+++ b/lib/misc.lisp
@@ -825,6 +825,7 @@ are running on, or NIL if we can't find any useful information."
   (#+ppc-target ppc-xdisassemble
    #+x86-target x86-xdisassemble
    #+arm-target arm-xdisassemble
+   #+arm64-target arm64-xdisassemble
    (require-type (function-for-disassembly thing) 'compiled-function)))
 
 (defun function-for-disassembly (thing)

--- a/lib/nfcomp.lisp
+++ b/lib/nfcomp.lisp
@@ -42,6 +42,8 @@
 (require "X8632-ARCH")
 #+x8664-target
 (require "X8664-ARCH")
+#+arm64-target
+(require "ARM64-ARCH")
 ) ;eval-when (:compile-toplevel :execute)
 
 
@@ -1288,6 +1290,9 @@ Will differ from *compiling-file* during an INCLUDE")
           #.x8664::fulltag-imm-1))
         #+arm-target
         (#.arm::tag-imm)
+        #+arm64-target
+        ((#.arm64::tag-single-float
+          #.arm64::tag-imm))
         (t
          (if
            #+ppc32-target
@@ -1304,6 +1309,11 @@ Will differ from *compiling-file* during an INCLUDE")
                                  (ash 1 x8664::fulltag-immheader-2))))
            #+arm-target
            (= (the fixnum (logand type-code arm::fulltagmask)) arm::fulltag-immheader)
+           #+arm64-target
+           (logbitp (the fixnum (logand type-code arm64::fulltagmask))
+                    (logior (ash 1 arm64::fulltag-immheader-0)
+                            (ash 1 arm64::fulltag-immheader-1)
+                            (ash 1 arm64::fulltag-immheader-2)))
            (case type-code
              (#.target::subtag-dead-macptr (fasl-unknown exp))
              (#.target::subtag-macptr
@@ -1324,6 +1334,13 @@ Will differ from *compiling-file* during an INCLUDE")
               #+x8632-target #.target::subtag-symbol
               #+x8664-target #.target::tag-symbol
               #+arm-target #.target::subtag-symbol (fasl-scan-symbol exp))
+             ;; Symbols and functions share lisptag 7 (TYPECODE returns it
+             ;; for both); only the fulltag (7 vs 15) distinguishes them.
+             #+arm64-target
+             (#.arm64::tag-7
+              (if (symbolp exp)
+                (fasl-scan-symbol exp)
+                (fasl-scan-clfun exp)))
              ((#.target::subtag-instance #.target::subtag-struct)
               (fasl-scan-user-form exp))
              (#.target::subtag-package (fasl-scan-ref exp))
@@ -1372,6 +1389,17 @@ Will differ from *compiling-file* during an INCLUDE")
     (do* ((k ncode-words (1+ k)))
          ((= k size))
       (fasl-scan-form (uvref fv k)))))
+
+;;; The code vector is a separate object in slot 0 (so there are no
+;;; inline code words to skip), but the function itself is
+;;; fulltag-function, which UVSIZE/%SVREF can't take directly.
+#+arm64-target
+(defun fasl-scan-clfun (f)
+  (let* ((fv (function-to-function-vector f)))
+    (fasl-scan-ref f)
+    (dotimes (i (uvsize fv))
+      (declare (fixnum i))
+      (fasl-scan-form (%svref fv i)))))
 
 (defun funcall-lfun-p (form)
   (and (listp form)
@@ -1770,15 +1798,16 @@ Will differ from *compiling-file* during an INCLUDE")
   (if (and (= (typecode f) target::subtag-xfunction)
            (= (typecode (uvref f 0)) target::subtag-u8-vector))
     (fasl-xdump-clfun f)
-    (let* ((n (uvsize f)))
+    (let* ((fv (if (functionp f) (function-to-function-vector f) f))
+           (n (uvsize fv)))
       (fasl-out-opcode $fasl-function f)
       (fasl-out-count n)
       (dotimes (i n)
         (if (= i 0)
           (target-arch-case
            (:arm (fasl-dump-form 0))
-           (t (fasl-dump-form (%svref f i))))
-          (fasl-dump-form (%svref f i)))))))
+           (t (fasl-dump-form (%svref fv i))))
+          (fasl-dump-form (%svref fv i)))))))
 
 #+x86-target
 (defun fasl-dump-function (f)

--- a/lisp-kernel/area.h
+++ b/lisp-kernel/area.h
@@ -133,7 +133,7 @@ typedef struct area_list {
 #define VSTACK_SOFTPROT CSTACK_SOFTPROT
 #endif
 
-#define MIN_TSTACK_SIZE (1<<18)
+#define MIN_TSTACK_SIZE (1<<19)
 #define TSTACK_HARDPROT ((1<<16)+(1<<12))
 #define TSTACK_SOFTPROT ((1<<16)+(1<<12))
 

--- a/lisp-kernel/arm64-constants.h
+++ b/lisp-kernel/arm64-constants.h
@@ -392,6 +392,21 @@ _structf macptr
   _node type
 _endstructf
 
+/* Assembler-visible mirror of constants.h INTERRUPT_LEVEL_BINDING_INDEX:
+ * the *INTERRUPT-LEVEL* thread-local-binding byte offset (binding
+ * index 1, fixnum-boxed = <<fixnumshift). */
+INTERRUPT_LEVEL_BINDING_INDEX = (1 << fixnumshift)
+
+/* A special-binding stack entry, as pushed on the VALUE stack by
+ * _SPbind and friends and walked via tcr.db_link: the saved value,
+ * the symbol's tlb byte offset (a boxed binding index), and the
+ * previous db_link. */
+_struct binding
+ _node link
+ _node sym
+ _node val
+_ends
+
 _struct tsp_frame
  _node backlink
  _node type

--- a/lisp-kernel/arm64-constants.h
+++ b/lisp-kernel/arm64-constants.h
@@ -630,7 +630,7 @@ static_assert(sizeof(TCR) == 2544,
                "sizeof(TCR) changed; update arm64-arch.lisp");
 
 #define ABI_VERSION_MIN 1
-#define ABI_VERSION_CURRENT 1
-#define ABI_VERSION_MAX 1
+#define ABI_VERSION_CURRENT 1046
+#define ABI_VERSION_MAX 1046
 
 #endif

--- a/lisp-kernel/arm64-constants.h
+++ b/lisp-kernel/arm64-constants.h
@@ -144,7 +144,8 @@ DEFCONST(fulltag_nil,          0b1011)
 DEFCONST(fulltag_misc,         0b1100)
 DEFCONST(fulltag_immheader_2,  0b1101)
 DEFCONST(fulltag_nodeheader_1, 0b1110)
-DEFCONST(fulltag_function,     0b1111)
+/* 0b1111 free: fulltag_function removed -- a function is an ordinary
+   miscobj (fulltag_misc + subtag_function); functionp checks the subtag. */
 
 DEFCONST(misc_bias, fulltag_misc)
 DEFCONST(cons_bias, fulltag_cons)
@@ -363,8 +364,8 @@ _structf symbol, -fulltag_symbol
   _node binding_index
 _endstructf
 
-/* A function has its own tag, but is otherwise a miscobj */
-_struct _function, -fulltag_function
+/* A function is an ordinary miscobj (fulltag_misc + subtag_function) */
+_struct _function, -fulltag_misc
  _node header
  _node code_vector
 _ends

--- a/lisp-kernel/arm64-constants.h
+++ b/lisp-kernel/arm64-constants.h
@@ -415,6 +415,29 @@ _structf catch_frame
  _node xframe                   /* exception frame chain */
  _node nfp
 _endstructf
+
+/* Foreign-call argument frame, built by HIS alloc-c-frame vinsn
+ * (arm64-vinsns.lisp:287) and consumed by _SPffcall.  The layout is his:
+ * `header' is a subtag_u64_vector header whose count covers everything
+ * after it; `savedsp' is the SP from before the allocation (his "element
+ * 0").  There is deliberately NO savelr -- 4 words are RESERVED at the
+ * frame TOP for a boundary lisp_frame, published by shrinking the count
+ * by 4 (arm642.lisp:6323).  The 8 AAPCS64 GPR argument words live at
+ * c_frame.params; stack (overflow) args sit immediately above them.
+ * 16m30: this block used to say {backlink@0, savelr@8}, so _SPffcall
+ * stored lr over savedsp and restored sp from the header -> sp=0xded. */
+_struct c_frame
+ _node header
+ _node savedsp
+ _struct_label params
+_ends
+
+/* Assembler-visible mirrors of the TCR_STATE_* values (constants.h is
+ * guarded out of the assembler pass above; this block is inside the
+ * __ASSEMBLER__ section, so these don't collide with the C-side
+ * defines). */
+TCR_STATE_LISP = 0
+TCR_STATE_FOREIGN = 1
 #endif
 
 DEFCONST(two_digit_bignum_header, ((2<<num_subtag_bits)|subtag_bignum))

--- a/lisp-kernel/arm64-macros.s
+++ b/lisp-kernel/arm64-macros.s
@@ -38,9 +38,10 @@ _SP\name:
         .macro Cons dest, car, cdr
         sub allocptr, allocptr, #(cons.size - fulltag_cons)
         cmp allocptr, allocbase
-        b.hi 1f
+        b.hi .Lcons\@
         uuo_alloc
-1:      str \cdr, [allocptr, #cons.cdr]
+.Lcons\@:
+        str \cdr, [allocptr, #cons.cdr]
         str \car, [allocptr, #cons.car]
         mov \dest, allocptr
         clear_allocptr_tag
@@ -53,9 +54,10 @@ _SP\name:
         sub \size, \size, #fulltag_misc
         sub allocptr, allocptr, \size
         cmp allocptr, allocbase
-        b.hi 1f
+        b.hi .Lmalloc\@
         uuo_alloc
-1:      str \header, [allocptr, #misc_header_offset]
+.Lmalloc\@:
+        str \header, [allocptr, #misc_header_offset]
         mov \dest, allocptr
         clear_allocptr_tag
         .endm
@@ -63,9 +65,10 @@ _SP\name:
         .macro Misc_Alloc_Fixed dest, header, sizeconst
         sub allocptr, allocptr, #(\sizeconst - fulltag_misc)
         cmp allocptr, allocbase
-        b.hi 1f
+        b.hi .Lmaf\@
         uuo_alloc
-1:      str \header, [allocptr, #misc_header_offset]
+.Lmaf\@:
+        str \header, [allocptr, #misc_header_offset]
         mov \dest, allocptr
         clear_allocptr_tag
         .endm

--- a/lisp-kernel/arm64-print.c
+++ b/lisp-kernel/arm64-print.c
@@ -457,9 +457,10 @@ sprint_lisp_object(LispObj o, int depth)  /* arm_print.c:415-491 */
     case fulltag_symbol:
       sprint_symbol(o);
       break;
-    case fulltag_function:
-      sprint_function(o, depth);
-      break;
+    /* fulltag_function removed: functions are ordinary miscobjs and
+       reach sprint_function via the fulltag_misc case's subtag dispatch;
+       tag 15 joins fulltag_reserved so the dispatch stays total. */
+    case 15:                    /* was fulltag_function */
     case fulltag_reserved:
       add_c_string("#<reserved-tag ");
       sprint_unsigned_hex(o);

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -64,7 +64,7 @@ endsp makeu64
  */
 
 // Obviously this is not complete. It's just for playing with the uuos.
-spentry misc_ref
+spentry misc_ref_upstream_sketch
         and imm0, arg_y, #fulltagmask
         cmp imm0, #fulltag_misc
         bne 0f
@@ -79,7 +79,7 @@ spentry misc_ref
 0:      uuo_error_reg_not_fulltag arg_y, fulltag_misc
 1:      uuo_error_reg_not_lisptag arg_z, tag_fixnum
 2:      uuo_error_vector_bounds arg_z, arg_y
-endsp misc_ref
+endsp misc_ref_upstream_sketch
 
 C(misc_ref_common):
         ret

--- a/lisp-kernel/arm64-uuo.s
+++ b/lisp-kernel/arm64-uuo.s
@@ -42,6 +42,10 @@ uuo_format_unary = 1
   // (index, dest); see "Errors that need three registers" in
   // doc/porting/arm64.md.  reg here is the slot vector.
   unary_info_slot_unbound = 6
+  // Funcalled a symbol naming a macro or special operator: the fcell
+  // holds the 2-element simple-vector whose slot 0 is %macro-code%,
+  // whose single instruction is this UUO.  reg = fname.
+  unary_info_apply_macro = 7
 
 /*
  * Two-register errors
@@ -143,6 +147,10 @@ uuo_format_wrong_type = 3
         // into dest.  A lone one is an internal error.
         .macro uuo_error_slot_unbound slotv
         uuo_unary \slotv, unary_info_slot_unbound
+        .endm
+
+        .macro uuo_error_apply_macro reg
+        uuo_unary \reg, unary_info_apply_macro
         .endm
 
         // binary format

--- a/lisp-kernel/arm64-uuo.s
+++ b/lisp-kernel/arm64-uuo.s
@@ -38,6 +38,10 @@ uuo_format_unary = 1
   unary_info_udf = 3
   unary_info_udf_call = 4
   unary_info_tlb_too_small = 5
+  // Must be FOLLOWED by a uuo_extra_registers companion carrying
+  // (index, dest); see "Errors that need three registers" in
+  // doc/porting/arm64.md.  reg here is the slot vector.
+  unary_info_slot_unbound = 6
 
 /*
  * Two-register errors
@@ -131,6 +135,14 @@ uuo_format_wrong_type = 3
 
         .macro uuo_error_tlb_too_small reg
         uuo_unary \reg, unary_info_tlb_too_small
+        .endm
+
+        // Three-register error: emit this, then uuo_extra_registers
+        // index, dest.  The handler reads the companion as data and
+        // resumes past BOTH instructions, storing slot-unbound's value
+        // into dest.  A lone one is an internal error.
+        .macro uuo_error_slot_unbound slotv
+        uuo_unary \slotv, unary_info_slot_unbound
         .endm
 
         // binary format

--- a/lisp-kernel/errors.s
+++ b/lisp-kernel/errors.s
@@ -32,6 +32,7 @@ error_suspend_all = 13
 error_resume = 14
 error_resume_all = 15					
 error_cant_call = 17
+error_apply_macro_or_special = 20
         
 error_type_error = 128
 

--- a/lisp-kernel/gc.h
+++ b/lisp-kernel/gc.h
@@ -62,8 +62,7 @@
 #ifdef ARM64
 #define is_node_fulltag(f)  ((1<<(f))&((1<<fulltag_cons)    | \
 				       (1<<fulltag_misc)    | \
-				       (1<<fulltag_symbol)  | \
-				       (1<<fulltag_function)))
+				       (1<<fulltag_symbol)))
 #endif
 
 extern LispObj GCarealow, GCareadynamiclow;

--- a/lisp-kernel/image.c
+++ b/lisp-kernel/image.c
@@ -369,6 +369,19 @@ load_openmcl_image(int fd, openmcl_image_file_header *h)
       if (a == NULL) {
 	return 0;
       }
+#ifdef ARM64
+      /* lisp_nil is a runtime value on ARM64 (lisp_globals.h); establish
+         it as soon as the static section is mapped, BEFORE any later
+         section's loader touches lisp_global() -- allocate_dynamic_area()
+         writes lisp_global(HEAP_START).  Geometry matches the xload
+         writer: static space maps at STATIC_BASE_ADDRESS (0x12000), a
+         4KB filler ivector precedes NIL, so NIL = low + 4K + fulltag_nil
+         = canonical-nil-value (#x1300b, arm64-arch.lisp:245). */
+      if (sect->code == AREA_STATIC) {
+        image_nil = (LispObj)(a->low) + (1024*4) + fulltag_nil;
+        set_nil(image_nil);
+      }
+#endif
     }
 
     for (i = 0, sect = sections; i < nsections; i++, sect++) {

--- a/lisp-kernel/lisp-errors.h
+++ b/lisp-kernel/lisp-errors.h
@@ -36,6 +36,7 @@
 #define error_cant_call 17
 #define error_allocate_list 18
 #define error_allocation_disabled 19
+#define error_apply_macro_or_special 20
 
 #define error_type_error 128
 

--- a/lisp-kernel/lisp_globals.h
+++ b/lisp-kernel/lisp_globals.h
@@ -139,7 +139,14 @@ extern LispObj lisp_nil;
    i.e. lisp_nil, which set_nil() stores at image-load time from the loaded
    static area's actual base, before any lisp_global/nrs_symbol use. */
 #define nil_value lisp_nil
-#define lisp_global(g) (((LispObj *)(nil_value-fulltag_nil-dnode_size))[(g)])
+/* Globals array base = untagged nil (0x13000): the kernel-global lisp
+   accessor is -(fulltag-nil + (1+pos)*8) relative to tagged nil
+   (arm64-arch.lisp %kernel-global), so global g=-1 sits at nil-fulltag-8.
+   The nil pun is TWO conses (0x13000..0x13020, xload
+   arm64-initialize-static-space); the first nrs symbol (T, header
+   observed in the image) starts at 0x13020 = nil-fulltag+2*dnode_size,
+   matching canonical-t-value (#x13020+fulltag-symbol). */
+#define lisp_global(g) (((LispObj *)(nil_value-fulltag_nil))[(g)])
 #define nrs_symbol(s) (((lispsymbol *)(nil_value-fulltag_nil+2*dnode_size))[(s)])
 #endif
 

--- a/xdump/xfasload.lisp
+++ b/xdump/xfasload.lisp
@@ -340,10 +340,7 @@
 
 
 (defun  %xload-unbound-function% ()
-  (+ *xload-dynamic-space-address*
-     (target-arch-case
-      (:arm64 *xload-target-fulltag-for-functions*)
-      (otherwise *xload-target-fulltag-misc*))))
+  (+ *xload-dynamic-space-address* *xload-target-fulltag-misc*))
 
 (defparameter *xload-dynamic-space* nil)
 (defparameter *xload-readonly-space* nil)
@@ -1062,17 +1059,6 @@
                   *xload-target-backend*)))
           (locally (declare (ftype (function (t) t) xload-arm-set-entrypoint))
             (xload-arm-set-entrypoint udf-object))))
-       (:arm64
-        ;; arm64 gives functions their own fulltag; callers load the
-        ;; code vector from slot 0 of a function-tagged pointer, so the
-        ;; PPC simple-vector pun (misc tag) misreads.  Real function
-        ;; object: {code-vector@0, lfbits@1}.
-        (let* ((udf-object (xload-make-gvector :function 2)))
-          (setf (xload-%svref udf-object 0)
-                (xload-save-code-vector
-                 (backend-xload-info-udf-code
-                  *xload-target-backend*)))
-          (setf (xload-%svref udf-object 1) 0)))
        (otherwise
         ;; The undefined-function object is a 1-element simple-vector (not
         ;; a function vector).  The code-vector in its 0th element should

--- a/xdump/xfasload.lisp
+++ b/xdump/xfasload.lisp
@@ -340,7 +340,10 @@
 
 
 (defun  %xload-unbound-function% ()
-  (+ *xload-dynamic-space-address* *xload-target-fulltag-misc*))
+  (+ *xload-dynamic-space-address*
+     (target-arch-case
+      (:arm64 *xload-target-fulltag-for-functions*)
+      (otherwise *xload-target-fulltag-misc*))))
 
 (defparameter *xload-dynamic-space* nil)
 (defparameter *xload-readonly-space* nil)
@@ -1059,6 +1062,17 @@
                   *xload-target-backend*)))
           (locally (declare (ftype (function (t) t) xload-arm-set-entrypoint))
             (xload-arm-set-entrypoint udf-object))))
+       (:arm64
+        ;; arm64 gives functions their own fulltag; callers load the
+        ;; code vector from slot 0 of a function-tagged pointer, so the
+        ;; PPC simple-vector pun (misc tag) misreads.  Real function
+        ;; object: {code-vector@0, lfbits@1}.
+        (let* ((udf-object (xload-make-gvector :function 2)))
+          (setf (xload-%svref udf-object 0)
+                (xload-save-code-vector
+                 (backend-xload-info-udf-code
+                  *xload-target-backend*)))
+          (setf (xload-%svref udf-object 1) 0)))
        (otherwise
         ;; The undefined-function object is a 1-element simple-vector (not
         ;; a function vector).  The code-vector in its 0th element should
@@ -1463,9 +1477,13 @@
 (defxloadfaslop $fasl-symfn (s)
   (let* ((symaddr (%fasl-expr-preserve-epush s))
          (fnobj (xload-%svref symaddr target::symbol.fcell-cell)))
-    (if (and (= *xload-target-fulltag-misc*
+    (if (and (= *xload-target-fulltag-for-functions*
                 (logand fnobj *xload-target-fulltagmask*))
-             (= (type-keyword-code :function) (xload-u8-at-address (+ fnobj *xload-target-misc-subtag-offset*))))
+             (= (type-keyword-code :function)
+                (xload-u8-at-address
+                 (+ (logior *xload-target-fulltag-misc*
+                            (logandc2 fnobj *xload-target-fulltagmask*))
+                    *xload-target-misc-subtag-offset*))))
       (%epushval s fnobj)
       (error "symbol at #x~x is unfbound . " symaddr))))
 
@@ -1646,7 +1664,24 @@
   (xfasl-read-gvector s (xload-target-subtype :simple-vector)))
 
 (defxloadfaslop $fasl-function (s)
-  (xfasl-read-gvector s (xload-target-subtype :function)))
+  ;; On targets whose function tag is a FULLTAG rather than a subtag of
+  ;; fulltag-misc (arm64: fulltag-function #b1111), the pushed/returned
+  ;; value must carry that tag -- self-references read during element
+  ;; fill must see the final tag.  $fasl-clfun applies the same rule.
+  ;; On subtag targets fulltag-for-functions = fulltag-misc, so this
+  ;; reduces to the previous behavior.
+  (let* ((n (%fasl-read-count s))
+         (vector (xload-make-gvector (xload-target-subtype :function) n))
+         (function (logior *xload-target-fulltag-for-functions*
+                           (logandc2 vector *xload-target-fulltagmask*))))
+    (%epushval s function)
+    (dotimes (i n)
+      (setf (xload-%svref vector i) (%fasl-expr s)))
+    (target-arch-case
+     (:arm
+      (locally (declare (ftype (function (t) t) xload-arm-set-entrypoint))
+        (xload-arm-set-entrypoint vector))))
+    (setf (faslstate.faslval s) function)))
 
 (defxloadfaslop $fasl-istruct (s)
   (xfasl-read-gvector s (xload-target-subtype :istruct)))


### PR DESCRIPTION
Interim patch series from a parallel Linux/arm64 port built on this branch. Based
at `9c61574` (the `arm64` head when this was opened), so every commit applies as-is.

Offered for cherry-picking rather than as a single take-it-or-leave-it merge —
each commit is independently scoped, has its own rationale in the message, and
cites the donor it was ported from (PPC64 in most cases, ARM32 or x8664 where
PPC has no analog). Nothing here depends on our own out-of-tree overlay: these
are all changes to files already in this branch.

### Where this gets to

With these applied plus our overlay, the arm64 build boots to a REPL, loads all
of level-1 and CLOS, runs its own resident compiler, does `COMPILE-FILE`, and
runs the ANSI test suite to completion: **21679 executed, 20 failures, no
exclusions** — 21659 passing, 99.908%. Every number quoted here is from a
measured run, not a projection.

### Rough map

42 files, +1094/-225.

- **`lisp-kernel/`** (10 files) — `.SPffcall` and the bind family bodies, image
  ABI version, NIL init, lisp-globals geometry, and `MIN_TSTACK_SIZE`.
- **`compiler/`** (10 files, 8 of them `ARM64/`) — UUO template renumbering to match
  `arm64-uuo.s`, register-bearing UUO templates, `arm64-subprimitive-offset`,
  `arm642-box-u32/-s32`, register maps sized for 32 GPRs rather than 16, NFP
  scratch-register fix, constant-index gating, the `DISASSEMBLE` entry point,
  and the compiler-correctness fixes found by the ANSI suite.
- **`level-0/`, `level-1/`, `lib/`** (21 files) — mostly missing `#+arm64-target`
  arms in shared code, where the absence silently yields NIL rather than
  failing loudly: `SYMBOL-NAME` returning its docstring, `SYMBOLP`,
  `SUBTAG-BYTES`, `IMMEDIATE-P`, `ARRAY-ELEMENT-TYPE` returning NIL for every
  array, the CLOS/dcode function builders, header-type tables, and the arch
  quads that load the arm64 support files.
- **`xdump/`, `lib/nfcomp.lisp`** — the fasl writer/scanner and cold-load
  function tagging for the arm64 tag scheme.

### Added since the PR was opened (commits 48-54)

- **48** — a UUO code for slot-unbound. This was the last `brk #xf0NN`
  placeholder in our tree; note `brk` does not trap as a UUO on arm64, so any
  remaining placeholder is a silent wrong-code path rather than an error.
- **49** — `MIN_TSTACK_SIZE` (1<<18) is *exactly* the tstack demand of reading a
  literal at `ARRAY-RANK-LIMIT`, so the suite died with zero headroom. Node size
  cancels out of the arithmetic, so every tsp-based port has the same
  zero-headroom collision, not just arm64.
- **50** — `%make-complex-{single,double}-float` kept ARM32's register-*pair*
  model instead of arm64's one-register-two-lane one.
- **51** — **removes `fulltag_function`**: a function becomes an ordinary
  miscobj (`fulltag_misc` + `subtag_function`), the code-vector offset goes
  −7 → −4, and `functionp` tests the subtag. This implements the design you
  described in the 2026-07-27 thread, and it dissolves the macro/special-operator
  fcell problem the original PR text listed as deliberately out of scope
  (`(funcall 'quote 1)` now signals rather than faulting). It is build-confirmed
  in our lane with zero regressions. If you would rather land your own version,
  say so and we will drop this commit and rebase onto yours — we are not asking
  you to take our shape over yours, only offering a working one.
- **52** — `ARM64-XDISASSEMBLE`. `compiler/ARM64/arm64-disassemble.lisp` supplies
  the whole disassembler but no CCL-facing entry point, so `DISASSEMBLE` had
  nothing to dispatch to.
- **53, 54** — **an upstream-wide defect, not an arm64-only one.** See below.

### Commits 53/54 are worth your eye even if you take nothing else

`arm642-elide-pushes` turns `(vpush P) … (vpop Q)` into a compensating copy
`Q := P`. When `P` is assigned inside the elided range the copy must be emitted
early — but the guard that permits the elision is the weaker condition *"Q's
last read precedes P's first write"* (`vinsn-sequence-refs-reg-p` returns the
last ref, `vinsn-sequence-sets-reg-p` the first set). That guard proves a safe
slot **exists** between those two points; the insertion ignored it and anchored
the copy at the push, clobbering a live base register ahead of its own uses.

Fixing that one anchor took our ANSI failures from **49 to 20**. The blast
radius is any three-operand form whose operands are nested accessors off a
common base — 29 tests, where we had predicted 9.

Reading across the other backends at `8b1ed247`:

| | vsp leg | nfp leg |
|---|---|---|
| `x862-elide-pushes` (x862.lisp:4054) | **already correct** — anchors at `popped-reg-is-reffed` (4164) | unguarded, anchors at the push (4093) |
| `arm2-elide-pushes` (arm2.lisp:3267) | computes `popped-reg-is-reffed` (3373) and then ignores it (3432) — the same defect | unguarded (3307) |
| `ppc2-elide-pushes` (ppc2.lisp:2794) | no vsp leg | unguarded (2817) |
| `arm642-elide-pushes` | the defect we hit | unguarded |

So x862's vsp leg is the correct donor and both ARM ports dropped the anchor
when adapting it. **`arm2.lisp:3432` looks like a live miscompile in the ARM32
backend**, reachable by the same source shapes — we have not built ARM32 to
confirm it, so treat that as a reading of the source rather than a measurement.

Commit 54 applies the same rule to the nfp leg, which had the wrong anchor *and*
no guard at all. It is offered on the identical-defect argument, not on a
failing test: its acceptance criterion was a full-suite run that does not move,
and that is what it did (21679/20, byte-identical failure list).

### Caveats, stated plainly

- Two hunks are tagged `ARM64-DEVIATION` in-file: places where AAPCS64 or the
  A64 encoding has no PPC-shaped equivalent and we made a judgement call. Those
  are the ones most worth your eye.
- Commit 9 renumbers the `arm64-asm` UUO templates to match the scheme in your
  `arm64-uuo.s`. It is mechanical, but it is a wide rename, so it is the most
  likely to conflict with in-flight work on your side — happy to rebase or drop it.
- A few kernel changes assume struct offsets and xtype values that we derived
  rather than found declared. Where we did that we said so in the commit
  message; if you would rather those live in `arm64-constants.h` we will move them.
- Commit 16 (`l1-clos`) is scoped to `level-1/l1-clos.lisp` only. Its
  `l1-clos-boot.lisp` half is already carried by commit 1.
- The series is verified to apply to a virgin checkout of this branch in order,
  **54/54**, with the `git am` result tree byte-identical to a `git apply`
  dry-run tree.
- The branch has moved on since `9c61574` (`1db0ab68` as of this update,
  including a large `arm642.lisp` expansion). We have not rebased yet; say the
  word and we will. `arm642-elide-pushes` still carries the commit-53 defect at
  `1db0ab68`.

Happy to split this into smaller PRs by area, reorder, or drop anything you
don't want.
