### PR TITLE
arm64: the Linux/arm64 kernel runtime and arm64-only Lisp sources (the other half of #560)

### DIFF
--- a/doc/porting/linuxarm64-build.md
+++ b/doc/porting/linuxarm64-build.md
@@ -1,0 +1,98 @@
+# Building CCL for Linux/arm64
+
+Notes from getting the linuxarm64 target to build and boot. Assumes this
+branch (or the two PRs that produced it) is applied; with those in place the
+build is the ordinary CCL build, and what follows is only the parts that are
+not obvious.
+
+## You need two machines (or one plus a cross environment)
+
+- **an x86-64 Linux host** to build the heap image, and
+- **a Linux/arm64 machine** to build the kernel and run the result.
+
+The image cannot be built natively on arm64: building it runs the
+cross-compiler, which needs a working host CCL. The kernel is the only piece
+built natively on the target.
+
+## The host CCL must be new enough
+
+The host CCL that runs the cross-compile has to know the `aapcs64-ff-call`
+nx1 operator. **A pristine 1.12.2 does not**, and the cross-compile dies
+partway through with an obscure failure. A 1.13 built from the `arm64` branch
+(`da35a7d` or later) works.
+
+## Kernel
+
+```
+cd lisp-kernel/linuxarm64
+make
+```
+
+The Makefile in this branch has been corrected for aarch64; before that it
+was ARM32 inheritance and had never been run. In particular the `.s.o` rule
+builds with `$(CC) -x assembler-with-cpp` rather than m4, because the arm64
+assembly layer is cpp-based — `imports.s` is the one genuine m4 file and
+keeps a rule of its own.
+
+## An install is six parts, not two
+
+This is the step that wastes an afternoon. A runnable install needs:
+
+```
+armcl64                 the kernel
+arm64-boot-*.image      the heap image
+level-1.la64fsl         the startup fasl
+bin/                    level-1 fasls
+l1-fasls/               more of the same
+arm64-headers64/        the FFI interface databases
+```
+
+Copy only the kernel and the image and it dies with a **bare SIGSEGV that
+looks like a port bug and is not**: startup opens `level-1.la64fsl` relative
+to the install, `CDB-OPEN` then needs `arm64-headers64/`, and the failure
+happens *inside the error path* —
+
+```
+Interface file .../arm64-headers64/libc/records.cdb does not exist
+  -> Unknown foreign type: :<D>L_INFO
+  -> FATAL (cold load): unbound variable *PRINT-PPRINT-DISPATCH*
+```
+
+`strace` names it in one run; a register dump does not.
+
+Run with the install directory as cwd — the image resolves `ccl:` and its
+startup fasl relative to itself:
+
+```
+cd /your/install && ./armcl64 --image-name ./arm64-boot-16m16.image
+echo '(print (list :ok (+ 1 2) (sin 1.0d0)))' | ./armcl64 --image-name ./arm64-boot-16m16.image
+```
+
+Expect `(:OK 3 0.8414709848078965D0)`.
+
+## Floating point on this target
+
+AArch64 defines the FPCR trap-enable bits (`IOE`/`DZE`/`OFE`/`UFE`/`IXE`),
+but implementing trapped floating-point exceptions is **optional**, and they
+are RAZ/WI on at least Neoverse N1 — writing `0x1f00` to FPCR reads back
+`0x0`. So there is no SIGFPE to field the way `ppc-exceptions.c` does, and
+enabled-exception detection polls the cumulative FPSR flags at checkpoints
+instead.
+
+Two consequences worth knowing before debugging anything float-related:
+
+- **FPSR exception flags are cumulative.** Any code that captures them for a
+  foreign call must zero FPSR *before* the call, not only after it —
+  otherwise the captured word carries every flag raised since the previous
+  foreign call, including unrelated inline Lisp arithmetic, and the wrong
+  callee gets blamed. That produced spurious `FLOATING-POINT-OVERFLOW` from
+  `log`, `exp`, `sin` and `atan`.
+- Inline floating-point arithmetic therefore cannot signal on such a part.
+  `(expt <float> <integer>)` is repeated multiplication and never reaches
+  `pow`, so it needs its own checkpoint if it is to conform.
+
+## Status
+
+With this branch applied, the Dietz ANSI suite runs to completion at **21677
+of 21679 passing, no exclusions** — the two remaining failures reproduce
+identically on x86-64 CCL 1.12.2.

--- a/level-0/ARM64/arm64-array.lisp
+++ b/level-0/ARM64/arm64-array.lisp
@@ -1,0 +1,577 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-array.lisp — Wave-8 DRAFT port of vendor/ccl/level-0/PPC/ppc-array.lisp
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/ppc-array.lisp)
+;;; Target: Matt Emerson upstream arm64 (low-tag) design, pin d71a5ad.
+;;; Per-line citations: "; ppc:NNN" = line NNN of vendor/ccl/level-0/PPC/ppc-array.lisp.
+;;;
+;;; CLASS-DISPATCH RESTRUCTURE (W8-D70): Matt's design has NO 8-bit ivector
+;;; class.  His classes (arm64-arch.lisp:89-91) are 64-bit (#b1101),
+;;; 32-bit (#b1100) and OTHER (#b0101); s8/u8/s16/u16/bit/complex-double-
+;;; float-vector all live in the OTHER class.  PPC64's four-way class
+;;; dispatch (64/32/8/residue) is re-keyed here: fulltag → 64/32, then the
+;;; OTHER residue dispatches on the header SUBTAG.  Per-subtag arms are
+;;; line-ported unchanged.
+;;;
+;;; NODEHEADER TEST (W8-D71): PPC64 tests the 2-bit lowtag against
+;;; lowtag-nodeheader.  Matt has no lowtags, but both nodeheader fulltags
+;;; (#b0110/#b1110, arm64-arch.lisp:62,70) share the 3-bit lisptag
+;;; tag-nodeheader (#b110, arm64-arch.lisp:52), so the test becomes
+;;; (and x tagmask) == tag-nodeheader.
+;;;
+;;; STATUS: DRAFT — not assembled; ledger in wave8-array-clos-report.md.
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; %init-misc — ppc:231 (#+ppc64-target arm; the ppc:41 arm is ppc32-only)
+;;; =====================================================================
+;;; Fill every element of a freshly-allocated uvector with val, after
+;;; type-checking val against the vector's element type.
+;;; Register plan (one-NZCV serialization; PPC uses cr0..cr7):
+;;;   imm1 = header fulltag (ivector class)   imm2 = header subtag
+;;;   imm3 = unboxed element count            imm4 = byte-offset cursor
+;;;   imm5 = val's typecode, held LIVE for the whole body; PPC's persistent
+;;;          cr7 (fixnum) / cr5 (bignum) compares are RE-ISSUED against
+;;;          imm5 at each use point.  (imm5=x5 is DISTINCT from nargs=x6
+;;;          on Matt's map — plain scratch use; @bad does its own set-nargs.)
+;;;   imm0 = scratch / the value eventually stored.
+(defarm64lapfunction %init-misc ((val arg_y)
+                                 (miscobj arg_z))
+  (getvheader imm0 miscobj)             ; ppc:233
+  (header-size imm3 imm0)               ; ppc:236 unboxed element count
+  (extract-fulltag imm1 imm0)           ; ppc:238 ivector class = header fulltag
+  (extract-lowbyte imm2 imm0)           ; ppc:240 header subtag
+  (cbz imm3 @return)                    ; ppc:237/241 silly 0-length case (beqlr cr3)
+  (mov imm4 (:$ arm64::misc-data-offset)) ; ppc:242
+  ;; node-vs-ivector: W8-D71 lisptag test replaces ppc:235/239 lowtag test
+  (and imm0 imm0 (:$ arm64::tagmask))   ; ppc:235 (clrldi → and tagmask)
+  (cmp imm0 (:$ arm64::tag-nodeheader)) ; ppc:239
+  (b.ne @imm)                           ; ppc:243
+  ;; Node vector.  Don't need to memoize, since initial value is
+  ;; older than vector.                 ; ppc:244-245
+  @node-loop                            ; ppc:246
+  (subs imm3 imm3 (:$ 1))               ; ppc:247-248 (cmpdi/subi → subs at loop top, wave-5)
+  (str val (:@ miscobj imm4))           ; ppc:249 stdx (regoff)
+  (add imm4 imm4 (:$ arm64::node-size)) ; ppc:250
+  (b.ne @node-loop)                     ; ppc:251
+  @return
+  (ret)                                 ; ppc:252
+  @imm                                  ; ppc:253
+  (extract-typecode imm5 val)           ; ppc:254 — persistent (see header note)
+  ;; W8-D70 class dispatch: 64/32 on fulltag, then OTHER residue on subtag
+  (cmp imm1 (:$ arm64::ivector-class-64-bit)) ; ppc:255
+  (b.eq @64)                            ; ppc:261
+  (cmp imm1 (:$ arm64::ivector-class-32-bit)) ; ppc:256
+  (b.eq @32)                            ; ppc:262
+  ;; OTHER class residue (ppc:257/263 ivector-class-8-bit has no analog)
+  (cmp imm2 (:$ arm64::subtag-s8-vector)) ; ppc:402 (@8 arm's s8 test, hoisted)
+  (b.eq @s8)
+  (cmp imm2 (:$ arm64::subtag-u8-vector)) ; ppc:257/263 (@8 arm's default = u8)
+  (b.eq @u8)
+  (cmp imm2 (:$ arm64::subtag-complex-double-float-vector)) ; ppc:260
+  (b.eq @complex-double-float)          ; ppc:264
+  ;; u16, s16, or bit-vector.  Val must be a fixnum.  ; ppc:265
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; ppc:258 cr7 (re-issued)
+  (b.ne @bad)                           ; ppc:268
+  (cmp imm2 (:$ arm64::subtag-u16-vector)) ; ppc:266
+  (b.eq @u16)                           ; ppc:269
+  (cmp imm2 (:$ arm64::subtag-s16-vector)) ; ppc:267
+  (b.eq @s16)                           ; ppc:270
+  ;; Bit vector.                        ; ppc:271
+  (cmp val (:$ (ash 1 arm64::fixnumshift))) ; ppc:272 cmpldi val '1 (UNSIGNED)
+  (add imm3 imm3 (:$ 63))               ; ppc:273 (flag-safe)
+  (lsr imm3 imm3 (:$ 6))                ; ppc:274 bit count → word count
+  (unbox-fixnum imm0 val)               ; ppc:275
+  (neg imm0 imm0)                       ; ppc:276 0 → 0, 1 → all-ones (non-flag-setting)
+  (b.ls @set-64)                        ; ppc:277 ble+ cr0 (unsigned ≤)
+  ;; fall through to @bad
+  @bad                                  ; ppc:278
+  (mov arg_x (:$ (ash $xnotelt arm64::fixnumshift))) ; ppc:279 li arg_x '#.$xnotelt
+  (save-lisp-context)                   ; ppc:280
+  (set-nargs 3)                         ; ppc:281
+  (call-symbol %err-disp)               ; ppc:282 — does not return (DECIDE-14/W3 call-symbol)
+  @complex-double-float                 ; ppc:283
+  (cmp imm5 (:$ arm64::subtag-complex-double-float)) ; ppc:284
+  (b.ne @bad)                           ; ppc:285
+  ;; scalar complex-double-float: pad word after header, realpart @ +12,
+  ;; imagpart @ +20 (arm64-arch.lisp:450-453) — not 8-multiples → ldur
+  (ldur d0 (:@ val (:$ arm64::complex-double-float.realpart))) ; ppc:286 lfd fp0
+  (ldur d1 (:@ val (:$ arm64::complex-double-float.imagpart))) ; ppc:287 lfd fp1
+  ;; W8-D72: destination vector's element 0 assumed at the same
+  ;; pad-aligned offset (misc-complex-dfloat-offset = 12) — 16-byte
+  ;; element alignment demands it, but the VECTOR layout is not spelled
+  ;; out in Matt's arch.  See ledger.
+  (mov imm4 (:$ arm64::complex-double-float.realpart)) ; ppc:288
+  @complex-double-float-loop            ; ppc:289
+  (subs imm3 imm3 (:$ 1))               ; ppc:290-291
+  (str d0 (:@ miscobj imm4))            ; ppc:292 stfdx (FP regoff)
+  (add imm4 imm4 (:$ 8))                ; ppc:293
+  (str d1 (:@ miscobj imm4))            ; ppc:294
+  (add imm4 imm4 (:$ 8))                ; ppc:295
+  (b.ne @complex-double-float-loop)     ; ppc:296
+  (ret)                                 ; ppc:297
+  @64                                   ; ppc:298
+  (cmp imm2 (:$ arm64::subtag-complex-single-float-vector)) ; ppc:299
+  (b.eq @complex-single-float)          ; ppc:303
+  (cmp imm2 (:$ arm64::subtag-fixnum-vector)) ; ppc:300
+  (b.eq @fixnum)                        ; ppc:304
+  (cmp imm2 (:$ arm64::subtag-double-float-vector)) ; ppc:301
+  (b.eq @dfloat)                        ; ppc:305
+  (cmp imm2 (:$ arm64::subtag-s64-vector)) ; ppc:302
+  (b.ne @u64)                           ; ppc:306
+  ;; s64                                ; ppc:307
+  (unbox-fixnum imm0 val)               ; ppc:308
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; cr7 re-issue
+  (b.eq @set-64)                        ; ppc:309 all fixnums are (SIGNED-BYTE 64)
+  (cmp imm5 (:$ arm64::subtag-bignum))  ; cr5 re-issue
+  (b.ne @bad)                           ; ppc:310
+  (getvheader imm1 val)                 ; ppc:311
+  ;; W8-D73: ppc:314 (rotldi imm0 imm0 32) DROPPED — on the little-endian
+  ;; target a 64-bit load of two LE 32-bit digits already has the low
+  ;; digit in the low half (x86-64 does no swap either).
+  (ldur imm0 (:@ val (:$ arm64::misc-data-offset))) ; ppc:312
+  (cmp imm1 (:$ arm64::two-digit-bignum-header)) ; ppc:313 (arch:662)
+  (b.eq @set-64)                        ; ppc:315
+  (b @bad)                              ; ppc:316
+  @complex-single-float                 ; ppc:317
+  (cmp imm5 (:$ arm64::subtag-complex-single-float)) ; ppc:318
+  (b.ne @bad)                           ; ppc:319
+  ;; 64-bit load grabs the {realpart,imagpart} pair as one element image
+  ;; (LE: real in low half; scalar and vector element layouts agree)
+  (ldur imm0 (:@ val (:$ arm64::complex-single-float.realpart))) ; ppc:320
+  (b @set-64)                           ; ppc:321
+  @fixnum                               ; ppc:322
+  (unbox-fixnum imm0 val)               ; ppc:323
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; cr7 re-issue
+  (b.eq @set-64)                        ; ppc:324
+  (b @bad)                              ; ppc:325
+  ;; u64 if fixnum and positive, 2-digit bignum and positive, or
+  ;; 3-digit bignum with most-significant digit 0.  ; ppc:326-327
+  @u64                                  ; ppc:328
+  (unbox-fixnum imm0 val)               ; ppc:330
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; cr7 re-issue
+  (b.ne @u64-maybe-bignum)              ; ppc:331
+  (cmp val (:$ 0))                      ; ppc:329 cr2 (re-issued at use point, signed)
+  (b.ge @set-64)                        ; ppc:332
+  (b @bad)                              ; ppc:333
+  @u64-maybe-bignum                     ; ppc:334
+  (cmp imm5 (:$ arm64::subtag-bignum))  ; cr5 re-issue
+  (b.ne @bad)                           ; ppc:335
+  (ldur imm0 (:@ val (:$ arm64::misc-data-offset))) ; ppc:336 (W8-D73: no rotldi)
+  (getvheader imm1 val)                 ; ppc:337
+  (cmp imm1 (:$ arm64::two-digit-bignum-header)) ; ppc:339
+  (b.eq @u64-two-digit)                 ; ppc:342
+  (cmp imm1 (:$ arm64::three-digit-bignum-header)) ; ppc:340 (arch:663)
+  (b.ne @bad)                           ; ppc:343
+  ;; third (most significant) digit must be 0
+  (ldr (:w imm1) (:@ val (:$ (+ 8 arm64::misc-data-offset)))) ; ppc:344 lwz @12 (4-aligned, scaled ok)
+  (cbz imm1 @set-64)                    ; ppc:345-346 (cmpwi/beq → cbz)
+  (b @bad)                              ; ppc:347
+  @u64-two-digit                        ; ppc:348
+  (cmp imm0 (:$ 0))                     ; ppc:341 cr0 (re-issued, signed)
+  (b.gt @set-64)                        ; ppc:349
+  (b @bad)                              ; ppc:350
+  @dfloat                               ; ppc:351
+  (cmp imm5 (:$ arm64::subtag-double-float)) ; ppc:352
+  (b.ne @bad)                           ; ppc:353
+  (ldur imm0 (:@ val (:$ arm64::double-float.value))) ; ppc:354 (offset 4 → ldur)
+  (b @set-64)                           ; ppc:355
+  @32                                   ; ppc:356
+  (cmp imm2 (:$ arm64::subtag-simple-base-string)) ; ppc:357
+  (b.eq @char32)                        ; ppc:360
+  (cmp imm2 (:$ arm64::subtag-s32-vector)) ; ppc:358
+  (b.eq @s32)                           ; ppc:361
+  (cmp imm2 (:$ arm64::subtag-single-float-vector)) ; ppc:359
+  (b.ne @u32)                           ; ppc:362
+  ;; @sfloat — single-floats are IMMEDIATE (bits in [63:32]) on BOTH
+  ;; PPC64 and Matt's design (his get-single-float-bits = lsr 32);
+  ;; ppc:365 ports verbatim.
+  (cmp imm5 (:$ arm64::subtag-single-float)) ; ppc:364
+  (lsr imm0 val (:$ 32))                ; ppc:365 (flag-safe)
+  (b.ne @bad)                           ; ppc:366
+  (b @set-32)                           ; ppc:367
+  @s32                                  ; ppc:368
+  ;; Must be a fixnum (and a (SIGNED-BYTE 32)).  ; ppc:369
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; cr7 re-issue
+  (b.ne @bad)                           ; ppc:370
+  (unbox-fixnum imm0 val)               ; ppc:371
+  (lsl imm1 imm0 (:$ 32))               ; ppc:372
+  (asr imm1 imm1 (:$ 32))               ; ppc:373
+  (cmp imm1 imm0)                       ; ppc:374
+  (b.ne @bad)                           ; ppc:375
+  (b @set-32)                           ; ppc:376
+  @char32                               ; ppc:377
+  (unbox-base-char imm0 val t)          ; ppc:378 — checked variant (brk #xf002, DECIDE-8)
+  (b @set-32)                           ; ppc:379
+  @u32                                  ; ppc:380
+  ;; Also has to be a fixnum (and an (UNSIGNED-BYTE 32)).  ; ppc:381
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; cr7 re-issue (ppc:384, hoisted before ands)
+  (b.ne @bad)                           ; ppc:384
+  (unbox-fixnum imm0 val)               ; ppc:382
+  (ands imm1 imm0 (:$ (ldb (byte 64 0) (lognot #xffffffff)))) ; ppc:383 clrrdi. 32 (ldb-wrap)
+  (b.ne @bad)                           ; ppc:385
+  (b @set-32)                           ; ppc:386
+  @u16                                  ; ppc:387
+  ;; fixnum-ness already checked at the residue dispatch (ppc:390 cr7)
+  (unbox-fixnum imm0 val)               ; ppc:388
+  (ands imm1 imm0 (:$ (ldb (byte 64 0) (lognot #xffff)))) ; ppc:389 clrrdi. 16 (ldb-wrap)
+  (b.ne @bad)                           ; ppc:391
+  (b @set-16)                           ; ppc:392
+  @s16                                  ; ppc:393
+  ;; fixnum-ness already checked at the residue dispatch (ppc:398 cr7)
+  ;; W8-D74: ppc:396 is cmpw (32-bit compare); full-width cmp used here is
+  ;; strictly stricter — see ledger.
+  (lsl imm0 val (:$ (- 64 (+ 16 arm64::fixnumshift))))  ; ppc:394
+  (asr imm0 imm0 (:$ (- 64 (+ 16 arm64::fixnumshift)))) ; ppc:395
+  (cmp imm0 val)                        ; ppc:396
+  (unbox-fixnum imm0 val)               ; ppc:397 (flag-safe)
+  (b.ne @bad)                           ; ppc:398-400
+  (b @set-16)                           ; ppc:399
+  @u8                                   ; ppc:401/404 (@8 arm's default = u8)
+  (extract-unsigned-byte-bits. imm0 val 8) ; ppc:404 (ror+ands; :eq iff u8 fixnum)
+  (unbox-fixnum imm0 val)               ; ppc:405 (flag-safe)
+  (b.eq @set-8)                         ; ppc:406
+  (b @bad)                              ; ppc:407
+  @s8                                   ; ppc:408
+  (cmp imm5 (:$ arm64::tag-fixnum))     ; ppc:413 cr7 (hoisted; one-NZCV)
+  (b.ne @bad)
+  (lsl imm0 val (:$ (- 64 (+ 8 arm64::fixnumshift))))  ; ppc:409
+  (asr imm0 imm0 (:$ (- 64 (+ 8 arm64::fixnumshift)))) ; ppc:410
+  (cmp imm0 val)                        ; ppc:411 (W8-D74 applies: cmpd here on PPC)
+  (unbox-fixnum imm0 val)               ; ppc:412 (flag-safe)
+  (b.ne @bad)                           ; ppc:414
+  (b @set-8)                            ; ppc:414
+  @char8                                ; ppc:416 — unreachable in the PPC64 source
+                                        ; too (base-strings are 32-bit); kept for fidelity
+  (unbox-base-char imm0 val t)          ; ppc:417
+  @set-8                                ; ppc:418 propagate low 8 bits into low 16
+  (add imm3 imm3 (:$ 1))                ; ppc:419
+  (lsl imm1 imm0 (:$ 8))                ; ppc:420 rlwimi → lsl+orr (imm1 dead here;
+  (orr imm0 imm0 imm1)                  ;   avoids bfi-lsb / shifted-orr encode landmines)
+  (lsr imm3 imm3 (:$ 1))                ; ppc:421
+  @set-16                               ; ppc:422 propagate low 16 bits into high 16
+  (add imm3 imm3 (:$ 1))                ; ppc:423
+  (lsl imm1 imm0 (:$ 16))               ; ppc:424
+  (orr imm0 imm0 imm1)
+  (lsr imm3 imm3 (:$ 1))                ; ppc:425
+  @set-32                               ; ppc:426 propagate low 32 bits into high 32
+  (add imm3 imm3 (:$ 1))                ; ppc:427
+  (lsl imm1 imm0 (:$ 32))               ; ppc:428 rldimi
+  (orr imm0 imm0 imm1)
+  (lsr imm3 imm3 (:$ 1))                ; ppc:429
+  @set-64                               ; ppc:430
+  (subs imm3 imm3 (:$ 1))               ; ppc:431-432 (subs at loop top)
+  (str imm0 (:@ miscobj imm4))          ; ppc:433 stdx (regoff)
+  (add imm4 imm4 (:$ 8))                ; ppc:434
+  (b.ne @set-64)                        ; ppc:435
+  (ret))                                ; ppc:436
+
+;;; =====================================================================
+;;; %extend-vector — ppc:575 (#+ppc64-target arm; ppc:443 arm is ppc32-only)
+;;; =====================================================================
+;;; Make a new vector of size newsize whose subtag matches that of
+;;; oldv-arg; blast old contents in, starting at start-arg.  ; ppc:438-441
+;;; Class dispatch re-keyed per W8-D70 (no 8-bit class).  The bit-vector
+;;; "hard loop" uses save4-6 on PPC; Matt's map has only save0-3
+;;; (arm64-asm.lisp:209-212) — see W8-D75 register/vstack reassignment.
+(defarm64lapfunction %extend-vector ((start-arg arg_x) (oldv-arg arg_y) (newsize arg_z))
+  (let ((oldv save0)
+        (oldsize save1)
+        (oldsubtag save2)
+        (start-offset save3))
+    (save-lisp-context)                 ; ppc:580
+    ;; ppc:581 (:regsave save3 0) — DECIDE-7: his lap DSL has no
+    ;; :regsave (16m5q xload wall: keyword forms are (MEMBER :ARGLIST
+    ;; :OPCODE)).  The vpushes below keep the NVR values GC-visible;
+    ;; the annotation's register-recovery-on-unwind semantics need a
+    ;; lap feature upstream — MAIL ITEM.
+    (vpush save0)                       ; ppc:582
+    (vpush save1)                       ; ppc:583
+    (vpush save2)                       ; ppc:584
+    (vpush save3)                       ; ppc:585
+    (mov oldv oldv-arg)                 ; ppc:586
+    (mov start-offset start-arg)        ; ppc:587
+    (getvheader imm0 oldv)              ; ppc:588
+    (header-length oldsize imm0)        ; ppc:589 boxed element count
+    (header-subtag[fixnum] oldsubtag imm0) ; ppc:590
+    (mov arg_y newsize)                 ; ppc:591
+    (mov arg_z oldsubtag)               ; ppc:592
+    (call-subprim .SPmisc-alloc)        ; ppc:593 bla — DECIDE-10 (not in Matt's table)
+    (unbox-fixnum imm0 oldsubtag)       ; ppc:594
+    (extract-fulltag imm2 imm0)         ; ppc:596 ivector class
+    (mov imm3 (:$ arm64::misc-data-offset)) ; ppc:603
+    (cbz oldsize @done)                 ; ppc:597/604 (boxed 0 = 0; cmpdi/beq → cbz)
+    ;; nodeheader test — W8-D71
+    (and imm1 imm0 (:$ arm64::tagmask)) ; ppc:595 extract-lowtag
+    (cmp imm1 (:$ arm64::tag-nodeheader)) ; ppc:598
+    (b.ne @imm)                         ; ppc:605
+    (sub imm1 start-offset (:$ (- arm64::misc-data-offset))) ; ppc:606 (boxed = byte offset)
+    ;; copy nodes.  New vector is "new", so no memoization required. ; ppc:607
+    @node-loop                          ; ppc:608
+    (subs oldsize oldsize (:$ (ash 1 arm64::fixnumshift))) ; ppc:609/612 boxed decrement (subs at top)
+    (ldr temp0 (:@ oldv imm1))          ; ppc:610 ldx (regoff)
+    (add imm1 imm1 (:$ 8))              ; ppc:611
+    (str temp0 (:@ arg_z imm3))         ; ppc:613 stdx
+    (add imm3 imm3 (:$ 8))              ; ppc:614
+    (b.ne @node-loop)                   ; ppc:615
+    ;; Restore registers.  New vector's been in arg_z all this time. ; ppc:616
+    @done                               ; ppc:617
+    (ldr save3 (:@ vsp (:$ 0)))         ; ppc:618
+    (ldr save2 (:@ vsp (:$ 8)))         ; ppc:619
+    (ldr save1 (:@ vsp (:$ 16)))        ; ppc:620
+    (ldr save0 (:@ vsp (:$ 24)))        ; ppc:621
+    (restore-full-lisp-context)         ; ppc:622 (frame vsp = entry vsp; pops the 4 slots)
+    (ret)                               ; ppc:623
+    @imm                                ; ppc:624
+    ;; W8-D70 re-key: fulltag → @32/@64; OTHER residue on subtag.
+    ;; As in PPC64 upstream, complex-double-float-vector and s16/u16 fall
+    ;; into the 16-bit loop (upstream's own comment ppc:629-630 flags the
+    ;; complex-double-float gap; behavior preserved, see ledger W8-D76).
+    (cmp imm2 (:$ arm64::ivector-class-32-bit)) ; ppc:600
+    (b.eq @32-bit)                      ; ppc:626
+    (cmp imm2 (:$ arm64::ivector-class-64-bit)) ; ppc:601
+    (b.eq @64-bit)                      ; ppc:627
+    (cmp imm0 (:$ arm64::subtag-bit-vector)) ; ppc:602 (imm0 = unboxed subtag)
+    (b.eq @1-bit)                       ; ppc:628
+    (cmp imm0 (:$ arm64::subtag-s8-vector)) ; ppc:599/625 8-bit class re-key
+    (b.eq @8-bit)
+    (cmp imm0 (:$ arm64::subtag-u8-vector))
+    (b.eq @8-bit)
+    ;; 16-bit residue (s16/u16 [+ complex-double-float-vector, W8-D76])
+    (lsr imm1 start-offset (:$ 2))      ; ppc:631 boxed → element*2 bytes
+    (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:632
+    @16-loop                            ; ppc:633
+    (subs oldsize oldsize (:$ (ash 1 arm64::fixnumshift))) ; ppc:634/637
+    (ldrh (:w imm4) (:@ oldv imm1))     ; ppc:635 lhzx
+    (add imm1 imm1 (:$ 2))              ; ppc:636
+    (strh (:w imm4) (:@ arg_z imm3))    ; ppc:638 sthx
+    (add imm3 imm3 (:$ 2))              ; ppc:639
+    (b.ne @16-loop)                     ; ppc:640
+    (b @done)                           ; ppc:641
+    @8-bit                              ; ppc:642
+    (lsr imm1 start-offset (:$ 3))      ; ppc:643 boxed → element bytes
+    (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:644
+    @8-loop                             ; ppc:645
+    (subs oldsize oldsize (:$ (ash 1 arm64::fixnumshift))) ; ppc:646/649
+    (ldrb (:w imm4) (:@ oldv imm1))     ; ppc:647 lbzx
+    (add imm1 imm1 (:$ 1))              ; ppc:648
+    (strb (:w imm4) (:@ arg_z imm3))    ; ppc:650 stbx
+    (add imm3 imm3 (:$ 1))              ; ppc:651
+    (b.ne @8-loop)                      ; ppc:652
+    (b @done)                           ; ppc:653
+    @32-bit                             ; ppc:654
+    (lsr imm1 start-offset (:$ 1))      ; ppc:655 boxed → element*4 bytes
+    (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:656
+    @32-loop                            ; ppc:657
+    (subs oldsize oldsize (:$ (ash 1 arm64::fixnumshift))) ; ppc:658/661
+    (ldr (:w imm4) (:@ oldv imm1))      ; ppc:659 lwzx
+    (add imm1 imm1 (:$ 4))              ; ppc:660
+    (str (:w imm4) (:@ arg_z imm3))     ; ppc:662 stwx
+    (add imm3 imm3 (:$ 4))              ; ppc:663
+    (b.ne @32-loop)                     ; ppc:664
+    (b @done)                           ; ppc:665
+    @64-bit                             ; ppc:666
+    (sub imm1 start-offset (:$ (- arm64::misc-data-offset))) ; ppc:667 (boxed = byte offset)
+    @64-loop                            ; ppc:668
+    (subs oldsize oldsize (:$ (ash 1 arm64::fixnumshift))) ; ppc:669/672
+    (ldr imm4 (:@ oldv imm1))           ; ppc:670 ldx
+    (add imm1 imm1 (:$ 8))              ; ppc:671
+    (str imm4 (:@ arg_z imm3))          ; ppc:673 stdx
+    (add imm3 imm3 (:$ 8))              ; ppc:674
+    (b.ne @64-loop)                     ; ppc:675
+    (b @done)                           ; ppc:676
+    @1-bit                              ; ppc:677
+    ;; W8-D75: PPC's (newv save4) (outi save5) (oldlen save6) have no
+    ;; arm64 homes.  Reassignment: oldlen → save1 (oldsize's last use is
+    ;; the subtraction), newv → save2 (oldsubtag dead after the alloc),
+    ;; outi → save0, and oldv moves to ONE vstack slot, reloaded per
+    ;; iteration (saves survive .SPmisc-ref/.SPmisc-set; vstack slot is
+    ;; GC-safe for the boxed vector).
+    (vpush oldv)                        ; ppc:681-683 analog (one slot, not three)
+    (sub save1 oldsize start-offset)    ; ppc:685 oldlen (boxed)
+    (mov save2 arg_z)                   ; ppc:684 newv
+    (mov save0 (:$ 0))                  ; ppc:686 outi = boxed 0
+    @hard-loop                          ; ppc:687
+    (ldr arg_y (:@ vsp (:$ 0)))         ; ppc:688 oldv (reloaded)
+    (mov arg_z start-offset)            ; ppc:689
+    (call-subprim .SPmisc-ref)          ; ppc:690 — DECIDE-10
+    (mov arg_x save2)                   ; ppc:691 newv
+    (mov arg_y save0)                   ; ppc:692 outi
+    (call-subprim .SPmisc-set)          ; ppc:693 — DECIDE-10
+    (add save0 save0 (:$ (ash 1 arm64::fixnumshift))) ; ppc:694
+    (add start-offset start-offset (:$ (ash 1 arm64::fixnumshift))) ; ppc:696 (flag-safe, hoisted)
+    (cmp save0 save1)                   ; ppc:695
+    (b.ne @hard-loop)                   ; ppc:697
+    (mov arg_z save2)                   ; ppc:698
+    (add vsp vsp (:$ arm64::node-size)) ; ppc:699-701 discard the oldv slot
+    (b @done)))                         ; ppc:702
+
+;;; =====================================================================
+;;; %array-header-data-and-offset — ppc:706
+;;; =====================================================================
+;;; argument is a vector header or an array header.  Or else.  ; ppc:705
+;;; PPC's cr0/cr1 subtag pair serialized: both compares re-issued
+;;; back-to-back ahead of their branches (loads/adds between are flag-safe).
+(defarm64lapfunction %array-header-data-and-offset ((a arg_z))
+  (let ((offset arg_y)
+        (disp arg_x)
+        (temp temp0))
+    (mov offset (:$ 0))                 ; ppc:710
+    (mov temp a)                        ; ppc:711
+    @loop                               ; ppc:712
+    (ldur a (:@ temp (:$ arm64::arrayH.data-vector))) ; ppc:713 (+20 → ldur)
+    (ldurb (:w imm0) (:@ a (:$ arm64::misc-subtag-offset))) ; ppc:714 lbz (LE low byte @ -4)
+    (ldur disp (:@ temp (:$ arm64::arrayH.displacement))) ; ppc:717 (+28 → ldur)
+    (mov temp a)                        ; ppc:718
+    (add offset offset disp)            ; ppc:719
+    (cmp imm0 (:$ arm64::subtag-vectorH)) ; ppc:715
+    (b.eq @loop)                        ; ppc:720
+    (cmp imm0 (:$ arm64::subtag-arrayH)) ; ppc:716 (re-issued — one NZCV)
+    (b.eq @loop)                        ; ppc:721
+    (vpush a)                           ; ppc:722
+    (vpush offset)                      ; ppc:723
+    (set-nargs 2)                       ; ppc:724
+    (add temp0 vsp (:$ (* 2 arm64::node-size))) ; ppc:725 entry-vsp for .SPvalues
+    ;; ppc:726 (ba .SPvalues) — TAIL, no-link (DECIDE-10; temp0 = entry-vsp)
+    (jump-subprim .SPvalues)))
+
+;;; =====================================================================
+;;; %simple-bit-boole — ppc:812 (#+ppc64-target arm; ppc:732 arm is ppc32-only)
+;;; =====================================================================
+;;; If the bit-arrays are all simple-bit-vector-p, do the boole op 64 bits
+;;; at a time.  ; ppc:729-730
+;;; PPC materializes the dispatch-table pc via bl/blrl/mflr; arm64 uses
+;;; adr (W8-D77).  PPC entries are 2 insns (8 bytes) so the BOXED op is
+;;; the byte offset; arm64 entries are FOUR insns (16 bytes) because
+;;; nand/nor need two ALU ops — offset = boxed-op * 2, formed by two adds
+;;; (shifted-register add avoided, encode-landmine family).
+;;; Dispatch entries are flag-free (mov/mvn/and/orr/eor/eon/bic/orn) and
+;;; end in ret; loop flags survive the blr call (W8-D78).
+(defarm64lapfunction %simple-bit-boole ((op 0) (bv1 arg_x) (bv2 arg_y) (result arg_z))
+  (add imm0 vsp (:$ 8))                 ; ppc:813 caller's vsp (one stack arg)
+  (save-lisp-context imm0)              ; ppc:814 (non-default variant; imm1 = marker scratch)
+  (vector-size imm4 result imm4)        ; ppc:815 unboxed bit count
+  (lsr imm3 imm4 (:$ 6))                ; ppc:816 srdi. — whole 64-bit words
+  (and imm4 imm4 (:$ 63))               ; ppc:817 residual bits (at most low 6 bits)
+  ;; ppc:818/820 bl @get-dispatch / mflr — the draft's `adr @label`
+  ;; doesn't exist in his lap (16m5q wall 3: adr wants a numeric
+  ;; immediate).  Use the donor's own double-link trick: bl to a
+  ;; `blr lr`, which branches straight back while re-linking lr to the
+  ;; instruction after itself = the dispatch table base (A64 BLR sets
+  ;; x30 := pc+4, exactly PPC's blrl).
+  (bl @get-dispatch)                    ; ppc:818
+  (mov imm5 lr)                         ; ppc:820 mflr loc-pc
+  (ldr temp0 (:@ vsp (:$ 0)))           ; ppc:821 boxed op
+  (add imm5 imm5 temp0)                 ; ppc:822 dispatch entry address...
+  (add imm5 imm5 temp0)                 ;   ...second add: 16-byte entries (see header)
+  (mov imm0 (:$ arm64::misc-data-offset)) ; ppc:824
+  (cbz imm3 @residual)                  ; ppc:816/825/834-835 loop gate (srdi./b @testd → cbz)
+  @nextd                                ; ppc:826
+  (ldr imm1 (:@ bv1 imm0))               ; ppc:829 ldx (regoff)
+  (ldr imm2 (:@ bv2 imm0))               ; ppc:830
+  (blr imm5)                            ; ppc:831 bctrl — entry computes imm1 = op(imm1,imm2)
+  (str imm1 (:@ result imm0))           ; ppc:832 stdx
+  (add imm0 imm0 (:$ 8))                ; ppc:833
+  (subs imm3 imm3 (:$ 1))               ; ppc:827-828 (cmpdi/subi → subs; adjacent to branch)
+  (b.ne @nextd)                         ; ppc:835
+  @residual
+  (cbz imm4 @done)                      ; ppc:819/836 (cmpdi cr1/beq → cbz)
+  ;; Not sure if we need to make this much fuss about the partial word
+  ;; in this simple case, but what the hell.  ; ppc:837-838
+  ;; W8-D79: bit-vectors are LSB-first on the LE targets (x86-64 family)
+  ;; vs MSB-first on PPC — the partial-word merge sense INVERTS: the new
+  ;; result contributes the LOW imm4 bits, the old contents keep the
+  ;; HIGH (64-imm4) bits.
+  (ldr imm1 (:@ bv1 imm0))               ; ppc:839
+  (ldr imm2 (:@ bv2 imm0))               ; ppc:840
+  (blr imm5)                            ; ppc:841
+  (ldr imm2 (:@ result imm0))           ; ppc:842 old contents
+  (lsrv imm2 imm2 imm4)                 ; ppc:843-844 clear LOW imm4 bits (sense inverted)
+  (lslv imm2 imm2 imm4)
+  (mov imm3 (:$ 64))                    ; ppc:845 subfic imm4,imm4,64 (imm3 free here)
+  (sub imm3 imm3 imm4)
+  (lslv imm1 imm1 imm3)                 ; ppc:846-847 keep LOW imm4 bits of new
+  (lsrv imm1 imm1 imm3)
+  (orr imm1 imm1 imm2)                  ; ppc:848
+  (str imm1 (:@ result imm0))           ; ppc:849
+  @done                                 ; ppc:850
+  (restore-full-lisp-context)           ; ppc:851 (restores caller vsp — pops op)
+  (ret)                                 ; ppc:852
+  @get-dispatch                         ; ppc:854
+  (blr lr)                              ; ppc:855 blrl — lr := @dispatch, branch back
+  ;; Dispatch table — ppc:856-888.  Order = boole-clr..boole-orc2 (0..15),
+  ;; exactly as PPC.  Each entry EXACTLY 4 instructions (16 bytes).
+  @dispatch
+  (mov imm1 (:$ 0))                     ; boole-clr        ; ppc:857
+  (ret) (ret) (ret)
+  (mov imm1 (:$ -1))                    ; boole-set        ; ppc:859 (movn alias)
+  (ret) (ret) (ret)
+  (ret)                                 ; boole-1          ; ppc:861 (imm1 already = b1 word)
+  (ret) (ret) (ret)
+  (mov imm1 imm2)                       ; boole-2          ; ppc:863
+  (ret) (ret) (ret)
+  (mvn imm1 imm1)                       ; boole-c1         ; ppc:865
+  (ret) (ret) (ret)
+  (mvn imm1 imm2)                       ; boole-c2         ; ppc:867
+  (ret) (ret) (ret)
+  (and imm1 imm1 imm2)                  ; boole-and        ; ppc:869
+  (ret) (ret) (ret)
+  (orr imm1 imm1 imm2)                  ; boole-ior        ; ppc:871
+  (ret) (ret) (ret)
+  (eor imm1 imm1 imm2)                  ; boole-xor        ; ppc:873
+  (ret) (ret) (ret)
+  (eon imm1 imm1 imm2)                  ; boole-eqv        ; ppc:875 (eqv = eon)
+  (ret) (ret) (ret)
+  (and imm1 imm1 imm2)                  ; boole-nand       ; ppc:877 (no arm64 nand:
+  (mvn imm1 imm1)                       ;   and+mvn — the reason entries are 16 bytes)
+  (ret) (ret)
+  (orr imm1 imm1 imm2)                  ; boole-nor        ; ppc:879 (orr+mvn)
+  (mvn imm1 imm1)
+  (ret) (ret)
+  (bic imm1 imm2 imm1)                  ; boole-andc1      ; ppc:881 (andc rS&~rB → bic)
+  (ret) (ret) (ret)
+  (bic imm1 imm1 imm2)                  ; boole-andc2      ; ppc:883
+  (ret) (ret) (ret)
+  (orn imm1 imm2 imm1)                  ; boole-orc1       ; ppc:885
+  (ret) (ret) (ret)
+  (orn imm1 imm1 imm2)                  ; boole-orc2       ; ppc:887
+  (ret) (ret) (ret))
+
+;;; =====================================================================
+;;; %aref2 / %aref3 / %aset2 / %aset3 — ppc:891-910
+;;; =====================================================================
+;;; Thin tails to the array subprims.  Register contract mirrors PPC64:
+;;; the vstack-passed array (and i, for aset3) are popped into temp0
+;;; (/temp1) before the tail jump.  None of these subprims are in Matt's
+;;; table — DECIDE-10 (no-link tail) on each.
+
+;;; from ppc-array.lisp:891
+(defarm64lapfunction %aref2 ((array arg_x) (i arg_y) (j arg_z))
+  (check-nargs 3)                       ; ppc:892
+  (jump-subprim .SParef2))              ; ppc:893 ba — TAIL no-link (DECIDE-10)
+
+;;; from ppc-array.lisp:895
+(defarm64lapfunction %aref3 ((array 0) (i arg_x) (j arg_y) (k arg_z))
+  (check-nargs 4)                       ; ppc:896
+  (vpop temp0)                          ; ppc:897 array → temp0 (subprim ABI input)
+  (jump-subprim .SParef3))              ; ppc:898 — TAIL no-link (DECIDE-10)
+
+;;; from ppc-array.lisp:901
+(defarm64lapfunction %aset2 ((array 0) (i arg_x) (j arg_y) (newval arg_z))
+  (check-nargs 4)                       ; ppc:902
+  (vpop temp0)                          ; ppc:903 array → temp0
+  (jump-subprim .SPaset2))              ; ppc:904 — TAIL no-link (DECIDE-10)
+
+;;; from ppc-array.lisp:906
+;;; PPC lambda list: ((array #.target::node-size) (i 0) ...) — array @ vsp+8,
+;;; i @ vsp+0; vpop order gives temp0 = i, temp1 = array (matches the
+;;; v2-tree subprim-ABI note: aset3 temp1=array temp0=i).
+(defarm64lapfunction %aset3 ((array 8) (i 0) (j arg_x) (k arg_y) (newval arg_z))
+  (check-nargs 5)                       ; ppc:907
+  (vpop temp0)                          ; ppc:908 i
+  (vpop temp1)                          ; ppc:909 array
+  (jump-subprim .SPaset3))              ; ppc:910 — TAIL no-link (DECIDE-10)

--- a/level-0/ARM64/arm64-bignum.lisp
+++ b/level-0/ARM64/arm64-bignum.lisp
@@ -1,0 +1,498 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-bignum.lisp — Wave-7 DRAFT port of vendor/ccl/level-0/PPC/PPC64/ppc64-bignum.lisp
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/PPC64/ppc64-bignum.lisp)
+;;; Target: Matt Emerson upstream arm64 (low-tag) design, pin d71a5ad.
+;;; Per-line citations: "; ppc:NNN" = line NNN of ppc64-bignum.lisp.
+;;; Cross-ref for ENDIANNESS (arm64 is little-endian like x86-64, NOT
+;;; big-endian like PPC64): vendor/ccl/level-0/X86/X8664/x8664-bignum.lisp
+;;; — cited "; x86:NNN".
+;;;
+;;; THE BIGNUM DIGIT-ORDER RULE (W7-D50):
+;;; CCL bignum digits are 32 bits, digit n living at byte offset
+;;; misc-data-offset + 4n.  All 32-bit accesses (lwzx/lwax/stw ↔
+;;; ldr/ldrsw/str W-forms) are therefore ENDIAN-NEUTRAL and port
+;;; line-by-line.  64-bit accesses to a digit PAIR are NOT: on
+;;; big-endian PPC64 the ld places digit n in the HIGH half, so the
+;;; PPC64 code rotldi-swaps by 32 after every ld and before every std
+;;; to get/put the LE-style value (digit n low, digit n+1 high).  On
+;;; little-endian arm64 a plain 64-bit load/store already has digit n
+;;; in the low half: EVERY ld+rotldi / rotldi+std pair collapses to a
+;;; plain ldr/str/ldur/stur.  Precedent: kernel draft
+;;; upstream-port/lisp-kernel/spentry-B-vectors-misc.s:951-953,966,
+;;; 979-980,992 ("LE: no rotldi") and wave-4 W4-D19 (%fixnum-set-natural
+;;; took the x86 shape for the same reason).  64-bit BITWISE ops on a
+;;; digit pair (%bignum-logior/logand) are order-neutral (both digits
+;;; transformed independently, stored back in place) — PPC64 itself
+;;; does no rotate there, port line-by-line.
+;;;
+;;; Alignment note: tagged misc pointer = object base + fulltag-misc(4),
+;;; so EA of a 64-bit digit-pair access [ptr + misc-data-offset(4) + 8k]
+;;; is 8-ALIGNED in memory (the +4 bias cancels the tag); 32-bit digit
+;;; accesses land 4-aligned.  misc-data-offset/misc-header-offset are
+;;; not 8-multiples, so 64-bit constant-offset forms use ldur/stur
+;;; (wave-1 convention); 32-bit forms at +4 use the scaled str/ldr
+;;; (multiple-of-4, u32-ref precedent in arm64-lapmacros-additions).
+;;;
+;;; CARRY CHAINS: PPC addc/adde/addze → adds/adcs/adc.  Every region
+;;; where the C flag is live between the setting adds and the consuming
+;;; adc is marked "C LIVE" inline; only flag-safe instructions (mul,
+;;; umulh, ldr, str, mov — none write NZCV) may intervene, mirroring
+;;; PPC where mulhdu doesn't touch CA (ppc:61-65).
+;;;
+;;; STATUS: DRAFT — not assembled; DECIDE rows in wave7-bignum-report.md.
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; %fixnum-to-bignum-set — from ppc64-bignum.lisp:24
+;;; =====================================================================
+;;; The caller has allocated a two-digit bignum (quite likely on the
+;;; stack).  If we can fit in a single digit (the high word is just a
+;;; sign extension of the low word), truncate the bignum in place.
+;;; Digit stores are 32-bit (endian-neutral, W7-D50).  The fits-in-one-
+;;; digit predicate takes the x86-64 whole-register shape (x86:26-29:
+;;; sign-extend low 32, compare with full value) because PPC's split
+;;; srawi/cmpw pair is a 32-bit-compare idiom with no 1:1 arm64 form.
+(defarm64lapfunction %fixnum-to-bignum-set ((bignum arg_y) (fixnum arg_z))
+  (unbox-fixnum imm0 fixnum)                      ; ppc:25
+  (lsr imm1 imm0 (:$ 32))                         ; ppc:26 srdi — high digit
+  (sbfx imm2 imm0 (:$ 0) (:$ 32))                           ; ppc:27 srawi 31 → sign-ext of low digit (x86:26-27 shape)
+  (cmp imm2 imm0)                                 ; ppc:28 cmpw — eq iff high = sign-ext(low)
+  (stur (:w imm0) (:@ bignum (:$ arm64::misc-data-offset)))  ; ppc:29 stw digit 0 (32-bit; -4 => STUR, 16m5q wall 4; flag-safe)
+  (mov imm2 (:$ arm64::one-digit-bignum-header))  ; ppc:30 (arch.lisp:661; flag-safe)
+  (b.eq @chop)                                    ; ppc:31
+  (stur (:w imm1) (:@ bignum (:$ (+ arm64::misc-data-offset 4)))) ; ppc:32 stw digit 1 = high word (0 unscaled => STUR pair w/ digit 0)
+  (ret)                                           ; ppc:33
+  @chop
+  (stur imm2 (:@ bignum (:$ arm64::misc-header-offset)))  ; ppc:35 std (-4 → stur)
+  (ret))                                          ; ppc:36
+
+;;; =====================================================================
+;;; %multiply-and-add-loop64 — from ppc64-bignum.lisp:39
+;;; =====================================================================
+;;; 64-bit-chunk inner multiply loop: r[i..] += x[i] * y[0..ylen-1] with
+;;; carry propagation.  All digit-pair loads/stores were ld/std+rotldi
+;;; on PPC64 (BE); on LE they are plain ldr/str (W7-D50; x86:40-67 uses
+;;; plain movq throughout).  idx is a boxed word index (= byte offset,
+;;; fixnumshift 3 = word-shift).  Register map per the PPC let: i=imm0,
+;;; j=imm1, xx=imm2, yy=imm3, rr=imm4, dd=imm5, cc=nargs (imm5=x5 and
+;;; nargs=x6 are DISTINCT in Matt's map, arm64-asm.lisp:183-185).
+(defarm64lapfunction %multiply-and-add-loop64
+    ((x (* 1 arm64::node-size)) (y 0) (r arg_x) (idx arg_y) (ylen arg_z))
+  (ldr temp0 (:@ vsp (:$ arm64::node-size)))      ; ppc:48 x bignum
+  (sub imm0 idx (:$ (- arm64::misc-data-offset)))     ; ppc:49 la i
+  (ldr imm2 (:@ temp0 imm0))                      ; ppc:50-51 ldx+rotldi x[i] → LE plain (x86:46)
+  (ldr temp0 (:@ vsp (:$ 0)))                     ; ppc:52 y bignum
+  (mov nargs (:$ 0))                              ; ppc:53 li cc 0
+  (mov imm1 (:$ arm64::misc-data-offset))         ; ppc:54 li j
+  @loop
+  (ldr imm3 (:@ temp0 imm1))                      ; ppc:56-57 ldx+rotldi y[j] → LE plain
+  (mul imm5 imm2 imm3)                            ; ppc:58 mulld — low 64 of product
+  (ldr imm4 (:@ r imm0))                          ; ppc:59-60 ldx+rotldi r[i] → LE plain
+  (adds imm4 imm4 imm5)                           ; ppc:61 addc — r[i] += low; C LIVE →
+  (umulh imm5 imm2 imm3)                          ; ppc:62 mulhdu — high 64 (flag-safe, as PPC mulhdu leaves CA)
+  (adc imm5 imm5 xzr)                             ; ppc:63 addze — dd = high + C; C DEAD
+  (adds imm4 imm4 nargs)                          ; ppc:64 addc — add carry digit; C LIVE →
+  (adc nargs imm5 xzr)                            ; ppc:65 addze — cc = dd + C; C DEAD
+  (str imm4 (:@ r imm0))                          ; ppc:66-67 rotldi+stdx → LE plain str
+  (cmp ylen (:$ (ash 1 arm64::fixnumshift)))      ; ppc:68 cmpdi '1
+  (add imm0 imm0 (:$ 8))                          ; ppc:69 (flag-safe)
+  (add imm1 imm1 (:$ 8))                          ; ppc:70 (flag-safe)
+  (sub ylen ylen (:$ (ash 1 arm64::fixnumshift))) ; ppc:71 subi '1 (flag-safe)
+  (b.ne @loop)                                    ; ppc:72
+  (str nargs (:@ r imm0))                         ; ppc:73-74 rotldi+stdx carry → LE plain (x86:66)
+  (set-nargs 0)                                   ; ppc:75
+  (add vsp vsp (:$ (* 2 arm64::node-size)))       ; ppc:76 la vsp 16
+  (ret))                                          ; ppc:77
+
+;;; =====================================================================
+;;; %multiply-and-add4 — from ppc64-bignum.lisp:82
+;;; =====================================================================
+;;; Multiply the (32-bit) digits X and Y, producing a 64-bit result.
+;;; Add the 32-bit "prev" and "carry-in" digits; return (VALUES high low).
+;;; Pure boxed arithmetic — no digit memory access, order-neutral (W7-D50);
+;;; port PPC64 line-by-line.  clrlsldi (box of low32) → ubfx + box-fixnum.
+(defarm64lapfunction %multiply-and-add4 ((x 0) (y arg_x) (prev arg_y) (carry-in arg_z))
+  (ldr temp0 (:@ vsp (:$ 0)))                     ; ppc:90 x @ vsp+0
+  (unbox-fixnum imm0 temp0)                       ; ppc:91 unboxed-x
+  (unbox-fixnum imm1 y)                           ; ppc:92 unboxed-y
+  (unbox-fixnum imm2 prev)                        ; ppc:93 unboxed-prev (arg_y consumed before high write)
+  (unbox-fixnum imm3 carry-in)                    ; ppc:94 unboxed-carry-in (arg_z consumed before low write)
+  (mul imm4 imm0 imm1)                            ; ppc:95 mulld — ≤64-bit product of two u32
+  (add imm4 imm4 imm2)                            ; ppc:96
+  (add imm4 imm4 imm3)                            ; ppc:97
+  (ubfx arg_z imm4 (:$ 0) (:$ 32))                          ; ppc:98 clrlsldi low — extract low digit
+  (box-fixnum arg_z arg_z)                        ;   ...and box
+  (lsr arg_y imm4 (:$ 32))                        ; ppc:99-100 clrrdi+srdi high — high digit
+  (box-fixnum arg_y arg_y)                        ;   ...boxed
+  (str arg_y (:@ vsp (:$ 0)))                     ; ppc:101 std high 0 vsp (overwrites x slot)
+  (set-nargs 2)                                   ; ppc:102
+  (vpush arg_z)                                   ; ppc:103 vpush low
+  (add temp0 vsp (:$ (ash 2 arm64::fixnumshift))) ; ppc:104 la temp0 '2 vsp (= entry vsp)
+  ;; ppc:105 (ba .SPvalues): TAIL no-link jump (DECIDE-10 — .SPvalues not
+  ;; in Matt's *subprims* table; wave-5 `values` precedent).
+  (jump-subprim .SPvalues))
+
+;;; =====================================================================
+;;; %multiply-and-add3 — from ppc64-bignum.lisp:107
+;;; =====================================================================
+;;; As %multiply-and-add4 without the "prev" digit.  Order-neutral.
+(defarm64lapfunction %multiply-and-add3 ((x arg_x) (y arg_y) (carry-in arg_z))
+  (unbox-fixnum imm0 x)                           ; ppc:114 unboxed-x
+  (unbox-fixnum imm1 y)                           ; ppc:115 unboxed-y
+  (unbox-fixnum imm2 carry-in)                    ; ppc:116 unboxed-carry-in
+  (mul imm3 imm0 imm1)                            ; ppc:117 mulld
+  (add imm3 imm3 imm2)                            ; ppc:118
+  (ubfx arg_z imm3 (:$ 0) (:$ 32))                          ; ppc:119 clrlsldi low (arg_z=carry-in consumed ppc:116)
+  (box-fixnum arg_z arg_z)
+  (lsr arg_y imm3 (:$ 32))                        ; ppc:120-121 clrrdi+srdi high (arg_y=y consumed ppc:115)
+  (box-fixnum arg_y arg_y)
+  (vpush arg_y)                                   ; ppc:122 vpush high
+  (set-nargs 2)                                   ; ppc:123
+  (vpush arg_z)                                   ; ppc:124 vpush low
+  (add temp0 vsp (:$ (ash 2 arm64::fixnumshift))) ; ppc:125 la temp0 '2 vsp (= entry vsp)
+  ;; ppc:126 (ba .SPvalues): TAIL no-link (DECIDE-10)
+  (jump-subprim .SPvalues))
+
+;;; =====================================================================
+;;; %multiply-and-add-fixnum-loop — from ppc64-bignum.lisp:128
+;;; =====================================================================
+;;; result[0..rlen-1] = x[0..rlen-1] * unboxed-y + carry, over 64-bit
+;;; words.  ld+rotldi / rotldi+stdx → plain ldr/str (W7-D50; x86:128-148
+;;; twin uses plain movq).  rlen and i are boxed word counts.
+;;; PPC register let: carry=imm4, iidx=imm3, unboxed-y=imm0, i=temp0,
+;;; hi=imm2, rlen=temp1 — kept 1:1.
+(defarm64lapfunction %multiply-and-add-fixnum-loop ((len64 0) (x arg_x) (y arg_y) (result arg_z))
+  (vpop temp1)                                    ; ppc:135 rlen (vpop adjusts vsp — no exit la)
+  (mov imm4 (:$ 0))                               ; ppc:136 li carry 0
+  (mov imm3 (:$ arm64::misc-data-offset))         ; ppc:137 li iidx
+  (mov temp0 (:$ 0))                              ; ppc:138 li i 0 (boxed 0)
+  (b @test)                                       ; ppc:139
+  @loop
+  (unbox-fixnum imm0 y)                           ; ppc:141
+  (ldr imm1 (:@ x imm3))                          ; ppc:142-143 ldx+rotldi x[i] → LE plain
+  (umulh imm2 imm1 imm0)                          ; ppc:144 mulhdu hi
+  (mul imm0 imm1 imm0)                            ; ppc:145 mulld low (dest = unboxed-y reg, as PPC)
+  (adds imm0 imm0 imm4)                           ; ppc:146 addc — low += carry; C LIVE →
+  (adc imm4 imm2 xzr)                             ; ppc:147 addze — carry = hi + C; C DEAD
+  (str imm0 (:@ result imm3))                     ; ppc:148-149 rotldi+stdx → LE plain
+  (add imm3 imm3 (:$ 8))                          ; ppc:150
+  (add temp0 temp0 (:$ (ash 1 arm64::fixnumshift))) ; ppc:151 la i '1
+  @test
+  (cmp temp0 temp1)                               ; ppc:153 cmpd (signed)
+  (b.lt @loop)                                    ; ppc:154
+  (str imm4 (:@ result imm3))                     ; ppc:155-156 rotldi+stdx carry → LE plain
+  (ret))                                          ; ppc:157
+
+;;; =====================================================================
+;;; %floor — from ppc64-bignum.lisp:163
+;;; =====================================================================
+;;; Return the (possibly truncated) 32-bit quotient and remainder from
+;;; dividing hi:low by divisor.  Pure register arithmetic, order-neutral.
+;;; divdu → udiv (64÷64 unsigned); remainder via mul+sub (PPC-faithful;
+;;; msub exists but keep 1:1).
+(defarm64lapfunction %floor ((num-high arg_x) (num-low arg_y) (divisor arg_z))
+  (lsl imm0 num-high (:$ (- 32 arm64::fixnumshift))) ; ppc:169 sldi — boxed high → val<<32
+  (unbox-fixnum imm1 num-low)                     ; ppc:170
+  (unbox-fixnum imm2 divisor)                     ; ppc:171
+  (orr imm0 imm0 imm1)                            ; ppc:172 combined 64-bit numerator
+  (udiv imm3 imm0 imm2)                           ; ppc:173 divdu
+  (mul imm4 imm3 imm2)                            ; ppc:174 mulld
+  (sub imm4 imm0 imm4)                            ; ppc:175 rem = num - quo*divisor
+  (ubfx arg_y imm3 (:$ 0) (:$ 32))                          ; ppc:176 clrlsldi — truncate quo to 32, box
+  (box-fixnum arg_y arg_y)
+  (ubfx arg_z imm4 (:$ 0) (:$ 32))                          ; ppc:177 clrlsldi — rem
+  (box-fixnum arg_z arg_z)
+  (mov temp0 vsp)                                 ; ppc:178 (entry vsp for .SPvalues)
+  (vpush arg_y)                                   ; ppc:179 quotient
+  (vpush arg_z)                                   ; ppc:180 remainder
+  (set-nargs 2)                                   ; ppc:181
+  ;; ppc:182 (ba .SPvalues): TAIL no-link (DECIDE-10)
+  (jump-subprim .SPvalues))
+
+;;; =====================================================================
+;;; %multiply — from ppc64-bignum.lisp:186
+;;; =====================================================================
+;;; Multiply two (UNSIGNED-BYTE 32) arguments, return (VALUES high low)
+;;; of the 64-bit result.  Order-neutral.
+(defarm64lapfunction %multiply ((x arg_y) (y arg_z))
+  (unbox-fixnum imm0 x)                           ; ppc:191
+  (unbox-fixnum imm1 y)                           ; ppc:192
+  (mul imm2 imm0 imm1)                            ; ppc:193 mulld
+  (ubfx arg_y imm2 (:$ 0) (:$ 32))                          ; ppc:194 clrlsldi — arg_y = boxed low32
+  (box-fixnum arg_y arg_y)
+  (lsr imm2 imm2 (:$ 32))                         ; ppc:195 srdi
+  (box-fixnum arg_z imm2)                         ; ppc:196 arg_z = boxed high32
+  (mov temp0 vsp)                                 ; ppc:197
+  (vpush arg_z)                                   ; ppc:198 high
+  (set-nargs 2)                                   ; ppc:199
+  (vpush arg_y)                                   ; ppc:200 low
+  ;; ppc:201 (ba .SPvalues): TAIL no-link (DECIDE-10)
+  (jump-subprim .SPvalues))
+
+;;; =====================================================================
+;;; %set-bignum-length — from ppc64-bignum.lisp:205
+;;; =====================================================================
+;;; Any words in the "tail" of the bignum should have been zeroed by the
+;;; caller.  Boxed newlen<<(num-subtag-bits - fixnumshift) = count<<8,
+;;; matching define-header (arch.lisp:653).  subtag-bignum (arch.lisp:143)
+;;; is not a guaranteed logical-immediate pattern → PPC's ori becomes
+;;; mov+orr(register) (W7-D51).
+(defarm64lapfunction %set-bignum-length ((newlen arg_y) (bignum arg_z))
+  (lsl imm0 newlen (:$ (- arm64::num-subtag-bits arm64::fixnumshift))) ; ppc:206 sldi
+  (mov imm1 (:$ arm64::subtag-bignum))            ; ppc:207 ori → mov+orr (W7-D51)
+  (orr imm0 imm0 imm1)
+  (stur imm0 (:@ bignum (:$ arm64::misc-header-offset))) ; ppc:208 std (-4 → stur)
+  (ret))                                          ; ppc:209
+
+;;; =====================================================================
+;;; %bignum-sign-bits — from ppc64-bignum.lisp:213
+;;; =====================================================================
+;;; Count the sign bits in the most significant digit; return fixnum.
+;;; The MS digit is at byte offset misc-data-offset + 4*(count-1) — a
+;;; 32-bit indexed access, endian-neutral (W7-D50; x86:213 same address
+;;; arithmetic).  cntlzw → clz (W-form); not → mvn (W-form).
+(defarm64lapfunction %bignum-sign-bits ((bignum arg_z))
+  (vector-size imm0 bignum imm0)                  ; ppc:214 — digit count
+  (lsl imm0 imm0 (:$ 2))                          ; ppc:215 sldi 2 — byte size
+  (sub imm0 imm0 (:$ (- 4 arm64::misc-data-offset))) ; ppc:216 la — offset of MS digit (= +0 on this layout; kept symbolic)
+  (ldr (:w imm0) (:@ bignum imm0))                ; ppc:217 lwzx (32-bit regoff, endian-neutral)
+  (cmp (:w imm0) (:$ 0))                          ; ppc:218 cmpwi (signed 32-bit)
+  (mvn (:w imm0) (:w imm0))                       ; ppc:219 not (flag-safe)
+  (b.lt @wasneg)                                  ; ppc:220 — negative: count leading ones (via complement)
+  (mvn (:w imm0) (:w imm0))                       ; ppc:221 not back — non-negative: count leading zeros
+  @wasneg
+  (clz (:w imm0) (:w imm0))                       ; ppc:223 cntlzw (W-form: counts within 32 bits)
+  (box-fixnum arg_z imm0)                         ; ppc:224
+  (ret))                                          ; ppc:225
+
+;;; =====================================================================
+;;; %signed-bignum-ref — from ppc64-bignum.lisp:227
+;;; =====================================================================
+;;; Sign-extended 32-bit digit read.  Boxed index n (= n<<3) >> 1 = 4n
+;;; byte offset (fixnumshift 3, same as PPC64).  lwax → ldrsw (regoff,
+;;; arm64-asm.lisp:721).  32-bit indexed access — endian-neutral (W7-D50).
+(defarm64lapfunction %signed-bignum-ref ((bignum arg_y) (index arg_z))
+  (lsr imm0 index (:$ 1))                         ; ppc:228 srdi 1 — boxed n → byte offset 4n
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset)))    ; ppc:229 la
+  (ldrsw imm0 (:@ bignum imm0))                   ; ppc:230 lwax — sign-extending 32-bit load
+  (box-fixnum arg_z imm0)                         ; ppc:231
+  (ret))                                          ; ppc:232
+
+;;; =====================================================================
+;;; %maybe-fixnum-from-one-or-two-digit-bignum — from ppc64-bignum.lisp:239
+;;; =====================================================================
+;;; One-digit → fixnum of the (signed) digit.  Two-digit → the 64-bit
+;;; digit-pair value if it fits a fixnum, else NIL.  The two-digit read
+;;; was ld+rotldi (BE digit swap) → plain ldur on LE (W7-D50; x86:245
+;;; plain movq).  The one-digit read is lwa → ldrsw (32-bit, endian-
+;;; neutral; scaled form, offset 4 = multiple of 4, arm64-asm.lisp:736).
+;;; PPC uses cr1/cr2 for the two header compares — serialized here into
+;;; sequential cmp/branch (one-NZCV rule); beqlr → b.eq to a ret label.
+;;; Header immediates (1<<8|subtag, 2<<8|subtag ≤ #x2ff) fit cmp's
+;;; 12-bit aimm.
+(defarm64lapfunction %maybe-fixnum-from-one-or-two-digit-bignum ((bignum arg_z))
+  (getvheader imm1 bignum)                        ; ppc:240 ld misc-header-offset
+  (cmp imm1 (:$ arm64::one-digit-bignum-header))  ; ppc:241 cmpdi cr1 (serialized)
+  (b.eq @one)                                     ; ppc:243 beq cr1
+  (cmp imm1 (:$ arm64::two-digit-bignum-header))  ; ppc:242 cmpdi cr2 (serialized)
+  (b.ne @no)                                      ; ppc:244 bne cr2
+  (ldur imm0 (:@ bignum (:$ arm64::misc-data-offset))) ; ppc:245-246 ld+rotldi → LE plain (x86:245)
+  (box-fixnum arg_z imm0)                         ; ppc:247 (truncates to 61 bits + tag)
+  (unbox-fixnum imm1 arg_z)                       ; ppc:248 round-trip
+  (cmp imm0 imm1)                                 ; ppc:249 — fits iff round-trip preserved
+  (b.eq @done)                                    ; ppc:250 beqlr → branch to ret
+  @no
+  (mov arg_z rnil)                                ; ppc:252 li nil
+  (ret)                                           ; ppc:253
+  @one
+  (ldursw imm0 (:@ bignum (:$ arm64::misc-data-offset))) ; ppc:255 lwa (signed 32-bit; -4 => LDURSW)
+  (box-fixnum arg_z imm0)                         ; ppc:256
+  @done
+  (ret))                                          ; ppc:257
+
+;;; =====================================================================
+;;; %digit-logical-shift-right — from ppc64-bignum.lisp:260
+;;; =====================================================================
+;;; PPC srw is a 32-bit shift with count taken mod 64 (counts 32..63 →
+;;; result 0).  A W-form lsr would take the count mod 32 (WRONG for
+;;; count=32).  The 64-bit lsr on the zero-extended digit is exact:
+;;; digit has only low-32 significance, count mod 64 identical → this is
+;;; the x86-64 shape (x86:262-267 shrq).  W7-D52.
+(defarm64lapfunction %digit-logical-shift-right ((digit arg_y) (count arg_z))
+  (unbox-fixnum imm0 digit)                       ; ppc:261 (u32 digit, zero-extended by unbox)
+  (unbox-fixnum imm1 count)                       ; ppc:262
+  (lsr imm0 imm0 imm1)                            ; ppc:263 srw → 64-bit lsrv (W7-D52; x86:265)
+  (box-fixnum arg_z imm0)                         ; ppc:264
+  (ret))                                          ; ppc:265
+
+;;; =====================================================================
+;;; %ashr — from ppc64-bignum.lisp:267
+;;; =====================================================================
+;;; PPC sraw: arithmetic 32-bit shift, count mod 64 (counts 32..63 →
+;;; all sign bits).  Exact 64-bit equivalent: sign-extend the digit to
+;;; 64 bits (x86:274 movslq shape), then 64-bit asr — identical for all
+;;; counts 0..63.  W7-D52.
+(defarm64lapfunction %ashr ((digit arg_y) (count arg_z))
+  (unbox-fixnum imm0 digit)                       ; ppc:268
+  (unbox-fixnum imm1 count)                       ; ppc:269
+  (sbfx imm0 imm0 (:$ 0) (:$ 32))                           ; x86:274 movslq — sign-extend digit
+  (asr imm0 imm0 imm1)                            ; ppc:270 sraw → 64-bit asrv (x86:275)
+  (box-fixnum arg_z imm0)                         ; ppc:271
+  (ret))                                          ; ppc:272
+
+;;; =====================================================================
+;;; %ashl — from ppc64-bignum.lisp:274
+;;; =====================================================================
+;;; PPC slw (32-bit shift left, count mod 64) followed by clrlsldi
+;;; (keep low 32, box): 64-bit lsl then extract low 32 is identical for
+;;; all counts 0..63 (x86:279-285 shlq+movl shape).  W7-D52.
+(defarm64lapfunction %ashl ((digit arg_y) (count arg_z))
+  (unbox-fixnum imm0 digit)                       ; ppc:275
+  (unbox-fixnum imm1 count)                       ; ppc:276
+  (lsl imm0 imm0 imm1)                            ; ppc:277 slw → 64-bit lslv (x86:282)
+  (ubfx imm0 imm0 (:$ 0) (:$ 32))                           ; ppc:278 clrlsldi — keep low digit (x86:283 movl)
+  (box-fixnum arg_z imm0)                         ; ppc:278 (shift-in tag)
+  (ret))                                          ; ppc:279
+
+;;; =====================================================================
+;;; macptr->fixnum — from ppc64-bignum.lisp:281
+;;; =====================================================================
+;;; If the macptr's address is 8-aligned it IS a fixnum on this tag
+;;; scheme (tag-fixnum=0, tagmask=7 — same trick as PPC64); else NIL.
+;;; (The x86:287 twin skips the alignment check; PPC's checked shape is
+;;; the safe one — kept.)
+(defarm64lapfunction macptr->fixnum ((ptr arg_z))
+  (macptr-ptr imm0 ptr)                           ; ppc:282
+  (ands imm1 imm0 (:$ arm64::tagmask))            ; ppc:283 andi. 7
+  (mov arg_z rnil)                                ; ppc:284 li nil (flag-safe)
+  (b.ne @done)                                    ; ppc:285
+  (mov arg_z imm0)                                ; ppc:286 aligned address = fixnum
+  @done
+  (ret))                                          ; ppc:288
+
+;;; =====================================================================
+;;; fix-digit-logand — from ppc64-bignum.lisp:290 (index 0)
+;;; =====================================================================
+;;; AND of a fixnum with the first digit PAIR of big (64-bit access):
+;;; ld+rotldi / rotldi+std → plain ldur/stur on LE (W7-D50; x86:294/302
+;;; plain movq; kernel precedent spentry-B-vectors-misc.s:966).  If dest
+;;; is NIL, return boxed result (PPC boxes with possible top-3-bit loss
+;;; for negative fix — faithful, not "fixed"); else store into dest's
+;;; digit pair.  cmp-to-nil then flag-safe and → b.ne, as PPC interleaves.
+(defarm64lapfunction fix-digit-logand ((fix arg_x) (big arg_y) (dest arg_z))
+  (ldur imm1 (:@ big (:$ arm64::misc-data-offset))) ; ppc:293+295 ld+rotldi → LE plain (w2)
+  (unbox-fixnum imm0 fix)                         ; ppc:294 (w1)
+  (cmp dest rnil)                                 ; ppc:296 cmpdi nil
+  (and imm0 imm0 imm1)                            ; ppc:297 (flag-safe)
+  (b.ne @store)                                   ; ppc:298
+  (box-fixnum arg_z imm0)                         ; ppc:299
+  (ret)                                           ; ppc:300
+  @store
+  (stur imm0 (:@ dest (:$ arm64::misc-data-offset))) ; ppc:302-303 rotldi+std → LE plain
+  (ret))                                          ; ppc:304
+
+;;; =====================================================================
+;;; fix-digit-logandc2 — from ppc64-bignum.lisp:308
+;;; =====================================================================
+;;; fix AND NOT big-digit-pair.  andc w1,w2 → bic Rd,Rn,Rm (Rn & ~Rm):
+;;; (andc imm1 imm0 imm1) = fix & ~big → (bic imm1 imm0 imm1).
+;;; 64-bit pair access → plain ldur/stur (W7-D50; x86:308-317).
+(defarm64lapfunction fix-digit-logandc2 ((fix arg_x) (big arg_y) (dest arg_z))
+  (cmp dest rnil)                                 ; ppc:309
+  (ldur imm1 (:@ big (:$ arm64::misc-data-offset))) ; ppc:310+312 ld+rotldi → LE plain (flag-safe)
+  (unbox-fixnum imm0 fix)                         ; ppc:311 (flag-safe)
+  (bic imm1 imm0 imm1)                            ; ppc:313 andc — fix & ~big (flag-safe)
+  (b.ne @store)                                   ; ppc:314
+  (box-fixnum arg_z imm1)                         ; ppc:315
+  (ret)                                           ; ppc:316
+  @store
+  (stur imm1 (:@ dest (:$ arm64::misc-data-offset))) ; ppc:318-319 rotldi+std → LE plain
+  (ret))                                          ; ppc:320
+
+;;; =====================================================================
+;;; fix-digit-logandc1 — from ppc64-bignum.lisp:322
+;;; =====================================================================
+;;; big-digit-pair AND NOT fix: (andc imm1 imm1 imm0) → (bic imm1 imm1 imm0).
+(defarm64lapfunction fix-digit-logandc1 ((fix arg_x) (big arg_y) (dest arg_z))
+  (cmp dest rnil)                                 ; ppc:323
+  (ldur imm1 (:@ big (:$ arm64::misc-data-offset))) ; ppc:324+326 ld+rotldi → LE plain (flag-safe)
+  (unbox-fixnum imm0 fix)                         ; ppc:325 (flag-safe)
+  (bic imm1 imm1 imm0)                            ; ppc:327 andc — big & ~fix (flag-safe)
+  (b.ne @store)                                   ; ppc:328
+  (box-fixnum arg_z imm1)                         ; ppc:329
+  (ret)                                           ; ppc:330
+  @store
+  (stur imm1 (:@ dest (:$ arm64::misc-data-offset))) ; ppc:332-333 rotldi+std → LE plain
+  (ret))                                          ; ppc:334
+
+;;; =====================================================================
+;;; %bignum-logior — from ppc64-bignum.lisp:340
+;;; =====================================================================
+;;; Do LOGIOR on the N 32-bit digits of A and B into C, 64 bits at a
+;;; time where possible.  Odd digit (if any) handled first with 32-bit
+;;; ops (endian-neutral); the 64-bit loop is a BITWISE op on digit pairs
+;;; — order-neutral, PPC itself does no rotldi here (W7-D50); port
+;;; line-by-line.  vpopped boxed N (n<<3) >>1 = total byte count 4n.
+;;; NZCV serialization is natural: andi.→b.eq, then cmpdi 4 survives
+;;; flag-safe sub/ldr/orr/str to the beqlr; in-loop cmpdi 0 survives to
+;;; the bne.  beqlr → b.eq @done (no conditional ret on arm64).
+(defarm64lapfunction %bignum-logior ((n 0) (a arg_x) (b arg_y) (c arg_z))
+  (vpop imm0)                                     ; ppc:341
+  (lsr imm0 imm0 (:$ 1))                          ; ppc:342 srdi 1 — boxed n → byte count
+  (ands imm1 imm0 (:$ 4))                         ; ppc:343 andi. — odd digit count?
+  (sub imm3 imm0 (:$ (- arm64::misc-data-offset)))    ; ppc:344 la (flag-safe)
+  (b.eq @loop)                                    ; ppc:345
+  (cmp imm0 (:$ 4))                               ; ppc:346 — was that the ONLY digit?
+  (sub imm0 imm0 (:$ 4))                          ; ppc:347 (flag-safe)
+  (sub imm3 imm3 (:$ 4))                          ; ppc:348 (flag-safe)
+  (ldr (:w imm1) (:@ a imm3))                     ; ppc:349 lwzx (32-bit, endian-neutral)
+  (ldr (:w imm2) (:@ b imm3))                     ; ppc:350 lwzx
+  (orr (:w imm1) (:w imm1) (:w imm2))             ; ppc:351 (flag-safe)
+  (str (:w imm1) (:@ c imm3))                     ; ppc:352 stwx
+  (b.eq @done)                                    ; ppc:353 beqlr
+  @loop
+  (sub imm0 imm0 (:$ 8))                          ; ppc:355
+  (sub imm3 imm3 (:$ 8))                          ; ppc:356
+  (cmp imm0 (:$ 0))                               ; ppc:357 (can't be equal on 1st iteration)
+  (ldr imm1 (:@ a imm3))                          ; ppc:358 ldx — digit pair (bitwise: order-neutral)
+  (ldr imm2 (:@ b imm3))                          ; ppc:359 ldx
+  (orr imm1 imm1 imm2)                            ; ppc:360 (flag-safe)
+  (str imm1 (:@ c imm3))                          ; ppc:361 stdx
+  (b.ne @loop)                                    ; ppc:362
+  @done
+  (ret))                                          ; ppc:363
+
+;;; =====================================================================
+;;; %bignum-logand — from ppc64-bignum.lisp:370
+;;; =====================================================================
+;;; Identical shape to %bignum-logior with AND.
+(defarm64lapfunction %bignum-logand ((n 0) (a arg_x) (b arg_y) (c arg_z))
+  (vpop imm0)                                     ; ppc:371
+  (lsr imm0 imm0 (:$ 1))                          ; ppc:372
+  (ands imm1 imm0 (:$ 4))                         ; ppc:373
+  (sub imm3 imm0 (:$ (- arm64::misc-data-offset)))    ; ppc:374 (flag-safe)
+  (b.eq @loop)                                    ; ppc:375
+  (cmp imm0 (:$ 4))                               ; ppc:376
+  (sub imm0 imm0 (:$ 4))                          ; ppc:377 (flag-safe)
+  (sub imm3 imm3 (:$ 4))                          ; ppc:378 (flag-safe)
+  (ldr (:w imm1) (:@ a imm3))                     ; ppc:379 lwzx (32-bit, endian-neutral)
+  (ldr (:w imm2) (:@ b imm3))                     ; ppc:380 lwzx
+  (and (:w imm1) (:w imm1) (:w imm2))             ; ppc:381 (flag-safe)
+  (str (:w imm1) (:@ c imm3))                     ; ppc:382 stwx
+  (b.eq @done)                                    ; ppc:383 beqlr
+  @loop
+  (sub imm0 imm0 (:$ 8))                          ; ppc:385
+  (sub imm3 imm3 (:$ 8))                          ; ppc:386
+  (cmp imm0 (:$ 0))                               ; ppc:387
+  (ldr imm1 (:@ a imm3))                          ; ppc:388 ldx (bitwise pair: order-neutral)
+  (ldr imm2 (:@ b imm3))                          ; ppc:389 ldx
+  (and imm1 imm1 imm2)                            ; ppc:390 (flag-safe)
+  (str imm1 (:@ c imm3))                          ; ppc:391 stdx
+  (b.ne @loop)                                    ; ppc:392
+  @done
+  (ret))                                          ; ppc:393

--- a/level-0/ARM64/arm64-clos.lisp
+++ b/level-0/ARM64/arm64-clos.lisp
@@ -1,0 +1,352 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-clos.lisp — Wave-8 DRAFT port of vendor/ccl/level-0/PPC/ppc-clos.lisp
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/ppc-clos.lisp)
+;;; Target: Matt Emerson upstream arm64 (low-tag) design, pin d71a5ad.
+;;; Per-line citations: "; ppc:NNN" = line NNN of vendor/ccl/level-0/PPC/ppc-clos.lisp.
+;;; Cross-ref (same low-tag family): vendor/ccl/level-0/X86/x86-clos.lisp ("; x86:NNN").
+;;;
+;;; CLOS slot indices (slot-id.index, gf.dispatch-table, gf.dcode, ...) are
+;;; TARGET-INDEPENDENT def-accessors enums from vendor/ccl/library/lispequ.lisp
+;;; (slot-id: :1208-1212 → slot-id.index = 2; generic-function: :1186-1194 →
+;;; gf.dispatch-table = 3, gf.dcode = 4).  Used by NAME, as on PPC.
+;;;
+;;; FUNCTION OBJECTS (W8-D80, updated by the fulltag-function removal,
+;;; patch 0055): generic functions and dcode functions are ordinary
+;;; miscobjs.  Slot k of a function is at
+;;;   (+ (* k arm64::node-size) arm64::misc-function-offset)     [-4 + 8k]
+;;; (misc-function-offset = misc-data-offset now, so these are just the
+;;; usual misc slot loads) and the final dispatch is ldur codevector
+;;; @ -4 + br.  slot-id objects are istructs — plain svref applies.
+;;;
+;;; ONE-NZCV: PPC's cmplr/cmpri pairs are serialized — unsigned bounds
+;;; compare (cmplr → b.hs) issued adjacent to its branch; the map-entry
+;;; zero test (cmpri/cmpwi 0 → cbz) uses no flags at all.
+;;;
+;;; STATUS: DRAFT — not assembled; ledger in wave8-array-clos-report.md.
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; It's easier to keep this in LAP; we want to play around with its
+;;; constants.  ; ppc:19-20
+
+;;; =====================================================================
+;;; %small-map-slot-id-lookup — ppc:25
+;;; =====================================================================
+;;; This just maps a SLOT-ID to a SLOT-DEFINITION or NIL.
+;;; The map is a vector of (UNSIGNED-BYTE 8); this should
+;;; be used when there are less than 255 slots in the class.  ; ppc:22-24
+;;; 'map / 'table are function-constant-pool refs (DECIDE-14).
+(defarm64lapfunction %small-map-slot-id-lookup ((slot-id arg_z))
+  (ldur temp1 (:@ nfn (:$ 'map)))             ; ppc:26 — DECIDE-14
+  (svref arg_x slot-id.index slot-id)   ; ppc:27 boxed index (istruct: plain svref)
+  (getvheader imm0 temp1)               ; ppc:28
+  (header-length imm3 imm0)             ; ppc:29 boxed map length
+  (ldur temp0 (:@ nfn (:$ 'table)))           ; ppc:30 — DECIDE-14
+  (lsr imm0 arg_x (:$ arm64::word-shift)) ; ppc:32 srri — boxed → raw byte index (u8 map)
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset))) ; ppc:33
+  (mov imm1 (:$ arm64::misc-data-offset)) ; ppc:34 out-of-bounds default: table[0]
+  (cmp arg_x imm3)                      ; ppc:31 cmplr — UNSIGNED, issued adjacent to branch
+  (b.hs @have-scaled-table-index)       ; ppc:35 bge on cmplr → b.hs
+  (ldrb (:w imm1) (:@ temp1 imm0))      ; ppc:36 lbzx — map entry
+  (lsl imm1 imm1 (:$ arm64::word-shift)) ; ppc:37
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:38
+  @have-scaled-table-index              ; ppc:39
+  (ldr arg_z (:@ temp0 imm1))           ; ppc:40 ldrx (regoff)
+  (ret))                                ; ppc:41
+
+;;; =====================================================================
+;;; %large-map-slot-id-lookup — ppc:44 [ppc64-sections: ppc64 arm ported;
+;;;   the #+pp32-target (sic) arm ignored]
+;;; =====================================================================
+;;; The same idea, only the map is a vector of (UNSIGNED-BYTE 32).  ; ppc:43
+(defarm64lapfunction %large-map-slot-id-lookup ((slot-id arg_z))
+  (ldur temp1 (:@ nfn (:$ 'map)))             ; ppc:45 — DECIDE-14
+  (svref arg_x slot-id.index slot-id)   ; ppc:46
+  (getvheader imm0 temp1)               ; ppc:47
+  (header-length imm3 imm0)             ; ppc:48
+  (ldur temp0 (:@ nfn (:$ 'table)))           ; ppc:49 — DECIDE-14
+  ;; W8-D81 UPSTREAM BUG: ppc:53 reads (srdi imm0 imm0 1), but imm0 holds
+  ;; the map HEADER there; the boxed index is in arg_x (compare the
+  ;; parallel %large-slot-id-value, ppc:105 (srdi imm0 arg_x 1)).  Ported
+  ;; with the intended source register.  Queue for the next Matt mail.
+  (lsr imm0 arg_x (:$ 1))               ; ppc:53 boxed → index*4 (u32 map)
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset))) ; ppc:54
+  (mov imm1 (:$ arm64::misc-data-offset)) ; ppc:58
+  (cmp arg_x imm3)                      ; ppc:50 cmplr — adjacent to branch
+  (b.hs @have-scaled-table-index)       ; ppc:59
+  (ldr (:w imm1) (:@ temp1 imm0))       ; ppc:60 lwzx — map entry
+  (lsl imm1 imm1 (:$ arm64::word-shift)) ; ppc:61
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:62
+  @have-scaled-table-index              ; ppc:63
+  (ldr arg_z (:@ temp0 imm1))           ; ppc:64
+  (ret))                                ; ppc:65
+
+;;; =====================================================================
+;;; %small-slot-id-value — ppc:67
+;;; =====================================================================
+(defarm64lapfunction %small-slot-id-value ((instance arg_y) (slot-id arg_z))
+  (ldur temp1 (:@ nfn (:$ 'map)))             ; ppc:68 — DECIDE-14
+  (svref arg_x slot-id.index slot-id)   ; ppc:69
+  (getvheader imm0 temp1)               ; ppc:70
+  (ldur temp0 (:@ nfn (:$ 'table)))           ; ppc:71 — DECIDE-14
+  (header-length imm3 imm0)             ; ppc:72
+  (lsr imm0 arg_x (:$ arm64::word-shift)) ; ppc:74
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset))) ; ppc:75
+  (cmp arg_x imm3)                      ; ppc:73 cmplr — adjacent to branch
+  (b.hs @missing)                       ; ppc:76
+  (ldrb (:w imm1) (:@ temp1 imm0))      ; ppc:77 lbzx
+  (cbz imm1 @missing)                   ; ppc:78/81 (cmpri 0 / beq → cbz, before scaling)
+  (lsl imm1 imm1 (:$ arm64::word-shift)) ; ppc:79
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:80
+  (ldr arg_z (:@ temp0 imm1))           ; ppc:82 slot-definition
+  (ldur arg_x (:@ nfn (:$ 'class)))           ; ppc:83 — DECIDE-14
+  (ldur nfn (:@ nfn (:$ '%maybe-std-slot-value))) ; ppc:84 — DECIDE-14 (last nfn use first)
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:85 codevector — W8-D80
+  (set-nargs 3)                         ; ppc:86
+  (br temp0)                            ; ppc:87-88 mtctr/bctr
+  @missing                              ; ppc:89 (%slot-id-ref-missing instance id)
+  (ldur nfn (:@ nfn (:$ '%slot-id-ref-missing))) ; ppc:90 — DECIDE-14
+  (set-nargs 2)                         ; ppc:91
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:92 — W8-D80
+  (br temp0))                           ; ppc:93-94
+
+;;; =====================================================================
+;;; %large-slot-id-value — ppc:96 [mixed-arch-body: ppc64 arm ported]
+;;; =====================================================================
+(defarm64lapfunction %large-slot-id-value ((instance arg_y) (slot-id arg_z))
+  (ldur temp1 (:@ nfn (:$ 'map)))             ; ppc:97 — DECIDE-14
+  (svref arg_x slot-id.index slot-id)   ; ppc:98
+  (getvheader imm0 temp1)               ; ppc:99
+  (ldur temp0 (:@ nfn (:$ 'table)))           ; ppc:100 — DECIDE-14
+  (header-length imm3 imm0)             ; ppc:101
+  (lsr imm0 arg_x (:$ 1))               ; ppc:104-105 #+ppc64 arm: boxed → index*4
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset))) ; ppc:106
+  (cmp arg_x imm3)                      ; ppc:102 cmplr — adjacent to branch
+  (b.hs @missing)                       ; ppc:110
+  (ldr (:w imm1) (:@ temp1 imm0))       ; ppc:111 lwzx
+  (cbz imm1 @missing)                   ; ppc:112/115 (cmpri 0 / beq → cbz)
+  (lsl imm1 imm1 (:$ arm64::word-shift)) ; ppc:113
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:114
+  @have-scaled-table-index              ; ppc:116 (vestigial label in PPC too — kept)
+  (ldur arg_x (:@ nfn (:$ 'class)))           ; ppc:117 — DECIDE-14
+  (ldur nfn (:@ nfn (:$ '%maybe-std-slot-value-using-class))) ; ppc:118 — DECIDE-14
+  (ldr arg_z (:@ temp0 imm1))           ; ppc:119 slot-definition
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:120 — W8-D80
+  (set-nargs 3)                         ; ppc:121
+  (br temp0)                            ; ppc:122-123
+  @missing                              ; ppc:124 (%slot-id-ref-missing instance id)
+  (ldur nfn (:@ nfn (:$ '%slot-id-ref-missing))) ; ppc:125 — DECIDE-14
+  (set-nargs 2)                         ; ppc:126
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:127 — W8-D80
+  (br temp0))                           ; ppc:128-129
+
+;;; =====================================================================
+;;; %small-set-slot-id-value — ppc:131
+;;; =====================================================================
+;;; header-length lands in imm5, as on PPC.  (imm5=x5 and nargs=x6 are
+;;; DISTINCT on Matt's map — corrected record; even under aliasing this
+;;; would be safe: last read precedes both set-nargs forms, and entry
+;;; nargs is dead — no check-nargs in the PPC original.)
+(defarm64lapfunction %small-set-slot-id-value ((instance arg_x)
+                                               (slot-id arg_y)
+                                               (new-value arg_z))
+  (ldur temp1 (:@ nfn (:$ 'map)))             ; ppc:134 — DECIDE-14
+  (svref imm3 slot-id.index slot-id)    ; ppc:135 boxed index
+  (getvheader imm0 temp1)               ; ppc:136
+  (ldur temp0 (:@ nfn (:$ 'table)))           ; ppc:137 — DECIDE-14
+  (header-length imm5 imm0)             ; ppc:138 (imm5 scratch — distinct from nargs, see above)
+  (lsr imm0 imm3 (:$ arm64::word-shift)) ; ppc:140
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset))) ; ppc:141
+  (cmp imm3 imm5)                       ; ppc:139 cmplr — adjacent to branch
+  (b.hs @missing)                       ; ppc:142
+  (ldrb (:w imm1) (:@ temp1 imm0))      ; ppc:143 lbzx
+  (cbz imm1 @missing)                   ; ppc:144/147 (cmpwi 0 / beq → cbz)
+  (lsl imm1 imm1 (:$ arm64::word-shift)) ; ppc:145
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:146
+  @have-scaled-table-index              ; ppc:148
+  (ldur temp1 (:@ nfn (:$ 'class)))           ; ppc:149 — DECIDE-14
+  (ldr arg_y (:@ temp0 imm1))           ; ppc:150 slot-definition (overwrites slot-id)
+  (ldur nfn (:@ nfn (:$ '%maybe-std-setf-slot-value-using-class))) ; ppc:151 — DECIDE-14
+  (set-nargs 4)                         ; ppc:152
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:153 — W8-D80
+  (vpush temp1)                         ; ppc:154 class = first (vstack) arg
+  (br temp0)                            ; ppc:155-156
+  @missing                              ; ppc:157 (%slot-id-set-missing instance id new-value)
+  (ldur nfn (:@ nfn (:$ '%slot-id-set-missing))) ; ppc:158 — DECIDE-14
+  (set-nargs 3)                         ; ppc:159
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:160 — W8-D80
+  (br temp0))                           ; ppc:161-162
+
+;;; =====================================================================
+;;; %large-set-slot-id-value — ppc:164 [ppc64-sections: ppc64 arm ported]
+;;; =====================================================================
+(defarm64lapfunction %large-set-slot-id-value ((instance arg_x)
+                                               (slot-id arg_y)
+                                               (new-value arg_z))
+  (ldur temp1 (:@ nfn (:$ 'map)))             ; ppc:167 — DECIDE-14
+  (svref imm3 slot-id.index slot-id)    ; ppc:168
+  (getvheader imm0 temp1)               ; ppc:169
+  (ldur temp0 (:@ nfn (:$ 'table)))           ; ppc:170 — DECIDE-14
+  (header-length imm5 imm0)             ; ppc:171 (imm5 scratch, as in the small twin)
+  (cmp imm3 imm5)                       ; ppc:172 cmplr — BEFORE the index is halved (as PPC)
+  (lsr imm3 imm3 (:$ 1))                ; ppc:173 #+ppc64 arm: boxed → index*4 (flag-safe)
+  (sub imm0 imm3 (:$ (- arm64::misc-data-offset))) ; ppc:174 (flag-safe)
+  (b.hs @missing)                       ; ppc:175
+  (ldr (:w imm1) (:@ temp1 imm0))       ; ppc:176 lwzx
+  (cbz imm1 @missing)                   ; ppc:177/180 (cmpwi 0 / beq → cbz)
+  (lsl imm1 imm1 (:$ arm64::word-shift)) ; ppc:178
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset))) ; ppc:179
+  @have-scaled-table-index              ; ppc:181
+  (ldur temp1 (:@ nfn (:$ 'class)))           ; ppc:182 — DECIDE-14
+  (ldr arg_y (:@ temp0 imm1))           ; ppc:183 slot-definition
+  (ldur nfn (:@ nfn (:$ '%maybe-std-setf-slot-value-using-class))) ; ppc:184 — DECIDE-14
+  (set-nargs 4)                         ; ppc:185
+  ;; ppc:186 is (svref temp0 0 nfn) — same load as the small twin's
+  ;; (ldr temp0 misc-data-offset nfn); nfn is FUNCTION-tagged → W8-D80.
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:186 — W8-D80
+  (vpush temp1)                         ; ppc:187
+  (br temp0)                            ; ppc:188-189
+  @missing                              ; ppc:190 (%slot-id-set-missing instance id new-value)
+  ;; ppc:191 loads '%slot-id-ref-missing (with set-nargs 3) although the
+  ;; comment and the small twin (ppc:158) say %slot-id-set-missing.
+  ;; x86-64 does the SAME (x86:151-153: set-missing comment,
+  ;; ref-missing load) — a cross-arch upstream quirk, ported FAITHFULLY.
+  ;; W8-D82 ledger note.
+  (ldur nfn (:@ nfn (:$ '%slot-id-ref-missing))) ; ppc:191 — DECIDE-14
+  (set-nargs 3)                         ; ppc:192
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:193 — W8-D80
+  (br temp0))                           ; ppc:194-195
+
+;;; =====================================================================
+;;; *gf-proto* — ppc:197-218 (#-dont-use-lexprs branch; W8-D83 closed
+;;; 16m10, demanded by l1-dcode load: register-dcode-proto references)
+;;; =====================================================================
+;;; The gag lexpr prototype CLOS instantiates for real gfs.  PPC keeps
+;;; the caller's return pc in loc_pc across .SPlexpr-entry (mflr/mtlr);
+;;; Matt's map has no loc_pc, so the LEXPR-RA channel is temp4 (spentry-E
+;;; lexpr_entry contract): prologue passes caller's return pc in temp4,
+;;; the subprim hands back the continuation the body must return through
+;;; (ret1val_addr on the mv path, lexpr_return1v on the 1v path) in
+;;; temp4, restored into lr before the tail transfer.  call-subprim
+;;; clobbers only imm1+lr, so temp4 survives into the kernel.  nfn (the
+;;; gf) is untouched by lexpr_entry; gf.dispatch-table = 3, gf.dcode = 4
+;;; (lispequ.lisp:1186-1194), both svrefs re-bias per W8-D80.
+(defparameter *gf-proto*
+  (nfunction
+   gag
+   (lambda (&lap &lexpr args)
+     (arm64-lap-function
+      gag
+      ()
+      (mov temp4 lr)                        ; ppc:205 (mflr loc-pc) — LEXPR-RA
+      (vpush-argregs)                       ; ppc:206
+      (vpush nargs)                         ; ppc:207
+      (add imm0 vsp nargs)                  ; ppc:208
+      (add imm0 imm0 (:$ arm64::node-size)) ; ppc:209 caller's vsp
+      (call-subprim .SPlexpr-entry)         ; ppc:210 (bla) — DECIDE-10
+      (mov lr temp4)                        ; ppc:211 (mtlr loc-pc) — lexpr cleanup continuation
+      (mov arg_z vsp)                       ; ppc:212 lexpr
+      (ldur arg_y (:@ nfn (:$ (+ (* gf.dispatch-table arm64::node-size)
+                                 arm64::misc-function-offset)))) ; ppc:213 dispatch table
+      (set-nargs 2)                         ; ppc:214
+      (ldur nfn (:@ nfn (:$ (+ (* gf.dcode arm64::node-size)
+                               arm64::misc-function-offset))))   ; ppc:215 dcode function
+      (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset)))     ; ppc:216 codevector — W8-D80
+      (br temp0)))))                        ; ppc:217-218 — DECIDE-15
+
+;;; =====================================================================
+;;; funcallable-trampoline — ppc:271
+;;; =====================================================================
+;;; nfn is the funcallable instance = a FUNCTION-tagged gvector: both
+;;; svrefs re-bias to misc-function-offset (W8-D80).
+;;; gf.dcode = 4 (lispequ.lisp:1186-1194).
+(defarm64lapfunction funcallable-trampoline ()
+  (ldur nfn (:@ nfn (:$ (+ (* gf.dcode arm64::node-size)
+                           arm64::misc-function-offset)))) ; ppc:272 (svref gf.dcode)
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset)))   ; ppc:273 (svref 0 = codevector)
+  (br temp0))                           ; ppc:274-275 mtctr/bctr — DECIDE-15
+
+;;; =====================================================================
+;;; unset-fin-trampoline — ppc:278
+;;; =====================================================================
+;;; This can't reference any of the function's constants.  ; ppc:277
+;;; (Satisfied: only subprims, immediates and rnil below.)
+;;; PPC saves lr in loc-pc across the first subprim call and only builds
+;;; a frame later via .SPsavecontextvsp.  No loc-pc register here: build
+;;; the marker frame at ENTRY (savevsp is identical — .SPheap-rest-arg's
+;;; push is popped again before PPC's frame is built) and let the frame
+;;; carry lr across both subprim calls (W4-D17 idiom).
+(defarm64lapfunction unset-fin-trampoline ()
+  (build-lisp-frame)                    ; ppc:279 (mflr loc-pc) + ppc:282 (.SPsavecontextvsp)
+  (call-subprim .SPheap-rest-arg)       ; ppc:280 cons up &rest arg, vpush it — DECIDE-10
+  (vpop arg_z)                          ; ppc:281 whoops, didn't really want to
+  (mov arg_x (:$ (ash $xnofinfunction arm64::fixnumshift))) ; ppc:283 li '#.$XNOFINFUNCTION
+  (mov arg_y nfn)                       ; ppc:284
+  (set-nargs 3)                         ; ppc:285
+  (call-subprim .SPksignalerr)          ; ppc:286 — DECIDE-10
+  (mov arg_z rnil)                      ; ppc:287
+  (restore-lisp-frame)                  ; ppc:288 (ba .SPpopj) → inline restore+ret (W5 idiom)
+  (ret))
+
+;;; =====================================================================
+;;; gag-one-arg — ppc:291
+;;; =====================================================================
+;;; is a winner - saves ~15%  ; ppc:290
+;;; nfn = the gf (FUNCTION-tagged): gf.dispatch-table = 3, gf.dcode = 4
+;;; (lispequ.lisp:1186-1194); both svrefs re-bias per W8-D80.
+(defarm64lapfunction gag-one-arg ((arg arg_z))
+  (check-nargs 1)                       ; ppc:292
+  (ldur arg_y (:@ nfn (:$ (+ (* gf.dispatch-table arm64::node-size)
+                             arm64::misc-function-offset)))) ; ppc:293 dispatch table first
+  (set-nargs 2)                         ; ppc:294
+  (ldur nfn (:@ nfn (:$ (+ (* gf.dcode arm64::node-size)
+                           arm64::misc-function-offset))))   ; ppc:295 dcode function
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset)))     ; ppc:296 codevector — W8-D80
+  (br temp0))                           ; ppc:297-298 — DECIDE-15
+
+;;; =====================================================================
+;;; gag-two-arg — ppc:301
+;;; =====================================================================
+(defarm64lapfunction gag-two-arg ((arg0 arg_y) (arg1 arg_z))
+  (check-nargs 2)                       ; ppc:302
+  (ldur arg_x (:@ nfn (:$ (+ (* gf.dispatch-table arm64::node-size)
+                             arm64::misc-function-offset)))) ; ppc:303 dispatch table first
+  (set-nargs 3)                         ; ppc:304
+  (ldur nfn (:@ nfn (:$ (+ (* gf.dcode arm64::node-size)
+                           arm64::misc-function-offset))))   ; ppc:305 dcode function
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset)))     ; ppc:306 codevector — W8-D80
+  (br temp0))                           ; ppc:307-308 — DECIDE-15
+
+;;; =====================================================================
+;;; *cm-proto* — ppc:310-330 (W8-D83 closed 16m10)
+;;; =====================================================================
+;;; Combined-method prototype: same lexpr shape as *gf-proto* (LEXPR-RA
+;;; temp4 channel, see the *gf-proto* header comment).  Slots differ:
+;;; combined-method.thing = 1, combined-method.dcode = 2
+;;; (lispequ.lisp:1178-1184); both svrefs re-bias per W8-D80.
+(defparameter *cm-proto*
+  (nfunction
+   gag
+   (lambda (&lap &lexpr args)
+     (arm64-lap-function
+      gag
+      ()
+      (mov temp4 lr)                        ; ppc:317 (mflr loc-pc) — LEXPR-RA
+      (vpush-argregs)                       ; ppc:318
+      (vpush nargs)                         ; ppc:319
+      (add imm0 vsp nargs)                  ; ppc:320
+      (add imm0 imm0 (:$ arm64::node-size)) ; ppc:321 caller's vsp
+      (call-subprim .SPlexpr-entry)         ; ppc:322 (bla) — DECIDE-10
+      (mov lr temp4)                        ; ppc:323 (mtlr loc-pc) — lexpr cleanup continuation
+      (mov arg_z vsp)                       ; ppc:324 lexpr
+      (ldur arg_y (:@ nfn (:$ (+ (* combined-method.thing arm64::node-size)
+                                 arm64::misc-function-offset)))) ; ppc:325 thing
+      (set-nargs 2)                         ; ppc:326
+      (ldur nfn (:@ nfn (:$ (+ (* combined-method.dcode arm64::node-size)
+                               arm64::misc-function-offset))))   ; ppc:327 dcode function
+      (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset)))     ; ppc:328 codevector — W8-D80
+      (br temp0)))))                        ; ppc:329-330 — DECIDE-15

--- a/level-0/ARM64/arm64-def.lisp
+++ b/level-0/ARM64/arm64-def.lisp
@@ -1,0 +1,575 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-def.lisp — ACTIVE seed (demand-driven from cold-load fatals;
+;;; lifted from upstream-port/level-0/drafts/arm64-def.lisp wave-4).
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/ppc-def.lisp)
+;;; Per-line citations: "; ppc:NNN" = line NNN of that file.
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+
+
+
+
+
+
+
+
+
+
+;;; =====================================================================
+;;; %function-vector-to-function / %function-to-function-vector — IDENTITY
+;;; since the fulltag_function removal (patch 0055): a function IS its
+;;; uvector, as on PPC64 (one misc-tagged object).  The type check is
+;;; kept (x86-def.lisp:21 precedent) so a non-function still traps; the
+;;; retag arithmetic is gone.  Callers (nfasload/l0-def/l1 builders)
+;;; flow through unchanged.
+(defarm64lapfunction %function-vector-to-function ((arg arg_z))
+  (trap-unless-typecode= arg arm64::subtag-function) ; x86:21
+  (ret))
+
+(defarm64lapfunction %function-to-function-vector ((arg arg_z))
+  (trap-unless-typecode= arg arm64::subtag-function)
+  (ret))
+
+;;; %nth-immediate — immediate (constant) N of a function.  Donor by NAME
+;;; = x86-def.lisp:37, but the body follows MATT'S arm64 function shape
+;;; {code-vector@slot0, constants@slot1..} (16k4 / e4440cb), NOT x8664's
+;;; inline-code layout: immediate n = uvector slot (1+ n).  fun is
+;;; misc-tagged (fulltag-function removed, patch 0055): slot(1+n) sits at
+;;; fun-12+8+8(1+n) = fun+4+8n, and boxed n IS 8n — one add + unscaled ldur.
+(defarm64lapfunction %nth-immediate ((fun arg_y) (n arg_z))
+  (trap-unless-typecode= fun arm64::subtag-function)
+  (add imm0 fun n)
+  (ldur arg_z (:@ imm0 (:$ (+ arm64::misc-data-offset arm64::node-size))))
+  (ret))
+
+;;; %set-nth-immediate — setter twin, donor x86-def.lisp:45 (16m11b
+;;; demand: l1-clos-boot gf-dcode install).  Store goes through .SPgvset
+;;; for the GC write barrier (x86:50 jmp .SPgvset), never inline.
+;;; gvset contract (spentry-B:77): arg_x = misc-tagged vector, arg_y =
+;;; boxed slot index (= byte offset at fixnumshift 3), arg_z = value.
+;;; Slot = (1+ n) on Matt's {cv@0, imms@1..} shape — x86:47-48's
+;;; code-words lookup drops out (no inline code here).
+(defarm64lapfunction %set-nth-immediate ((fun arg_x) (n arg_y) (new arg_z))
+  (trap-unless-typecode= fun arm64::subtag-function)  ; x86:46
+  (add arg_y n (:$ (ash 1 arm64::fixnumshift)))       ; boxed 1+n
+  ;; fun is already the misc-tagged vector (fulltag-function removed,
+  ;; patch 0055) — no retag before .SPgvset.
+  (jump-subprim .SPgvset))                            ; x86:50
+
+;;; closure-function — x86-def.lisp:496 verbatim (his function shape:
+;;; a closure's inner function = immediate 0, with the vector
+;;; indirection for lfun-vector-reached cases).  16m5t demand.
+(defun closure-function (fun)
+  (while (and (functionp fun)  (not (compiled-function-p fun)))
+    (setq fun (%nth-immediate fun 0))
+    (when (vectorp fun)
+      (setq fun (svref fun 0))))
+  fun)
+
+;;; =====================================================================
+;;; PPC compares nargs on cr0 BEFORE check-nargs; Matt's check-nargs is
+;;; itself cmp-based (one NZCV) so the compare moves AFTER it (x86:175 order).
+
+(defarm64lapfunction %fixnum-ref ((fixnum arg_y) #| &optional |# (offset arg_z))
+  (check-nargs 1 2)                     ; ppc:75
+  (cmp nargs (:$ (ash 1 arm64::fixnumshift))) ; ppc:74
+  (b.ne @2-args)                        ; ppc:76
+  (mov fixnum offset)                   ; ppc:77 (mr)
+  (mov offset (:$ 0))                   ; ppc:78 (li)
+  @2-args
+  (unbox-fixnum imm0 offset)            ; ppc:80
+  (ldr arg_z (:@ fixnum imm0))          ; ppc:81 ldrx — regoff form (wave-3)
+  (ret))                                ; ppc:82
+
+;;; %fixnum-ref-natural — ppc:98 (#+ppc64-target arm; ppc32 twin ppc:86 skipped)
+(defarm64lapfunction %fixnum-ref-natural ((fixnum arg_y) #| &optional |# (offset arg_z))
+  (check-nargs 1 2)                     ; ppc:100
+  (cmp nargs (:$ (ash 1 arm64::fixnumshift))) ; ppc:99
+  (b.ne @2-args)                        ; ppc:101
+  (mov fixnum offset)                   ; ppc:102
+  (mov offset (:$ 0))                   ; ppc:103
+  @2-args
+  (unbox-fixnum imm0 offset)            ; ppc:105
+  (ldr imm0 (:@ fixnum imm0))           ; ppc:106 ldx
+  ;; ppc:107 (ba .SPmakeu64) — TAIL jump.  DECIDE W4-D10 (not in table; needs
+  ;; jmp-subprim/no-link form) + W4-D11 (imm0 is .SPmakeu64's INPUT and
+  ;; call-subprim's dispatch scratch — broken until scratch moves off imm0).
+  (jump-subprim .SPmakeu64))
+
+;;; %fixnum-set — ppc:109
+(defarm64lapfunction %fixnum-set ((fixnum arg_x) (offset arg_y) #| &optional |# (new-value arg_z))
+  (check-nargs 2 3)                     ; ppc:111
+  (cmp nargs (:$ (ash 2 arm64::fixnumshift))) ; ppc:110
+  (b.ne @3-args)                        ; ppc:112
+  (mov fixnum offset)                   ; ppc:113
+  (mov offset (:$ 0))                   ; ppc:114
+  @3-args
+  (unbox-fixnum imm0 offset)            ; ppc:116
+  (str new-value (:@ fixnum imm0))      ; ppc:117 strx — regoff form
+  ;; ppc:118 (mr arg_z new-value) — new-value IS arg_z; no-op elided
+  (ret))                                ; ppc:119
+
+;;; %fixnum-set-natural — ppc:159 (#+ppc64-target arm; ppc32 twin ppc:122 skipped)
+;;; DEVIATION (DECIDE W4-D19): the PPC64 body pokes bignum digits inline —
+;;; 32-bit digits in BIG-ENDIAN order (ld+rotldi swap, ppc:176-190); that
+;;; layout does not transfer to little-endian arm64.  The x86-64 twin
+;;; (x86:213-226) instead calls .SPgetu64 to unbox-with-typecheck; mirror it
+;;; (bignum digits are 32-bit on Matt's design too, arch :143).
+(defarm64lapfunction %fixnum-set-natural ((fixnum arg_x) (offset arg_y) #| &optional |# (new-value arg_z))
+  (check-nargs 2 3)                     ; ppc:161
+  (save-lisp-context)                   ; x86:216 save-simple-frame
+  (cmp nargs (:$ (ash 2 arm64::fixnumshift))) ; ppc:160 (frame build flag-safe)
+  (b.ne @3-args)                        ; ppc:162
+  (mov fixnum offset)                   ; ppc:163
+  (mov offset (:$ 0))                   ; ppc:164
+  @3-args
+  ;; .SPgetu64: arg_z -> unboxed u64 in imm0, type-error if not (x86:222).
+  ;; DECIDE W4-D10 (not in Matt's table; exists in our spentry-B drafts).
+  (call-subprim .SPgetu64)
+  (unbox-fixnum imm1 offset)            ; ppc:166 / x86:223
+  (str imm0 (:@ fixnum imm1))           ; ppc:192 stdx / x86:224
+  (restore-full-lisp-context)           ; x86:225
+  ;; arg_z (= new-value) preserved by .SPgetu64 — ppc:193 (mr arg_z new-value)
+  (ret))                                ; ppc:194
+
+;;; =====================================================================
+;;; Frame / stack accessors — ppc:197-273
+
+
+
+
+
+
+
+;;; =====================================================================
+
+(defarm64lapfunction %get-object ((macptr arg_y) (offset arg_z))
+  (check-nargs 2)                       ; ppc:1127
+  (trap-unless-typecode= arg_y arm64::subtag-macptr) ; ppc:1128 (W4-D16 brk)
+  (macptr-ptr imm0 arg_y)               ; ppc:1129
+  (trap-unless-lisptag= arg_z arm64::tag-fixnum imm1) ; ppc:1130 (W4-D16 brk)
+  (unbox-fixnum imm1 arg_z)             ; ppc:1131
+  (ldr arg_z (:@ imm0 imm1))            ; ppc:1132 ldrx — regoff
+  (ret))                                ; ppc:1133
+
+(defarm64lapfunction %set-object ((macptr arg_x) (offset arg_y) (value arg_z))
+  (check-nargs 3)                       ; ppc:1137
+  (trap-unless-typecode= arg_x arm64::subtag-macptr) ; ppc:1138
+  (macptr-ptr imm0 arg_x)               ; ppc:1139
+  (trap-unless-lisptag= arg_y arm64::tag-fixnum imm1) ; ppc:1140
+  (unbox-fixnum imm1 arg_y)             ; ppc:1141
+  (str arg_z (:@ imm0 imm1))            ; ppc:1142 strx — regoff
+  (ret))                                ; ppc:1143
+
+;;; =====================================================================
+;;; Method-context apply family — ppc:1146-1224
+
+;;; =====================================================================
+;;; %make-code-executable — ppc:22
+;;; =====================================================================
+;;; FF-call MakeDataExecutable for I/D-cache sync — REQUIRED on arm64
+;;; (freshly loaded fasl code vectors must be flushed before execution),
+;;; unlike the x86-64 twin's no-op (x86:98).  PPC builds a PowerOpen
+;;; c-frame + .SPpoweropen-ffcall; here the AAPCS64 c_frame + .SPffcall
+;;; (kernel contract: `spentry ffcall' in
+;;; upstream-port/lisp-kernel/arm64-spentry.s, 16m30):
+;;;   {header@0, savedsp@8, param0..7@16..72, 4 reserved boundary
+;;;    lisp_frame words@80..111} = 112 bytes / 14 words.
+;;; The header is a REAL uvector header whose element count (words-1 = 13)
+;;; deliberately COVERS the 4 reserved words.  _SPffcall derives the
+;;; boundary-frame base from that count, parks lr there, publishes the
+;;; frame by shrinking the count by 4, and on return restores sp from
+;;; savedsp -- NOT from offset 0, which is the header.
+;;; 16m31: 16m30 renamed backlink/savelr -> header/savedsp but missed this
+;;; DEPLOYED twin (its handoff claimed only the undeployed drafts were
+;;; left), so this body still referenced the now-unbound
+;;; arm64::c-frame.backlink and walled the XLOAD in l0 arm64-def.
+;;; save-lisp-context preserves the entry lr across the
+;;; call-subprim blr; restore-full-lisp-context pops the lisp frame.
+;;; TBI: codev's tag rides in the top byte and is ignored by the kernel's
+;;; VA cache-maintenance, so the tagged pointer is a valid address arg.
+(defarm64lapfunction %make-code-executable ((codev arg_z))
+  (let ((len imm2)
+        (word-offset imm0))
+    (save-lisp-context)                 ; ppc:25
+    (getvheader word-offset codev)      ; ppc:26
+    (header-size len word-offset)       ; ppc:27
+    ;; ppc:32-33 (stru sp -(c-frame) sp): str sp unencodable (Rt=xzr) —
+    ;; stage the saved SP through imm1 (wave-3 idiom).
+    (mov imm1 sp)
+    (sub sp sp (:$ arm64::c-frame.ffcall-size))  ; 16 head + 8 params + 4 reserved
+    (movz imm3 (:$ arm64::c-frame.ffcall-header))
+    (str imm3 (:@ sp (:$ arm64::c-frame.header)))
+    (str imm1 (:@ sp (:$ arm64::c-frame.savedsp)))
+    (sub imm0 codev (:$ (- arm64::misc-data-offset))) ; ppc:34 (la; canonical la→sub idiom)
+    (lsl len len (:$ 2))                ; ppc:35 slri — 32-bit code elements
+    (str imm0 (:@ sp (:$ arm64::c-frame.param0)))         ; ppc:36
+    (str len (:@ sp (:$ (+ arm64::c-frame.param0 8))))    ; ppc:37 param1
+    (ref-global imm3 kernel-imports)    ; ppc:38
+    (ldr arg_z (:@ imm3 (:$ arm64::kernel-import-makedataexecutable))) ; ppc:39
+    (call-subprim .SPffcall)            ; ppc:40 (bla — LINKED call)
+    (mov arg_z rnil)                    ; ppc:41
+    (restore-full-lisp-context)         ; ppc:42
+    (ret)))                             ; ppc:43
+
+;;; =====================================================================
+;;; %lookup-subprim-address — ARM-ISA analog (arm-def.lisp:612); no PPC64
+;;; body exists because PPC64's `ba' encodes subprim addresses directly
+;;; (ppc-callback-support needs no lookup).  Returns the absolute kernel
+;;; address of the subprim whose rcontext-relative sptab offset is SUBP —
+;;; a boxed fixnum holding the same arm64::subprimitive-offset value the
+;;; call-subprim/jump-subprim lapmacros use.  The per-thread sptab
+;;; entries are identical static kernel addresses in every thread, so
+;;; the current thread's entry is a valid jump target for foreign
+;;; trampoline code (consumer: level-1/arm64-callback-support.lisp).
+;;; ARM64-DEVIATION: ARM32 tail-jumps .SPmakeu32 to box the address;
+;;; kernel text addresses fit a 61-bit low-tag fixnum with room to
+;;; spare, and no .SPmakeu64 subprim exists on this lane — box-fixnum.
+;;; =====================================================================
+(defarm64lapfunction %lookup-subprim-address ((subp arg_z))
+  (check-nargs 1)
+  (unbox-fixnum imm1 subp)              ; arm:613 (:lsr subp fixnumshift)
+  (ldr imm0 (:@ rcontext imm1))         ; arm:613 (sptab entry)
+  (box-fixnum arg_z imm0)               ; arm:614 (.SPmakeu32 — see note)
+  (ret))
+
+;;; =====================================================================
+;;; %get-kernel-global-from-offset — ppc:45
+;;; =====================================================================
+;;; offset = the (negative) rnil-relative offset from arm64::%kernel-global,
+;;; boxed.  PPC adds (target-nil-value); rnil holds tagged nil (x86:151 same).
+
+(defarm64lapfunction %get-kernel-global-from-offset ((offset arg_z))
+  (check-nargs 1)                       ; ppc:46
+  (unbox-fixnum imm0 offset)            ; ppc:47
+  (add imm0 imm0 rnil)                  ; ppc:48 (addi imm0 imm0 nil-value)
+  (ldr arg_z (:@ imm0 (:$ 0)))          ; ppc:49
+  (ret))                                ; ppc:50
+
+;;; %set-kernel-global-from-offset — ppc:52
+(defarm64lapfunction %set-kernel-global-from-offset ((offset arg_y) (new-value arg_z))
+  (check-nargs 2)                       ; ppc:53
+  (unbox-fixnum imm0 offset)            ; ppc:54
+  (add imm0 imm0 rnil)                  ; ppc:55
+  (str new-value (:@ imm0 (:$ 0)))      ; ppc:56
+  (ret))                                ; ppc:57
+
+;;; =====================================================================
+;;; %current-frame-ptr / %current-vsp — ppc:197/202
+;;; =====================================================================
+(defarm64lapfunction %current-frame-ptr ()
+  (check-nargs 0)                       ; ppc:198
+  (mov arg_z sp)                        ; ppc:199 (mr arg_z sp; MOV Xd,SP = ADD alias)
+  (ret))                                ; ppc:200
+
+(defarm64lapfunction %current-vsp ()
+  (check-nargs 0)                       ; ppc:203
+  (mov arg_z vsp)                       ; ppc:204
+  (ret))                                ; ppc:205
+
+;;; =====================================================================
+;;; %code-vector-pc — ppc:327 (promoted from the def draft; demand:
+;;; 16m17 arm64-trap-support return-address-offset — xcmain/%xerr-disp
+;;; fake-frame construction).
+;;; =====================================================================
+;;; Returns the boxed byte-offset of *pcptr's value within code-vector,
+;;; or nil if the PC is outside it.  loc-pc -> imm2; the nil move is
+;;; NZCV-safe between cmp and b.hs.  32-bit code elements, so
+;;; header-size << 2 = byte size (as PPC64's slri 2, ppc:334).
+(defarm64lapfunction %code-vector-pc ((code-vector arg_y) (pcptr arg_z))
+  (macptr-ptr imm0 pcptr)               ; ppc:328
+  (ldr imm2 (:@ imm0 (:$ 0)))           ; ppc:329 (ldr loc-pc 0 imm0)
+  (sub imm0 imm2 code-vector)           ; ppc:330
+  ;; ppc:331 (subi imm0 imm0 misc-data-offset).  misc-data-offset is
+  ;; NEGATIVE here (-4: fulltag-misc 12, arm64-arch.lisp:268), so
+  ;; subtracting it is an add of the positive constant — the assembler
+  ;; refuses negative immediates (neg-imm drift class, 16m5).
+  (add imm0 imm0 (:$ (- arm64::misc-data-offset)))
+  (getvheader imm1 code-vector)         ; ppc:332
+  (header-size imm1 imm1)               ; ppc:333
+  (lsl imm1 imm1 (:$ 2))                ; ppc:334 slri — 32-bit code elements
+  (cmp imm0 imm1)                       ; ppc:335 cmplr (unsigned)
+  (mov arg_z rnil)                      ; ppc:336 (li — NZCV-safe)
+  (b.hs @ret)                           ; ppc:337 (bgelr)
+  (box-fixnum arg_z imm0)               ; ppc:338
+  @ret
+  (ret))                                ; ppc:339
+
+;;; =====================================================================
+;;; Frame-walk / catch-top set — ppc:227/236/241/270/289 (promoted from
+;;; the def draft; demand: 16m17 lib/arm64-backtrace cfp-lfun cluster,
+;;; 16m21 %frame-backlink runtime call from the trap reporter/backtrace).
+;;; lisp-frame layout is kernel ground truth: marker@0 savevsp@8
+;;; savefn@16 savelr@24 — 4 nodes = 32 bytes (arm64-constants.h:378
+;;; `_struct lisp_frame`; spentry-D-call-builtins.s:60-64).
+;;; =====================================================================
+
+;;; %%frame-backlink — ppc:227.  ARM64-DEVIATION: PPC loads a stored
+;;; backlink from lisp-frame word @0, but Matt's marker frame has marker@0
+;;; and NO stored backlink.  Under the DECIDED cstack-walk design (Option
+;;; A, comms/ARM64-CSTACK-WALK-DECISION.md — cstack is a homogeneous 32B
+;;; frame chain, nfp + stack-cons on the TSP), the parent (older) frame is
+;;; simply the next 32-byte frame at a higher address, so backlink = p+32
+;;; (kernel-verified lisp_frame size).  Matches the fixed-frame assumption
+;;; the rest of this set already bakes in.  (16m21: this fell through the
+;;; quartet promotion and was left undefined, looping the trap reporter.)
+(defarm64lapfunction %%frame-backlink ((p arg_z))
+  (check-nargs 1)                       ; ppc:228
+  (add arg_z arg_z (:$ 32))             ; ppc:229 — lisp_frame.size (32)
+  (ret))                                ; ppc:230
+
+;;; %%frame-savefn — ppc:236
+(defarm64lapfunction %%frame-savefn ((p arg_z))
+  (check-nargs 1)                       ; ppc:237
+  (ldr arg_z (:@ arg_z (:$ 16)))        ; ppc:238 lisp-frame.savefn -> @16
+  (ret))                                ; ppc:239
+
+;;; %cfp-lfun — ppc:241
+;;; Returns (values lfun pc-offset) or (values nil nil).
+;;; PPC tests extract-typecode == subtag-function; since the
+;;; fulltag-function removal (patch 0055) that is the RIGHT test here
+;;; too — a function is a misc-tagged uvector, exactly PPC's shape.
+;;; loc-pc register does not exist — savelr staged in imm2.
+(defarm64lapfunction %cfp-lfun ((p arg_z))
+  (ldr arg_y (:@ p (:$ 16)))            ; ppc:242 lisp-frame.savefn
+  (extract-typecode imm0 arg_y)         ; ppc:243
+  (ldr imm2 (:@ p (:$ 24)))             ; ppc:245 lisp-frame.savelr -> imm2
+  (cmp imm0 (:$ arm64::subtag-function)) ; ppc:244
+  (b.ne @no)                            ; ppc:246
+  ;; codevector = function slot 0 @ misc-function-offset (-4) — ldur
+  (ldur arg_x (:@ arg_y (:$ arm64::misc-function-offset))) ; ppc:247
+  (sub imm1 imm2 arg_x)                 ; ppc:248 pc - tagged codevector
+  ;; ppc:249 (la imm1 (- misc-data-offset) imm1).  misc-data-offset is
+  ;; NEGATIVE here (-4), so subtracting it is an add of the positive
+  ;; constant (neg-imm drift class, 16m5).
+  (add imm1 imm1 (:$ (- arm64::misc-data-offset)))
+  (getvheader imm0 arg_x)               ; ppc:250
+  (header-length imm0 imm0)             ; ppc:251 boxed element count
+  (cmp imm1 imm0)                       ; ppc:252 cmplr (unsigned; boxed
+                                        ; count over-bounds byte length
+                                        ; 2x, same slack as PPC64)
+  (box-fixnum imm1 imm1)                ; ppc:253 (lsl — NZCV-safe)
+  (b.hs @no)                            ; ppc:254 bge (unsigned)
+  (vpush arg_y)                         ; ppc:255
+  (vpush imm1)                          ; ppc:256
+  @go
+  (set-nargs 2)                         ; ppc:258
+  (add temp0 vsp (:$ (* 2 arm64::node-size))) ; ppc:259 (la temp0 '2 vsp); temp0 = entry-vsp
+  (jump-subprim .SPvalues)              ; ppc:260 ba — TAIL no-link
+  @no
+  (mov imm0 rnil)                       ; ppc:262
+  (vpush imm0)                          ; ppc:263
+  (vpush imm0)                          ; ppc:264
+  (b @go))                              ; ppc:265
+
+;;; %%frame-savevsp — ppc:270
+(defarm64lapfunction %%frame-savevsp ((p arg_z))
+  (check-nargs 1)                       ; ppc:271
+  (ldr arg_z (:@ arg_z (:$ 8)))         ; ppc:272 lisp-frame.savevsp -> @8
+  (ret))                                ; ppc:273
+
+;;; %catch-top — ppc:289
+;;; tcr.catch-top = 24 (arm64-arch.lisp:744-749 tcr layout, = kernel
+;;; arm64-constants.h:441 _struct tcr: next/prev/db_link/catch_top).
+;;; The tcr arg is a "fixnum" whose bits ARE the tcr address
+;;; (8-aligned), as on PPC64.
+(defarm64lapfunction %catch-top ((tcr arg_z))
+  (check-nargs 1)                       ; ppc:290
+  (ldr arg_z (:@ tcr (:$ arm64::tcr.catch-top))) ; ppc:291
+  (cbnz arg_z @ret)                     ; ppc:292-293 (cmpri 0 / bne)
+  (mov arg_z rnil)                      ; ppc:294
+  @ret
+  (ret))                                ; ppc:296
+
+;;; =====================================================================
+;;; %copy-function / replace-function-code / closure-function —
+;;; ppc-def.lisp:1227/1237/1245
+;;; =====================================================================
+;;; Demand: 16m11a frontier — l1-clos-boot gf-dcode install dies at
+;;; `undefined function REPLACE-FUNCTION-CODE` (nargs 2).
+;;;
+;;; Since the fulltag-function removal (patch 0055) functions are plain
+;;; misc-tagged uvectors, exactly PPC's shape, and the
+;;; %function-to-function-vector calls below are identity-with-typecheck.
+;;; Bodies keep PPC64 semantics (codevector @ slot 0, whole-gvector copy
+;;; — Matt's function shape is PPC64's, not x8664's inline-code one).
+;;; ppc:1245 closure-function is already active above (16m5t, x86 body).
+
+(defun %copy-function (proto &optional target) ; ppc:1227
+  (let* ((protov (%function-to-function-vector proto))
+         (total-size (uvsize protov))
+         (newv (if target
+                 (%function-to-function-vector target)
+                 (allocate-typed-vector :function total-size))))
+    (declare (fixnum total-size))
+    (when target
+      (unless (eql total-size (uvsize newv))
+        (error "Wrong size target ~s" target)))
+    (%copy-gvector-to-gvector protov 0 newv 0 total-size)
+    (%function-vector-to-function newv)))
+
+(defun replace-function-code (target-fn proto-fn) ; ppc:1237
+  (if (typep target-fn 'function)
+    (if (typep proto-fn 'function)
+      (setf (uvref (%function-to-function-vector target-fn) 0)
+            (uvref (%function-to-function-vector proto-fn) 0))
+      (report-bad-arg proto-fn 'function))
+    (report-bad-arg target-fn 'function)))
+
+;;; =====================================================================
+;;; Method-context apply family — ppc:1146-1224 (promoted from the def
+;;; draft; demand: 16m11c udf %APPLY-LEXPR-TAIL-WISE, l1-clos-boot; the
+;;; two spread siblings ride along — same dcode application paths).
+;;; =====================================================================
+;;; nargs is a TAGGED fixnum (boxed count IS byte count, fixnumshift=3).
+;;; next-method-context = temp1 on Matt's map too (arm64-asm.lisp:203
+;;; define-register-alias), same as PPC.
+;;; lr-preservation idiom (PPC mflr loc-pc / bla / mtlr loc-pc, no loc-pc
+;;; register here): build-lisp-frame, call the subprim, then pop ONLY fn/lr
+;;; and discard the frame — vsp must NOT be reloaded because the spread
+;;; subprim pushed the spread args on the vstack.  DECIDE W4-D17.
+;;; Final dispatch through codevector slot 0 (misc-function-offset -4) + br:
+;;; wave-3 DECIDE-6 recurrence (W4-D15).
+;;; Kernel bodies exist: spread_lexprz spentry-E:561, spreadargz
+;;; spentry-D:631; .SPspread-lexprz registration verified (w12:20).
+
+(defarm64lapfunction %apply-lexpr-with-method-context ((magic arg_x)
+                                                       (function arg_y)
+                                                       (args arg_z))
+  ;; Somebody's called (or tail-called) us.       ; ppc:1149-1154 comments
+  (mov next-method-context magic)       ; ppc:1155 (mr temp1 magic)
+  (mov nfn function)                    ; ppc:1156
+  (set-nargs 0)                         ; ppc:1157
+  (build-lisp-frame)                    ; ppc:1158 (mflr loc-pc) — W4-D17
+  ;; .SPspread-lexprz preserves nfn/next-method-context (PPC contract;
+  ;; spentry-E @4883).  DECIDE W4-D10: not in Matt's table.
+  (call-subprim .SPspread-lexprz)      ; ppc:1159 (bla)
+  (ldp fn lr (:@ sp (:$ 16)))           ; ppc:1160 (mtlr loc-pc)
+  (add sp sp (:$ 32))                   ;   discard frame; vsp NOT reloaded
+  (ldur imm0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:1161 codevector
+  (br imm0))                            ; ppc:1162-1163 (mtctr/bctr) — W4-D15
+
+(defarm64lapfunction %apply-with-method-context ((magic arg_x)
+                                                 (function arg_y)
+                                                 (args arg_z))
+  ;; Same shape; spreads a LIST instead of a lexpr.  ; ppc:1169-1174
+  (mov next-method-context magic)       ; ppc:1175
+  (mov nfn function)                    ; ppc:1176
+  (set-nargs 0)                         ; ppc:1177
+  (build-lisp-frame)                    ; ppc:1178 — W4-D17
+  (call-subprim .SPspreadargZ)          ; ppc:1179 (bla) — W4-D10
+  (ldp fn lr (:@ sp (:$ 16)))           ; ppc:1180
+  (add sp sp (:$ 32))
+  (ldur imm0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:1181
+  (br imm0))                            ; ppc:1182-1183 — W4-D15
+
+;;; %apply-lexpr-tail-wise — ppc:1188
+;;; Preconditions ppc:1189-1199 apply verbatim (lexpr via .SPlexpr-entry;
+;;; LR = lexpr-cleanup code; cleanup EQ ret1valaddr => discard the extra
+;;; MV frame).  Frame field offsets are the MARKER frame's (savevsp@8,
+;;; savefn@16, savelr@24; W4-D18 — matches build-lisp-frame/
+;;; restore-lisp-frame's {marker,vsp,fn,lr}); nargs loaded from the lexpr
+;;; is BOXED (byte count), so (sub vsp imm0 nargs) is unscaled exactly as
+;;; PPC64.
+;;; PPC keeps cr0/cr1/cr2 live; single NZCV -> cr2 resolved first, then the
+;;; nargs compares re-issued at the pop points (vpop/ldp are flag-safe).
+;;; ppc:1204 (mr imm5 nargs) elided — VESTIGIAL dead code in the source:
+;;; imm5 is never read after the copy (the tail-called method clobbers
+;;; volatiles), and BOTH other ports drop it (arm-def.lisp:527-557,
+;;; x86-def.lisp:458ff).  NB imm5/nargs are DISTINCT registers on both
+;;; PPC (r8/r11) and Matt's map (x5/x6) — an earlier "aliases" claim
+;;; here was wrong (record corrected in wave-8 lead-verify).
+(defarm64lapfunction %apply-lexpr-tail-wise ((method arg_y) (args arg_z))
+  (ref-global imm0 ret1valaddr)         ; ppc:1201
+  (ldr nargs (:@ args (:$ 0)))          ; ppc:1203 lexpr count (boxed)
+  (mov nfn method)                      ; ppc:1207
+  (ldur temp0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:1208 (mtctr temp0)
+  (cmp lr imm0)                         ; ppc:1200-1202 (mflr/cmpr cr2)
+  (b.ne @no-mv-frame)                   ; ppc:1210 (if (:cr2 :eq) ...)
+  (add sp sp (:$ 32))                   ; ppc:1211 discard MV frame
+  @no-mv-frame
+  (ldr lr (:@ sp (:$ 24)))              ; ppc:1212 savelr (mtlr ppc:1216)
+  (ldr fn (:@ sp (:$ 16)))              ; ppc:1213 savefn
+  (ldr imm0 (:@ sp (:$ 8)))             ; ppc:1214 savevsp
+  (sub vsp imm0 nargs)                  ; ppc:1215 (boxed nargs IS byte count)
+  (add sp sp (:$ 32))                   ; ppc:1217 (la sp lisp-frame.size sp)
+  (cbz nargs @jump)                     ; ppc:1205/1218 (cr0; beqctr)
+  (vpop arg_z)                          ; ppc:1219
+  (cmp nargs (:$ (ash 2 arm64::fixnumshift))) ; ppc:1206 (cr1 re-issued)
+  (b.lo @jump)                          ; ppc:1220 (bltctr cr1)
+  (vpop arg_y)                          ; ppc:1221 (ldr post-index: flag-safe)
+  (b.eq @jump)                          ; ppc:1222 (beqctr cr1)
+  (vpop arg_x)                          ; ppc:1223
+  @jump
+  (br temp0))                           ; ppc:1224 (bctr) — W4-D15
+
+
+;;; ---------------------------------------------------------------------
+;;; apply+ — promoted 16m41 (regression stage 11: SETF-APPLY.1-4).
+;;;
+;;; (apply+ f butlast last) = (apply f (append butlast (list last))).
+;;; This is the ONLY thing (setf (apply #'aref ...) ...) expands into
+;;; (lib/setf.lisp:505's `(define-setf-method apply ...)' leg), and it is a
+;;; PER-ARCH LAP definition -- present for PPC/x86/ARM32 and, until now,
+;;; absent on arm64, so all four SETF-APPLY tests reported
+;;; UNDEFINED-FUNCTION-CALL.  Same class as 16m37's missing VALUES.
+;;;
+;;; LOGIC DONOR: ppc-def.lisp:1256-1278 (line-for-line below).
+;;; SHAPE DONOR for the two places PPC cannot be followed: arm-def.lisp:591,
+;;; the other port with no loc-pc register and no conditional-store-free
+;;; branchless push.  Three corrections to the wave-4 draft, each verified
+;;; against this lane rather than assumed:
+;;;
+;;;  1. `(:arglist ...)' pseudo-op, NOT PPC's `(defun (&lap ...))' + a
+;;;     trailing `(lfun-bits #'apply+ ...)'.  arm64-lap.lisp:124 implements
+;;;     :arglist as `(setq *arm64-lap-lfun-bits* (encode-lambda-list arg))',
+;;;     which encodes 3-required-plus-rest exactly as PPC's explicit
+;;;     `(logior $lfbits-rest-bit (dpb 3 $lfbits-numreq 0))'.  Setting both
+;;;     would be redundant; ARM32 sets only the arglist.
+;;;  2. The callee goes in temp0, as PPC does -- NOT in nfn, as ARM32 does.
+;;;     OUR .SPfuncall dispatches on temp0 (spentry-D-call-builtins.s:146
+;;;     `and imm0,temp0,#fulltagmask'), so ARM32's `(ldr nfn (:@ nfn
+;;;     'funcall))' would hand the subprim a stale callee.
+;;;  3. nfn (the constant-pool base for `'funcall') and temp0 (`last') must
+;;;     survive .SPspreadargz.  VERIFIED by reading it
+;;;     (spentry-D-call-builtins.s:631-660): it writes only imm0, imm1,
+;;;     arg_x, arg_y, arg_z, nargs and vsp.  PPC relies on the same contract.
+;;;
+;;; lr across the subprim: build-lisp-frame, call, then pop ONLY fn/lr and
+;;; discard the frame -- vsp must NOT be reloaded, because the spread pushed
+;;; the spread args onto the vstack.  That is the vetted W4-D17 idiom already
+;;; live in %apply-lexpr-with-method-context above.
+;;; ARM64-DEVIATION: PPC's branchless `blt cr0 @nopush' is kept as a real
+;;; branch (a64 has no conditional store; ARM32 uses `strhs' instead).
+(defarm64lapfunction apply+ ()
+  (:arglist (function arg1 arg2 &rest other-args))
+  (check-nargs 3 nil)                   ; ppc:1258
+  (vpush arg_x)                         ; ppc:1259
+  (mov temp0 arg_z)                     ; ppc:1260 last
+  (mov arg_z arg_y)                     ; ppc:1261 butlast
+  (sub nargs nargs (:$ (ash 2 arm64::fixnumshift))) ; ppc:1262 (subi nargs '2)
+  (build-lisp-frame)                    ; ppc:1263 (mflr loc-pc) — W4-D17
+  (call-subprim .SPspreadargz)          ; ppc:1264 (bla)
+  (ldp fn lr (:@ sp (:$ 16)))           ; ppc:1266 (mtlr loc-pc); flag-safe
+  (add sp sp (:$ 32))                   ;   discard frame; vsp NOT reloaded
+  (cmp nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:1265 (cmpri cr0 nargs '3)
+  (add nargs nargs (:$ (ash 1 arm64::fixnumshift))) ; ppc:1267 count for last
+  (b.lt @nopush)                        ; ppc:1268 (blt cr0 @nopush)
+  (vpush arg_x)                         ; ppc:1269
+  @nopush
+  (mov arg_x arg_y)                     ; ppc:1271
+  (mov arg_y arg_z)                     ; ppc:1272
+  (mov arg_z temp0)                     ; ppc:1273
+  (ldur temp0 (:@ nfn (:$ 'funcall)))   ; ppc:1274 constant-pool ref (DECIDE-14)
+  ;; jump-subprim, NOT call-subprim: PPC's `ba' is a tail BRANCH.  call-subprim
+  ;; emits `bl', so .SPfuncall returned into the end of this code vector and
+  ;; execution fell through into the NEXT object's `udf #0' sentinel --
+  ;; "Unhandled exception 4 at 0x300000004ac4, insn 0x00000000".  This is the
+  ;; SAME correction arm64-misc.lisp:457-460 records for the VALUES draft in
+  ;; 16m37; the drafts systematically spell tail subprim jumps as calls.
+  (jump-subprim .SPfuncall))           ; ppc:1275 (ba .SPfuncall) — TAIL

--- a/level-0/ARM64/arm64-float.lisp
+++ b/level-0/ARM64/arm64-float.lisp
@@ -1,0 +1,775 @@
+;;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-float.lisp — ACTIVE seed (promoted from drafts wave-6 at the
+;;; 16m5p %INT-TO-SFLOAT demand; pin-gate sweep applied — see the
+;;; PIN-GATED CLUSTER banner).
+;;;;
+;;;; arm64-float.lisp — wave-6 draft: level-0 float LAP functions for
+;;;; Matt Emerson's upstream arm64 (low-tag) design, pin d71a5ad.
+;;;;
+;;;; Source: vendor/ccl/level-0/PPC/ppc-float.lisp (PPC64/unguarded forms
+;;;; only; every form's feature guard re-verified against the source —
+;;;; see wave6-float-report.md ledger).
+;;;; Macro vocabulary: Matt's arm64-lapmacros.lisp (get-double-float,
+;;;; get-single-float-bits, unbox-fixnum, box-fixnum, check-nargs) plus
+;;;; upstream-port/level-0/drafts/arm64-lapmacros-additions.lisp
+;;;; (get/put-single-float, put-double-float, int-to-freg,
+;;;; clear-fpu-exceptions, macptr-ptr, vpush/vpop).
+;;;;
+;;;; Representation ground truth (his arm64-arch.lisp @ d71a5ad):
+;;;;   * single-floats are IMMEDIATE: tag-single-float = #b001 (:47),
+;;;;     fulltag-single-float = #b0001 (:57), subtag-single-float =
+;;;;     fulltag-single-float = 1 (:78), :single-float-tag-is-subtag nil
+;;;;     (:951).  IEEE bits live in the TOP 32 bits of the tagged word —
+;;;;     his own get-single-float-bits is `(lsr dest node (:$ 32))`
+;;;;     (arm64-lapmacros.lisp:49-51) — SAME packing as PPC64, so the
+;;;;     PPC64 single-float shift arithmetic ports line-for-line.
+;;;;     (MISSING-CONSTANTS-RATIFY.md §10.1 tracks ratification.)
+;;;;   * double-floats are uvectors: subtag-double-float (:144),
+;;;;     double-float.value = misc-data-offset = 4 (:432) — misc-biased,
+;;;;     NOT an 8-multiple, so all value accesses are ldur/stur.
+;;;;     LE cell map: value-cell=0 ALIASES val-low-cell=0; val-high-cell=1
+;;;;     (:433-437).
+;;;;   * FP register convention (this file): PPC fpN → dN (double) / sN
+;;;;     (single), SAME number: fp0→d0/s0, fp1→d1/s1, fp2→d2/s2.
+;;;;     get-single-float / put-single-float / int-to-freg stage through
+;;;;     imm0 (additions macros) — noted where imm0 is otherwise live.
+;;;;   * FP-EXCEPTION MODEL = ARM32/VFP lineage, NOT PPC (W6-D40):
+;;;;     ARMv8 FPCR trap-enable bits (IOE..IDE, bits 8-15) are OPTIONAL
+;;;;     and RAZ/WI on mainstream cores — untrapped FP is the baseline,
+;;;;     exactly the NEON situation vendor arm-float.lisp:384-390 solved.
+;;;;     Adopted model: the LOGICAL exception-enable mask lives in
+;;;;     SOFTWARE (bits 8-15 of *fp-logical-enables*, a special variable
+;;;;     and therefore per-thread); the hardware FPCR carries only the
+;;;;     rounding mode (RMode, bits 22-23); cumulative status comes from
+;;;;     tcr.foreign-fpsr, the FPSR the ffcall spentry captures and clears
+;;;;     around each foreign call (arm64-spentry.s:264-266).
+;;;;     mrs/msr fpsr/fpcr templates + names verified at tip
+;;;;     (arm64-asm.lisp:577-578, :1440-1443; resolves
+;;;;     MISSING-CONSTANTS-RATIFY.md §10.6's open question).
+;;;;     ⚠ UPDATED 16m44.  This block used to say the mask lives in
+;;;;     tcr.lisp-fpscr at offset 16 with tcr.ffi-exception at 136, and
+;;;;     flagged a W4-D20 disagreement with arm64-constants.h.  Both slots
+;;;;     were REMOVED upstream at f067047; only tcr.foreign-fpsr survives,
+;;;;     and lisp/kernel now agree on it.  The disagreement is closed and
+;;;;     the two offsets above are gone — do not reinstate them.
+;;;;
+;;;; STATUS: DRAFT — not compiled; brk placeholders: none (this file needs
+;;;; no subprims, no lisp frames, no constant-pool refs, no type-trap UUOs).
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "NUMBER-MACROS")
+  (require :number-case-macro)
+  (require "ARM64-LAPMACROS"))
+
+;;; from ppc-float.lisp:48 (#+ppc64-target %make-float-from-fixnums)
+;;; make a float from hi - high 24 bits mantissa (ignore implied higher bit)
+;;;                   lo -  low 28 bits mantissa
+;;;                   exp  - take low 11 bits
+;;;                   sign - sign(sign) => result
+;;; no error checks, no tweaks, no nuthin.
+;;; PPC64 assembles the two 32-bit halves and stw's them separately (BE);
+;;; here the whole 64-bit IEEE word is built in imm1 and stored once (LE).
+;;; PPC64's sign extraction is `rlwinm imm0 sign 0 0 0` (keep bit 31 of the
+;;; low word of the BOXED sign — works for small ±fixnums); the intent per
+;;; the header comment is sign(sign), expressed here as asr #63 of the boxed
+;;; fixnum (negative fixnums have bit 63 set), same trick for any magnitude.
+;;; NB: like PPC, does NOT move the float into arg_z — callers
+;;; (l0-float.lisp) keep their own reference and ignore the return value.
+(defarm64lapfunction %make-float-from-fixnums ((float 8) (hi 0) (lo arg_x) (exp arg_y) (sign arg_z))
+  (ldr imm2 (:@ vsp (:$ hi)))           ; boxed hi (vstack)
+  (ldr temp0 (:@ vsp (:$ float)))       ; the double-float node (vstack)
+  (add vsp vsp (:$ 16))                 ; ppc:59 (la vsp '2 vsp)
+  (unbox-fixnum imm2 imm2)
+  (and imm2 imm2 (:$ #xffffff))         ; hi: 24 mantissa bits
+  (lsl imm2 imm2 (:$ 28))               ; → IEEE bits 28..51
+  (unbox-fixnum imm1 lo)
+  (and imm1 imm1 (:$ #xfffffff))        ; lo: 28 mantissa bits → bits 0..27
+  (orr imm1 imm1 imm2)
+  (unbox-fixnum imm0 exp)
+  (and imm0 imm0 (:$ #x7ff))            ; exp: low 11 bits (ppc:50 keeps 11)
+  (lsl imm0 imm0 (:$ 52))               ; = IEEE-double-float-exponent-offset
+  (orr imm1 imm1 imm0)
+  (asr imm0 sign (:$ 63))               ; 0 (sign>=0) or -1 (sign<0)
+  (lsl imm0 imm0 (:$ 63))               ; → IEEE sign bit
+  (orr imm1 imm1 imm0)
+  (stur imm1 (:@ temp0 (:$ arm64::double-float.value)))  ; offset 4 → stur
+  (ret))
+
+;;; from ppc-float.lisp:72 (unguarded)
+(defarm64lapfunction %%double-float-abs! ((n arg_y) (val arg_z))
+  (get-double-float d1 n)               ; upstream macro: ldur d1, [n, #4]
+  (fabs d1 d1)
+  (put-double-float d1 val)
+  (ret))
+
+;;; from ppc-float.lisp:86 (#+ppc64-target %short-float-abs; the
+;;; destructive #+ppc32 %%short-float-abs! at :79 is SKIPped)
+(defarm64lapfunction %short-float-abs ((n arg_z))
+  (get-single-float s1 n)               ; stages via imm0
+  (fabs s0 s1)
+  (put-single-float s0 arg_z)           ; stages via imm0
+  (ret))
+
+;;; from ppc-float.lisp:92 (unguarded)
+(defarm64lapfunction %double-float-negate! ((src arg_y) (res arg_z))
+  (get-double-float d0 src)
+  (fneg d1 d0)
+  (put-double-float d1 res)
+  (ret))
+
+;;; from ppc-float.lisp:107 (#+ppc64-target, non-destructive)
+(defarm64lapfunction %short-float-negate ((src arg_z))
+  (get-single-float s0 src)
+  (fneg s1 s0)
+  (put-single-float s1 arg_z)
+  (ret))
+
+;;; from ppc-float.lisp:160 (unguarded; body is 32-bit-halves code)
+;;; PPC counts leading zeros of the top-justified 20-bit significand-high
+;;; word, falling through to 20+clz32(low word).  On a 64-bit LE load this
+;;; collapses to clz64(value << 12): for ANY nonzero significand the two
+;;; agree exactly; for an all-zero significand PPC yields 20+32 = 52 while
+;;; clz64 yields 64 — clamp to 52 to stay value-identical (3 extra insns;
+;;; only ±0.0/±inf hit it).
+(defarm64lapfunction dfloat-significand-zeros ((dfloat arg_z))
+  (ldur imm1 (:@ dfloat (:$ arm64::double-float.value)))  ; 64-bit IEEE word
+  (lsl imm1 imm1 (:$ 12))               ; drop sign+exp: (1+ IEEE-double-float-exponent-width)
+  (clz imm1 imm1)
+  (mov imm0 (:$ 52))
+  (cmp imm1 (:$ 52))
+  (csel imm1 imm1 imm0 (:? ls))         ; 64 (zero significand) → 52, as PPC
+  (box-fixnum arg_z imm1)
+  (ret))
+
+;;; from ppc-float.lisp:174 (unguarded; #+ppc64-target body arm
+;;; `srdi imm1 sfloat 32` = his get-single-float-bits)
+;;; PPC then counts within a 32-bit word (rlwinm 9 0 22 + cntlzw); done
+;;; here with W-register forms so the mantissa==0 case gives 32 exactly
+;;; as cntlzw does — bit-identical, no clamp needed.
+(defarm64lapfunction sfloat-significand-zeros ((sfloat arg_z))
+  (get-single-float-bits imm1 sfloat)   ; upstream macro: lsr #32
+  (lsl (:w imm1) (:w imm1) (:$ 9))      ; drop sign+exp: (- 32 IEEE-single-float-mantissa-width)
+  (clz (:w imm1) (:w imm1))             ; W clz = cntlzw semantics
+  (box-fixnum arg_z imm1)
+  (ret))
+
+;;; from ppc-float.lisp:210 (#+ppc64-target %%scale-dfloat!)
+;;; PPC builds the scale factor 2^(int-bias) by storing (unboxed int)<<20
+;;; as the high word of a double in tsp scratch memory and reloading it;
+;;; here the identical bit pattern is (unboxed int)<<52 moved to an FPR
+;;; with fmov — no scratch memory, no tsp.  As on PPC, the exponent is
+;;; NOT biased here (callers pass the biased value; ppc:223 comment).
+(defarm64lapfunction %%scale-dfloat! ((float arg_x) (int arg_y) (result arg_z))
+  (clear-fpu-exceptions)                ; additions macro: msr fpsr, xzr
+  (get-double-float d0 float)
+  (unbox-fixnum imm0 int)
+  (lsl imm0 imm0 (:$ 52))               ; = IEEE-double-float-exponent-offset
+  (fmov d1 imm0)                        ; raw bits → double 2^int
+  (fmul d2 d0 d1)
+  (put-double-float d2 result)
+  (ret))
+
+;;; from ppc-float.lisp:252 (#+ppc64-target %%scale-sfloat!, 2-arg form)
+(defarm64lapfunction %%scale-sfloat! ((float arg_y) (int arg_z))
+  (clear-fpu-exceptions)
+  (get-single-float s0 float)           ; stages via imm0 — before int unbox
+  (unbox-fixnum imm0 int)
+  (lsl imm0 imm0 (:$ IEEE-single-float-exponent-offset))  ; <<23
+  (fmov s1 (:w imm0))                   ; raw bits → single 2^int
+  (fmul s2 s0 s1)
+  (put-single-float s2 arg_z)
+  (ret))
+
+;;; from ppc-float.lisp:267 (unguarded)
+(defarm64lapfunction %copy-double-float ((f1 arg_y) (f2 arg_z))
+  (get-double-float d0 f1)
+  (put-double-float d0 f2)
+  (ret))
+
+;;; from ppc-float.lisp:312 (unguarded)
+;;; PPC's put-double-float of an lfs-loaded single relies on lfs's
+;;; load-time widening; ARM64 needs the explicit fcvt (cf. vendor
+;;; arm-float.lisp:234-238 %short-float->double-float, same shape).
+(defarm64lapfunction %short-float->double-float ((src arg_y) (result arg_z))
+  (get-single-float s0 src)
+  (fcvt d1 s0)                          ; single → double
+  (put-double-float d1 result)
+  (ret))
+
+;;; from ppc-float.lisp:326 (#+ppc64-target, 1-arg form)
+(defarm64lapfunction %double-float->short-float ((src arg_z))
+  ;;(clear-fpu-exceptions)              ; commented out in PPC (ppc:327) — kept as-is
+  (get-double-float d0 src)
+  (fcvt s1 d0)                          ; double → single (rounds; PPC frsp)
+  (put-single-float s1 arg_z)
+  (ret))
+
+;;; from ppc-float.lisp:343 (#+ppc64-target %int-to-sfloat)
+;;; PPC64 rounds int→double (int-to-freg) then double→single (frsp), and
+;;; materializes the tagged immediate via a pre-seeded 8-byte scratch slot
+;;; tcr.single-float-convert (stfs into it + ld the whole word).  The fmov
+;;; path (put-single-float) makes the scratch slot unnecessary — no tcr
+;;; field needed.  The two-step int→double→single rounding is kept
+;;; PPC-faithful (a direct scvtf-to-single would round once, differing for
+;;; magnitudes ≥ 2^53).
+(defarm64lapfunction %int-to-sfloat ((int arg_z))
+  (int-to-freg d0 int)                  ; additions macro: asr imm0 + scvtf d0
+  (fcvt s1 d0)                          ; PPC frsp fp1 fp0
+  (put-single-float s1 arg_z)
+  (ret))
+
+;;; from ppc-float.lisp:351 (unguarded)
+(defarm64lapfunction %int-to-dfloat ((int arg_y) (dfloat arg_z))
+  (int-to-freg d0 int)
+  (put-double-float d0 dfloat)
+  (ret))
+
+;;; ===================================================================
+;;; FPSCR family — W6-D40: ARM32/VFP model, NOT a PPC line-port.
+;;; PPC's FPSCR is one trapping control+status register (mffs/mtfsf via an
+;;; FPR + memory).  ARM64 splits it into FPCR (control) + FPSR (status),
+;;; readable directly into GPRs with mrs/msr — no FPR/memory staging, no
+;;; scratch TCR slots.  Word layouts:
+;;;   status (FPSR):  IOC=0 DZC=1 OFC=2 UFC=3 IXC=4 IDC=7
+;;;   control (FPCR): IOE=8 DZE=9 OFE=10 UFE=11 IXE=12 IDE=15
+;;;                   + RMode=(byte 2 22)
+;;;   RMode: 0=nearest 1=+inf 2=-inf 3=zero (≠ PPC's 0=nearest 1=zero …)
+;;; The enable bits sit uniformly 8 above their status twins, which is what
+;;; makes enabled-and-occurred a single shift-and-AND everywhere below.
+;;;
+;;; ⚠ SUPERSEDED 16m44: this block used to say the LOGICAL enable mask
+;;; lives in tcr.lisp-fpscr bits 8-15 (the W6-D40 model, following vendor
+;;; arm-float.lisp:384-390).  Matt removed tcr.lisp-fpscr and
+;;; tcr.ffi-exception at f067047, so no such slot exists on this lane and
+;;; the whole cluster that depended on it had been compiled out.  Enables
+;;; now live in hardware FPCR and the captured post-ff-call status in
+;;; tcr.foreign-fpsr — see the cluster header below for the full rationale
+;;; and the RAZ/WI caveat.
+;;; ===================================================================
+
+
+;;; =====================================================================
+;;; FORMERLY PIN-GATED CLUSTER — UN-GATED 16m44.
+;;;
+;;; History: Matt removed tcr.lisp-fpscr and tcr.ffi-exception at f067047
+;;; (only tcr.foreign-fpsr survives; lisp runs with the process-default
+;;; FPCR per the w13 ffcall design).  These five forms had been written
+;;; against the REMOVED slots and were gated on #+arm64-lisp-fpscr-slot —
+;;; a feature defined NOWHERE in this repo or Matt's tree — so the reader
+;;; discarded them and the file still compiled clean.
+;;;
+;;; That cost ~190 ANSI failures.  l1-numbers.lisp calls
+;;; (%ffi-exception-status) on EVERY sin/cos/tan/asin/acos/atan/sinh/cosh/
+;;; tanh/asinh/acosh/atanh/exp/log/expt, so the whole transcendental family
+;;; died with "Undefined function CCL::%FFI-EXCEPTION-STATUS" — measured
+;;; 16m44, and it is why SIN.1-24/COS.1-24/TAN.1-24 were red.  Nothing in
+;;; boot or cold-load calls sin, which is why it hid until the suite tail
+;;; first executed.
+;;;
+;;; THE RE-PORT.  Same W6-D40 formula, sourced from what the lane HAS:
+;;;   * enables  — hardware FPCR bits 8-15, not a software TCR word.
+;;;   * status   — tcr.foreign-fpsr, which our spentry publishes after
+;;;                every ff-call (arm64-spentry.s:265, spentry-E-ffi.s:337).
+;;; AArch64 keeps the trap-enable bits 8 above their FPSR flag twins
+;;; (IOE8/IOC0, DZE9/DZC1, OFE10/OFC2, UFE11/UFC3, IXE12/IXC4, IDE15/IDC7),
+;;; so enabled-and-occurred = flags AND (enables>>8) — one shift and one
+;;; AND, exactly the ARM32 idiom (arm-float.lisp:270-280), with FPCR
+;;; standing in for ARM32's tcr.lisp-fpscr.
+;;;
+;;; ⚠ WHERE THE ENABLES LIVE — and why NOT in hardware FPCR.
+;;; AArch64's FPCR trap-enable bits are OPTIONAL and are RAZ/WI on every
+;;; implementation without trapped-FP support (Graviton included): you write
+;;; them, they read back 0.  Sourcing the enables from FPCR therefore makes
+;;; %ffi-exception-status unconditionally NIL and NO floating-point condition
+;;; can ever be signalled.  Measured cost when this file did that: the eight
+;;; EXP.ERROR.4-7 / EXPT.ERROR.4-7 tests, which assert that
+;;;   (exp (+ (log most-positive-single-float) 100))
+;;; signals FLOATING-POINT-OVERFLOW.
+;;;
+;;; Hardware traps are also the wrong mechanism here regardless of support:
+;;; the exception happens inside libm, during a foreign call.  The ffcall
+;;; spentry already captures the callee's cumulative FPSR into
+;;; tcr.foreign_fpsr and then zeroes FPSR (arm64-spentry.s:264-266), so the
+;;; check is a pure software AND against the LOGICAL enables afterwards --
+;;; which is exactly the ARM32 model (arm-float.lisp:384-390) and the reason
+;;; ARM32 keeps its enables in tcr.lisp-fpscr rather than in the FPSCR.
+;;;
+;;; arm64 has no such TCR slot (removed at f067047) and adding one would
+;;; shift every following slot and the sptab in Matt's layout.  A special
+;;; variable gives the same PER-THREAD granularity the TCR slot gave ARM32,
+;;; costs no layout change, and keeps the whole thing upstream-friendly.
+;;; Only the rounding mode -- which FPCR really does hold -- stays hardware.
+;;; MAIL ITEM.
+;;; =====================================================================
+
+;;; ⚠ The defvar for *fp-logical-enables* and the three defuns that use it
+;;; live at the END of this file, beside *rounding-mode-alist*, NOT here.
+;;; Placing the defvar at this point in the file made cold load die with
+;;; "FATAL (cold load, no lisp error system): undefined function %DEFVAR"
+;;; (measured 16m44, image e53da35a).  Only the LAP helpers are here.
+;;; from ppc-float.lisp:360 (%get-fpscr-control — PPC: low 8 FPSCR bits)
+;;; Hardware half only: the rounding mode, FPCR (byte 2 22).
+(defarm64lapfunction %get-fpcr-rmode ()
+  (mrs imm0 fpcr)
+  (and imm0 imm0 (:$ (ash 3 22)))
+  (box-fixnum arg_z imm0)
+  (ret))
+
+;;; ldb-wrap on the lognot: the encoder rejects negative logimms.
+(defarm64lapfunction %set-fpcr-rmode ((new arg_z))
+  (unbox-fixnum imm0 new)
+  (and imm0 imm0 (:$ (ash 3 22)))                             ; new RMode
+  (mrs imm1 fpcr)
+  (and imm1 imm1 (:$ (ldb (byte 64 0) (lognot (ash 3 22)))))  ; clear old
+  (orr imm0 imm0 imm1)
+  (msr fpcr imm0)
+  (ret))
+
+;;; The FPSR flag byte captured by the ffcall spentry, consumed and cleared
+;;; on read — x86-64's %get-post-ffi-mxcsr shape (x86-float.lisp:201).
+;;; The spentry does `msr fpsr, xzr' immediately after capturing, so the slot
+;;; carries THIS call's flags only and cannot accumulate across calls.  (A
+;;; sticky source here would make every transcendental after the first
+;;; overflow report an overflow.)
+(defarm64lapfunction %get-post-ffi-fpsr ()
+  (ldr imm0 (:@ rcontext (:$ arm64::tcr.foreign-fpsr)))
+  (mov imm1 (:$ 0))
+  (str imm1 (:@ rcontext (:$ arm64::tcr.foreign-fpsr)))
+  (and imm0 imm0 (:$ #xff))
+  (box-fixnum arg_z imm0)
+  (ret))
+
+;;; from ppc-float.lisp:368 (%get-fpscr-status — cumulative exception flags)
+;;; ARM32 shape (arm-float.lisp:402-406).  NB the PPC original loads from
+;;; `tsp` (ppc:371) — a latent bug in the vendor source (should be
+;;; rcontext); moot here, no memory staging at all.
+(defarm64lapfunction %get-fpscr-status ()
+  (mrs imm0 fpsr)
+  (and imm0 imm0 (:$ #xff))
+  (box-fixnum arg_z imm0)
+  (ret))
+
+;;; from ppc-float.lisp:377 (%set-fpscr-status — set/clear cumulative flags)
+;;; ARM32 shape (arm-float.lisp:409-416): read-modify-write the flag byte,
+;;; preserving FPSR's non-flag bits (QC bit 27, AArch32-compat NZCV 28-31).
+(defarm64lapfunction %set-fpscr-status ((new arg_z))
+  (mrs imm1 fpsr)
+  (unbox-fixnum imm0 new)
+  (and imm0 imm0 (:$ #xff))
+  (and imm1 imm1 (:$ (ldb (byte 64 0) (lognot #xff))))  ; ldb-wrap (encoder rejects negative logimms)
+  (orr imm0 imm0 imm1)
+  (msr fpsr imm0)
+  (ret))
+
+;;; from ppc-float.lisp:394 (%ffi-exception-status)
+;;; PPC replays the FPSCR captured at ff-call return (tcr.ffi-exception)
+;;; through CR logic to compute the FEX summary of enabled-and-occurred
+;;; exceptions.  ARM64: FPCR enable bits sit uniformly 8 above their FPSR
+;;; flags (IOE 8/IOC 0 … IDE 15/IDC 7), so enabled-and-occurred =
+;;; flags AND (enables>>8) — the ARM32 idiom (arm-float.lisp:270-280),
+;;; masked against the SOFTWARE enables in *fp-logical-enables*.
+;;;
+;;; ⚠ NOT the hardware FPCR, and this is not an optimisation.  CCL's ARM
+;;; port deliberately never puts enable bits in the FPU at all — see the
+;;; comment above %get-fpscr-control in arm-float.lisp ("the NEON doesn't
+;;; support traps on FP exceptions ... we keep the (logical) enabled
+;;; exception mask in tcr.lisp-fpscr, and just store the rounding mode in
+;;; the hardware FPSCR").  On Graviton the FPCR enable bits are RAZ/WI on
+;;; top of that, so a mask taken from hardware would read 0 and this
+;;; function would silently return NIL forever — i.e. every FP condition
+;;; would vanish and the only symptom would be missing errors.
+;;; See comms/EXPT-ERROR-FP-OVERFLOW-FINDING.md.
+;;; Returns NIL when nothing fired, else the offending flag bits (ARM32
+;;; contract; consumed by the %*-check-exception-* defuns below, which test
+;;; it with WHEN).  Reads the CAPTURED copy per the ffcall design
+;;; (FPSR → tcr.foreign_fpsr, arm64-spentry.s:265 / spentry-E-ffi.s:337).
+;;;
+;;; enabled-and-occurred = flags AND (enables >> 8): AArch64 keeps each
+;;; enable exactly 8 bits above its status twin (IOE8/IOC0, DZE9/DZC1,
+;;; OFE10/OFC2, UFE11/UFC3, IXE12/IXC4), so the shift lines them up.
+;;; DEFINED AT THE END OF THIS FILE, with the defvar it reads.
+
+;;; from ppc-float.lisp:418-464 (%df/%sf-check-exception-2/-1)
+;;; ARM32 shape (arm-float.lisp:282-313): fp-status is NIL or the boxed
+;;; enabled-and-occurred FPSR flag bits (see %ffi-exception-status /
+;;; %get-fpscr-status + logical mask).  Double operands heap-consed as on
+;;; PPC; single operands passed directly (immediates on this 64-bit
+;;; design — the vendor #+ppc64-target arms do the same, ppc:439/442/464).
+(defun %df-check-exception-2 (operation op0 op1 fp-status)
+  (when fp-status
+    (let* ((condition-name (fp-condition-name-from-fpscr-status fp-status)))
+      (error (make-instance (or condition-name 'arithmetic-error)
+                            :operation operation
+                            :operands (list (%copy-double-float op0 (%make-dfloat))
+                                            (%copy-double-float op1 (%make-dfloat))))))))
+
+(defun %sf-check-exception-2 (operation op0 op1 fp-status)
+  (when fp-status
+    (let* ((condition-name (fp-condition-name-from-fpscr-status fp-status)))
+      (error (make-instance (or condition-name 'arithmetic-error)
+                            :operation operation
+                            :operands (list op0 op1))))))
+
+(defun %df-check-exception-1 (operation op0 fp-status)
+  (when fp-status
+    (let* ((condition-name (fp-condition-name-from-fpscr-status fp-status)))
+      (error (make-instance (or condition-name 'arithmetic-error)
+                            :operation operation
+                            :operands (list (%copy-double-float op0 (%make-dfloat))))))))
+
+(defun %sf-check-exception-1 (operation op0 fp-status)
+  (when fp-status
+    (let* ((condition-name (fp-condition-name-from-fpscr-status fp-status)))
+      (error (make-instance (or condition-name 'arithmetic-error)
+                            :operation operation
+                            :operands (list op0))))))
+
+;;; Replaces ppc-float.lisp:467 (fp-condition-from-fpscr) + :487
+;;; (%fp-error-from-status): with untrapped FP there is no separate
+;;; control-bit check at condition-mapping time (the mask was applied in
+;;; %ffi-exception-status / the inline status check).  ARM32 shape
+;;; (arm-float.lisp:441-447); also what an arm64-error-signal.lisp will
+;;; call (cf. vendor level-1/arm-error-signal.lisp:290).  FPSR bits,
+;;; W6-D41 proposes arm64::fpsr-* names.
+;;; ppc:497's fp-minor-opcode-operation NOT carried — PPC-instruction-
+;;; opcode keyed; only consumer is level-1/ppc-error-signal.lisp.
+(defun fp-condition-name-from-fpscr-status (status)
+  (cond
+    ((logbitp 0 status) 'floating-point-invalid-operation) ; FPSR.IOC
+    ((logbitp 1 status) 'division-by-zero)                 ; FPSR.DZC
+    ((logbitp 2 status) 'floating-point-overflow)          ; FPSR.OFC
+    ((logbitp 3 status) 'floating-point-underflow)         ; FPSR.UFC
+    ((logbitp 4 status) 'floating-point-inexact)))         ; FPSR.IXC
+
+;;; from ppc-float.lisp:507 (unguarded; "Don't we already have about 20
+;;; versions of this ?")
+(defarm64lapfunction %double-float-from-macptr! ((ptr arg_x) (byte-offset arg_y) (dest arg_z))
+  (macptr-ptr imm0 ptr)
+  (unbox-fixnum imm1 byte-offset)
+  (ldr d1 (:@ imm0 imm1))               ; lfdx → register-offset FP load
+  (put-double-float d1 dest)
+  (ret))
+
+;;; from ppc-float.lisp:515 (*rounding-mode-alist*)
+;;; ARM64 FPCR.RMode encoding: 0=RN(nearest) 1=RP(+inf) 2=RM(-inf) 3=RZ(zero)
+;;; — NOT PPC's (0=nearest 1=zero 2=+inf 3=-inf).  Same alist as ARM32
+;;; (arm-float.lisp:315-316, VFP = same encoding).
+(defvar *rounding-mode-alist*
+  '((:nearest . 0) (:positive . 1) (:negative . 2) (:zero . 3)))
+
+;;; ===================================================================
+;;; THE SOFTWARE HALF OF THE FPSCR MODEL.  See the cluster header above
+;;; for WHY the logical enables cannot live in hardware FPCR.
+;;;
+;;; ⚠ POSITION IS LOAD-ORDER-SENSITIVE, not stylistic.  These four forms
+;;; sat next to their LAP helpers ~150 lines up, and cold load died with
+;;;   FATAL (cold load, no lisp error system): undefined function %DEFVAR
+;;; (measured 16m44, image e53da35a).  %defvar is a level-1 function
+;;; (l1-utils.lisp) that nfasload's defvar/defparameter fasl ops call, so
+;;; a defvar is only safe at a point in cold load where it already exists.
+;;; *rounding-mode-alist* directly above is the proven-good position in
+;;; this file.  Keep this block here, and put new defvars beside it —
+;;; NOT beside the code that uses them.
+;;; ===================================================================
+
+;;; Default matches every other CCL port's initial fpu mode:
+;;; invalid + division-by-zero + overflow enabled, underflow/inexact not.
+(defvar *fp-logical-enables* #x0700)    ; IOE(8) | DZE(9) | OFE(10)
+
+(defun %get-fpscr-control ()
+  (logior (logand #xff00 *fp-logical-enables*) (%get-fpcr-rmode)))
+
+(defun %set-fpscr-control (new)
+  (setq *fp-logical-enables* (logand #xff00 new))
+  (%set-fpcr-rmode new)
+  new)
+
+;;; from ppc-float.lisp:394 (%ffi-exception-status)
+;;; enabled-and-occurred = captured flags AND (enables >> 8).  Returns NIL
+;;; when nothing fired, else the offending flag bits — the ARM32 contract
+;;; (arm-float.lisp:270-280); the %*-check-exception-* defuns test it with
+;;; WHEN.
+(defun %ffi-exception-status ()
+  (let* ((hit (logand (%get-post-ffi-fpsr)
+                      (ash (logand #xff00 *fp-logical-enables*) -8))))
+    (unless (eql 0 hit) hit)))
+
+;;; ---------------------------------------------------------------------
+;;; INLINE-arithmetic exception checkpoints.
+;;;
+;;; The FFI path above is not enough.  PPC64 and x86-64 catch an overflow in
+;;; an INLINE fp multiply with a hardware trap (PPC's %set-fpscr-control does
+;;; `mtfsf #xff', putting the enable bits in the real FPSCR, and
+;;; ppc-exceptions.c:1297 fields the SIGFPE).  AArch64 defines the same
+;;; enables — FPCR.IOE/DZE/OFE/UFE/IXE — but implementing them is OPTIONAL,
+;;; and they are RAZ/WI on this part.  MEASURED on Neoverse N1 (CPU part
+;;; 0xd0c): wrote 0x1f00 to FPCR, read back 0x0.  So there is no trap to take
+;;; and the only way to see the exception is to POLL the cumulative flags.
+;;;
+;;; This is the fallback arm of the intended design, NOT a statement that
+;;; "arm64 has no fp traps" — other AArch64 implementations may implement
+;;; them, in which case the right answer is a startup capability probe plus
+;;; a line-port of ppc-exceptions.c's SIGFPE path, and these checkpoints
+;;; become dead weight on that hardware.  See
+;;; comms/EXPT-ERROR-FP-OVERFLOW-FINDING.md.
+;;;
+;;; MEASURED, so that the next reader does not re-derive it: the cumulative
+;;; FPSR flags DO survive to a Lisp-level read — after a compiled multiply,
+;;; after the result is boxed, and under the interpreter (all three read
+;;; #x14 = OFC|IXC, against #x0 for a control with no arithmetic).  A poll
+;;; does NOT have to be adjacent to the operation.  One earlier observation
+;;; read #x0, and the only difference was a signalled error immediately
+;;; before it, so the unwind path is the suspect; poll BEFORE signalling
+;;; anything, which the callers below do by construction.
+;;;
+;;; The flags are STICKY, so a checkpoint must clear before the operation or
+;;; it will report an exception raised by unrelated earlier arithmetic.  That
+;;; clear is the same one ARM32 does before each of its FFI ops
+;;; (`#+arm-target (%set-fpscr-status 0)', l1-numbers.lisp).
+
+(defun %fp-begin-inline-check ()
+  "Clear the cumulative FPSR flags so a following %FP-INLINE-EXCEPTION-STATUS
+reports only what the operation in between raised."
+  (%set-fpscr-status 0)
+  nil)
+
+(defun %fp-inline-exception-status ()
+  "Enabled-and-occurred flags from the LIVE FPSR, or NIL.  The inline-
+arithmetic twin of %FFI-EXCEPTION-STATUS, which reads the ffcall spentry's
+captured copy and would return 0 here."
+  (let* ((hit (logand (%get-fpscr-status)
+                      (ash (logand #xff00 *fp-logical-enables*) -8))))
+    (unless (eql 0 hit) hit)))
+
+(defun %fp-check-inline-exception (operation operands status)
+  "Signal the fp condition named by STATUS, if any.  Unlike the
+%*-check-exception-N quartet this takes OPERANDS as a ready-made list and
+copies nothing: an integer-exponent EXPT has operands (float integer), so
+the double-float coercion those do would be wrong here."
+  (when status
+    (error (make-instance (or (fp-condition-name-from-fpscr-status status)
+                              'arithmetic-error)
+                          :operation operation
+                          :operands operands))))
+
+;;; from ppc-float.lisp:518 (get-fpu-mode) — ARM32 shape
+;;; (arm-float.lisp:318-341); control word per W6-D40/41: RMode (byte 2 22),
+;;; logical enables IOE=8 DZE=9 OFE=10 UFE=11 IXE=12.
+(defun get-fpu-mode (&optional (mode nil mode-p))
+  (let* ((flags (%get-fpscr-control)))
+    (declare (fixnum flags))
+    (let* ((rounding-mode
+            (car (nth (ldb (byte 2 22) flags) *rounding-mode-alist*)))
+           (overflow (logbitp 10 flags))         ; OFE
+           (underflow (logbitp 11 flags))        ; UFE
+           (division-by-zero (logbitp 9 flags))  ; DZE
+           (invalid (logbitp 8 flags))           ; IOE
+           (inexact (logbitp 12 flags)))         ; IXE
+      (if mode-p
+        (ecase mode
+          (:rounding-mode rounding-mode)
+          (:overflow overflow)
+          (:underflow underflow)
+          (:division-by-zero division-by-zero)
+          (:invalid invalid)
+          (:inexact inexact))
+        `(:rounding-mode ,rounding-mode
+          :overflow ,overflow
+          :underflow ,underflow
+          :division-by-zero ,division-by-zero
+          :invalid ,invalid
+          :inexact ,inexact)))))
+
+;;; from ppc-float.lisp:537 (set-fpu-mode) — ARM32 shape
+;;; (arm-float.lisp:344-381) with logior/logandc2 in place of ARM32's
+;;; bitsetf/bitclrf; returns the new control word (ARM32 returns its
+;;; %get-fpscr, which ppc-float has no analog of).
+(defun set-fpu-mode (&key (rounding-mode :nearest rounding-p)
+                          (overflow t overflow-p)
+                          (underflow t underflow-p)
+                          (division-by-zero t zero-p)
+                          (invalid t invalid-p)
+                          (inexact t inexact-p))
+  (let* ((current (%get-fpscr-control))
+         (new current))
+    (declare (fixnum current new))
+    (when rounding-p
+      (let* ((rc-bits (or
+                       (cdr (assoc rounding-mode *rounding-mode-alist*))
+                       (error "Unknown rounding mode: ~s" rounding-mode))))
+        (declare (fixnum rc-bits))
+        (setq new (dpb rc-bits (byte 2 22) new))))
+    (macrolet ((set-enable (flag-p flag bit)
+                 `(when ,flag-p
+                    (setq new (if ,flag
+                                (logior new (ash 1 ,bit))
+                                (logandc2 new (ash 1 ,bit)))))))
+      (set-enable invalid-p invalid 8)            ; IOE
+      (set-enable zero-p division-by-zero 9)      ; DZE
+      (set-enable overflow-p overflow 10)         ; OFE
+      (set-enable underflow-p underflow 11)       ; UFE
+      (set-enable inexact-p inexact 12))          ; IXE
+    (unless (= current new)
+      (%set-fpscr-control new))
+    new))
+
+;;; from ppc-float.lisp:574 (unguarded)
+;;; Copy a single float pointed at by the macptr in single
+;;; to a double float pointed at by the macptr in double.
+;;; PPC lfs widens on load; explicit fcvt here (arm-float.lisp:462-469 same).
+(defarm64lapfunction %single-float-ptr->double-float-ptr ((single arg_y) (double arg_z))
+  (check-nargs 2)
+  (macptr-ptr imm0 single)
+  (ldr s0 (:@ imm0 (:$ 0)))
+  (fcvt d1 s0)
+  (macptr-ptr imm0 double)
+  (str d1 (:@ imm0 (:$ 0)))
+  (ret))
+
+;;; from ppc-float.lisp:584 (unguarded)
+;;; Copy a double float pointed at by the macptr in double
+;;; to a single float pointed at by the macptr in single.
+(defarm64lapfunction %double-float-ptr->single-float-ptr ((double arg_y) (single arg_z))
+  (check-nargs 2)
+  (macptr-ptr imm0 double)
+  (ldr d0 (:@ imm0 (:$ 0)))
+  (fcvt s2 d0)
+  (macptr-ptr imm0 single)
+  (str s2 (:@ imm0 (:$ 0)))
+  (ret))
+
+;;; from ppc-float.lisp:593 (unguarded)
+;;; PPC stfs converts double→single on store; explicit fcvt here.
+(defarm64lapfunction %set-ieee-single-float-from-double ((src arg_y) (macptr arg_z))
+  (check-nargs 2)
+  (macptr-ptr imm0 macptr)
+  (get-double-float d1 src)
+  (fcvt s0 d1)
+  (str s0 (:@ imm0 (:$ 0)))
+  (ret))
+
+;;; from ppc-float.lisp:607 (#+ppc64-target; the :601 defun is ppc32)
+;;; Identical packing to PPC64 (bits in [63:32], subtag in the low byte):
+;;; the PPC64 body ports line-for-line.  fixnumshift=3 both.
+(defarm64lapfunction host-single-float-from-unsigned-byte-32 ((u32 arg_z))
+  (lsl arg_z u32 (:$ (- 32 arm64::fixnumshift)))
+  (orr arg_z arg_z (:$ arm64::subtag-single-float))
+  (ret))
+
+;;; from ppc-float.lisp:618 (#+ppc64-target; the :614 defun is ppc32)
+;;; Payload [63:32] → boxed fixnum; the low-nibble tag (1) falls off the
+;;; bottom of the 29-bit shift.  Line-for-line PPC64.
+(defarm64lapfunction single-float-bits ((f arg_z))
+  (lsr arg_z f (:$ (- 32 arm64::fixnumshift)))
+  (ret))
+
+;;; from ppc-float.lisp:622/626 (double-float-bits / double-float-from-bits)
+;;; LE cell adaptation: his value-cell(0) ALIASES val-low-cell(0) with the
+;;; high 32 bits in val-high-cell(1) (arm64-arch.lisp:433-437) — PPC64 (BE)
+;;; has value-cell = the HIGH half, so a verbatim port would read/write
+;;; cell 0 twice.  high/low semantics preserved via val-high/val-low cells.
+(defun double-float-bits (f)
+  (values (uvref f arm64::double-float.val-high-cell)
+          (uvref f arm64::double-float.val-low-cell)))
+
+(defun double-float-from-bits (high low)
+  (let* ((f (%make-dfloat)))
+    (setf (uvref f arm64::double-float.val-high-cell) high
+          (uvref f arm64::double-float.val-low-cell) low)
+    f))
+
+;;; from ppc-float.lisp:632 (unguarded)
+;;; PPC signed-compares the 32-bit high word; the sign is bit 63 of the
+;;; 64-bit value — tbz on the single ldur (catches -0.0, as PPC does).
+(defarm64lapfunction %double-float-sign ((n arg_z))
+  (ldur imm0 (:@ n (:$ arm64::double-float.value)))
+  (mov arg_z rnil)
+  (tbz imm0 (:$ 63) @done)
+  (add arg_z rnil (:$ arm64::t-offset))
+  @done
+  (ret))
+
+;;; from ppc-float.lisp:640 (unguarded; ppc64 body arm srdi-32 =
+;;; his get-single-float-bits); sign = bit 31 of the payload.
+(defarm64lapfunction %short-float-sign ((n arg_z))
+  (get-single-float-bits imm0 n)
+  (mov arg_z rnil)
+  (tbz imm0 (:$ 31) @done)
+  (add arg_z rnil (:$ arm64::t-offset))
+  @done
+  (ret))
+
+;;; from ppc-float.lisp:657 (#+64-bit-target %single-float-sqrt; the
+;;; destructive #+32-bit-target %single-float-sqrt! at :650 is SKIPped)
+(defarm64lapfunction %single-float-sqrt ((arg arg_z))
+  (get-single-float s1 arg)
+  (fsqrt s2 s1)
+  (put-single-float s2 arg_z)
+  (ret))
+
+;;; from ppc-float.lisp:663 (unguarded)
+(defarm64lapfunction %double-float-sqrt! ((src arg_y) (dest arg_z))
+  (get-double-float d1 src)
+  (fsqrt d2 d1)
+  (put-double-float d2 dest)
+  (ret))
+
+;;; from ppc-float.lisp:670 (#+poweropen-target %get-fp-arg-regs —
+;;; linuxppc64 is PowerOpen-ABI-family, so PPC64-reachable; FFI-CRITICAL
+;;; per W4-D13).  AAPCS64 re-shape (W6-D42): PPC dumps its 13 FP arg/result
+;;; registers f1-f13 into a 104-byte block; AAPCS64's FP arg/result
+;;; registers are d0-d7 — 8 doubles, d_i at byte offset 8*i, 64 bytes.
+;;; NB: this buffer is FPRs-only at offset 0; it is NOT the
+;;; ffcall-return-registers regbuf ({x0-x7@0..56, d0-d7@64..120},
+;;; spentry-E-ffi.s:286-289).
+(defarm64lapfunction %get-fp-arg-regs ((ptr arg_z))
+  (macptr-ptr imm0 ptr)
+  (str d0 (:@ imm0 (:$ 0)))
+  (str d1 (:@ imm0 (:$ 8)))
+  (str d2 (:@ imm0 (:$ 16)))
+  (str d3 (:@ imm0 (:$ 24)))
+  (str d4 (:@ imm0 (:$ 32)))
+  (str d5 (:@ imm0 (:$ 40)))
+  (str d6 (:@ imm0 (:$ 48)))
+  (str d7 (:@ imm0 (:$ 56)))
+  (ret))
+
+;;; from ppc-float.lisp:688 (#+poweropen-target %load-fp-arg-regs)
+;;; The d0-d7 loader named by W4-D13(b): n = BOXED count of FP args, ptr =
+;;; macptr to the fp-args block (layout above, W6-D42).  Loads d0..d(n-1)
+;;; then returns; spentry-E's ffcall expects "FP args already staged in
+;;; d0-d7" on entry (spentry-E-ffi.s:183, :235-237), so the future
+;;; AAPCS64 %ff-call defun calls this immediately before %do-ff-call.
+;;; PPC's 8-CR-field compare pipeline (cr0-cr7) serialized to one NZCV:
+;;; cmp/b.eq per step, with only flag-safe FP loads between (wave-1
+;;; convention).  Arity 13 → 8 (AAPCS64).
+(defarm64lapfunction %load-fp-arg-regs ((n arg_y) (ptr arg_z))
+  (cbz n @done)                         ; ppc:697 beqlr cr0
+  (macptr-ptr imm0 ptr)
+  (ldr d0 (:@ imm0 (:$ 0)))
+  (cmp n (:$ (ash 1 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d1 (:@ imm0 (:$ 8)))
+  (cmp n (:$ (ash 2 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d2 (:@ imm0 (:$ 16)))
+  (cmp n (:$ (ash 3 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d3 (:@ imm0 (:$ 24)))
+  (cmp n (:$ (ash 4 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d4 (:@ imm0 (:$ 32)))
+  (cmp n (:$ (ash 5 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d5 (:@ imm0 (:$ 40)))
+  (cmp n (:$ (ash 6 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d6 (:@ imm0 (:$ 48)))
+  (cmp n (:$ (ash 7 arm64::fixnumshift)))
+  (b.eq @done)
+  (ldr d7 (:@ imm0 (:$ 56)))
+  @done
+  (ret))

--- a/level-0/ARM64/arm64-hash.lisp
+++ b/level-0/ARM64/arm64-hash.lisp
@@ -1,0 +1,301 @@
+;;;; -*- Mode: Lisp; Package: CCL -*-
+;;;;
+;;;; arm64-hash.lisp — ARM64 LAP function drafts for hash functions
+;;;;
+;;;; Ported line-by-line from vendor/ccl/level-0/PPC/ppc-hash.lisp (PPC64 arms).
+;;;; Register map: Matt Emerson's upstream arm64 (arm64-asm.lisp).
+;;;; Tags: LOW tags, fixnumshift=3, misc-data-offset=4, misc-header-offset=-4.
+;;;;
+;;;; STATUS: LEAD-VERIFIED 2026-07-08 (line-by-line vs PPC64; assemble-gate clean
+;;;; except DECIDE-blocked sites — see drafts/wave1-verify-report.md)
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "HASHENV" "ccl:xdump;hashenv")
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; fast-mod — from vendor/ccl/level-0/PPC/ppc-hash.lisp:30
+;;; =====================================================================
+;;;
+;;; Equivalent to cl:mod when both args are positive fixnums.
+;;; PPC64: (divdu imm0 number divisor) (mulld arg_z imm0 divisor)
+;;;        (subf arg_z arg_z number)
+;;; ARM64: udiv + msub (or udiv + mul + sub).
+;;; Since both args are fixnums (tag bits = low 3 zeros), the division
+;;; and multiply work on the raw fixnum representation and the tag
+;;; bits cancel out correctly: number mod divisor = number - (number/divisor)*divisor
+;;; (all as fixnums, since fixnum arithmetic is closed under these ops
+;;; when both are positive and result < divisor).
+
+(defarm64lapfunction fast-mod ((number arg_y) (divisor arg_z))
+  ;; udiv imm0, number, divisor (unsigned integer divide)
+  (udiv imm0 number divisor)
+  ;; msub arg_z, imm0, divisor, number  =  number - imm0*divisor
+  (msub arg_z imm0 divisor number)
+  (ret))
+
+;;; =====================================================================
+;;; fast-mod-3 — from vendor/ccl/level-0/PPC/ppc-hash.lisp:43
+;;; =====================================================================
+;;;
+;;; Fast modulo using a reciprocal approximation.
+;;; PPC64: srdi, mulhd, mulld, sub, sub, srari, and, add.
+;;; The algorithm: unbox number, multiply high by recip, multiply low by
+;;; divisor to get quotient*divisor, subtract twice, then fix up with
+;;; conditional add.
+;;;
+;;; On ARM64: smulh replaces mulhd (signed multiply high), umulh for unsigned.
+;;; PPC64 uses mulhd which is SIGNED multiply-high.
+
+(defarm64lapfunction fast-mod-3 ((number arg_x) (divisor arg_y) (recip arg_z))
+  ;; (srdi imm0 number ppc64::fixnumshift) — unbox number
+  (lsr imm0 number (:$ arm64::fixnumshift))
+  ;; (mulhd imm1 imm0 recip) — signed multiply high
+  (smulh imm1 imm0 recip)
+  ;; (mulld imm0 imm1 divisor) — quotient * divisor
+  (mul imm0 imm1 divisor)
+  ;; (sub number number imm0)
+  (sub number number imm0)
+  ;; (sub number number divisor)
+  (sub number number divisor)
+  ;; (srari imm0 number (1- target::nbits-in-word)) — arithmetic shift right 63
+  ;; This produces 0 if number >= 0, -1 if number < 0 (sign extension)
+  (asr imm0 number (:$ (1- arm64::nbits-in-word)))
+  ;; (and divisor divisor imm0) — divisor if number < 0, else 0
+  (and divisor divisor imm0)
+  ;; (add arg_z number divisor)
+  (add arg_z number divisor)
+  (ret))
+
+;;; =====================================================================
+;;; %dfloat-hash — from vendor/ccl/level-0/PPC/ppc-hash.lisp:70 (ppc64 arm)
+;;; =====================================================================
+;;;
+;;; PPC64: load 64-bit double value, box as fixnum.
+;;; On arm64, double-float.value = misc-data-offset = 4.
+
+(defarm64lapfunction %dfloat-hash ((key arg_z))
+  ;; (ld imm0 ppc64::double-float.value key)
+  (ldur imm0 (:@ key (:$ arm64::double-float.value)))
+  ;; (box-fixnum arg_z imm0)
+  (box-fixnum arg_z imm0)
+  (ret))
+
+;;; =====================================================================
+;;; %sfloat-hash — from vendor/ccl/level-0/PPC/ppc-hash.lisp:82 (ppc64 arm)
+;;; =====================================================================
+;;;
+;;; PPC64 version: checks for negative zero (0x80000000 in upper 32 bits),
+;;; returns 0 for -0.0, otherwise shifts the float bits to a fixnum.
+;;; On arm64: single-floats are IMMEDIATE (IEEE bits in upper 32 of tagged word).
+;;; The hash is derived from those bits.
+;;;
+;;; PPC64 code:
+;;;   (lis imm0 #x8000)          ; imm0 = 0x80000000
+;;;   (srdi imm1 key 32)         ; imm1 = upper 32 bits of tagged sf
+;;;   (cmpw imm0 imm1)           ; is it negative zero?
+;;;   (srdi arg_z key (- 32 ppc64::fixnumshift))  ; shift to fixnum
+;;;   (bnelr)                     ; not neg-zero, return
+;;;   (li arg_z 0)               ; neg-zero hashes to 0
+;;;   (blr)
+;;;
+;;; On arm64 with immediate single-floats: same logic applies.
+;;; The tagged single-float has IEEE bits in [63:32] and tag in [2:0].
+;;; Extract upper 32 bits, check for -0 (0x80000000), produce fixnum.
+
+(defarm64lapfunction %sfloat-hash ((key arg_z))
+  ;; (lis imm0 #x8000) — load 0x80000000
+  (mov imm0 (:$ #x80000000))
+  ;; (srdi imm1 key 32) — extract upper 32 bits (IEEE float value)
+  (lsr imm1 key (:$ 32))
+  ;; (cmpw imm0 imm1) — is it negative zero?
+  (cmp imm0 imm1)
+  ;; (srdi arg_z key (- 32 ppc64::fixnumshift)) — shift to fixnum position
+  ;; On arm64: fixnumshift=3, so shift right by 29 (= 32-3)
+  (lsr arg_z key (:$ (- 32 arm64::fixnumshift)))
+  ;; Clear the tag bits that leaked into the fixnum.
+  ;; ldb wrap: Matt's encode-logical-immediate rejects negative lisp
+  ;; integers, so the lognot mask must be expressed as unsigned 64-bit.
+  (and arg_z arg_z (:$ (ldb (byte 64 0) (lognot arm64::fixnummask))))
+  (b.ne @done)
+  ;; Negative zero — hash to 0
+  (mov arg_z (:$ 0))
+  @done
+  (ret))
+
+;;; =====================================================================
+;;; %macptr-hash — from vendor/ccl/level-0/PPC/ppc-hash.lisp:91
+;;; =====================================================================
+;;;
+;;; PPC64: load macptr address, add high-shifted version, clear low bits
+;;; for fixnum.
+;;; (ldr imm0 target::macptr.address key)
+;;; (slri imm1 imm0 24)              — shift right by 24 (PPC slri=shift LEFT??)
+;;; Wait: in the INVENTORY.md, the macros used are: clrrri, ldr, slri.
+;;; PPC source: (slri imm1 imm0 24) (add imm0 imm0 imm1) (clrrri arg_z imm0 fixnumshift)
+;;; From the transform table: slri = shift LEFT immediate.
+;;; So: imm1 = imm0 << 24?? That doesn't make sense for hashing (would lose bits).
+;;; Let me re-read the PPC source carefully.
+
+;;; PPC source (ppc-hash.lisp:91-96):
+;;;   (ldr imm0 target::macptr.address key)
+;;;   (slri imm1 imm0 24)
+;;;   (add imm0 imm0 imm1)
+;;;   (clrrri arg_z imm0 target::fixnumshift)
+;;;
+;;; Wait — looking at the lapmacros-report.md transform table:
+;;;   slri (dest, src, n) -> lsl dest, src, #n  (Shift left immediate)
+;;;   srri (dest, src, n) -> lsr dest, src, #n  (Logical shift right immediate)
+;;;
+;;; So (slri imm1 imm0 24) = imm1 = imm0 << 24.  That means we add the
+;;; address shifted LEFT by 24 to itself.  This mixes high bits into the
+;;; hash... hmm, this IS a hash function so spreading bits is the point.
+;;; Actually wait — re-reading ppc-lapmacros.lisp more carefully:
+;;; PPC sldi = shift left doubleword immediate = "slri" macro in the codebase?
+;;; Let me check: the INVENTORY uses "slri" as "shift left register immediate".
+;;; From ppc-lapmacros.lisp, slri is defined as rldicr (rotate left doubleword
+;;; immediate then clear right) which IS shift-left.
+;;; BUT looking at the hash context: adding (addr << 24) to addr makes the hash
+;;; LARGER, mixing low bits with high bits.  That's reasonable for a pointer hash.
+;;; Actually I think this is srri (shift RIGHT) not slri.  Let me re-check.
+;;;
+;;; Re-reading ppc-hash.lisp:91-96 raw:
+;;;   (defppclapfunction %macptr-hash ((key arg_z))
+;;;     (ldr imm0 target::macptr.address key)
+;;;     (slri imm1 imm0 24)
+;;;     (add imm0 imm0 imm1)
+;;;     (clrrri arg_z imm0 target::fixnumshift)
+;;;     (blr))
+;;;
+;;; With slri = shift LEFT by 24: imm1 = addr << 24, result = addr + (addr<<24)
+;;; with low fixnumshift bits cleared.  This is the hash.  It works because
+;;; addresses are typically in a limited range and the left-shift spreads
+;;; the interesting bits (byte offsets 0-15) into the upper portion.
+;;; On ARM64: lsl for shift left.
+
+(defarm64lapfunction %macptr-hash ((key arg_z))
+  ;; (ldr imm0 target::macptr.address key)
+  (macptr-ptr imm0 key)
+  ;; (slri imm1 imm0 24) — shift left by 24
+  (lsl imm1 imm0 (:$ 24))
+  ;; (add imm0 imm0 imm1)
+  (add imm0 imm0 imm1)
+  ;; (clrrri arg_z imm0 target::fixnumshift) — clear low fixnumshift bits
+  ;; ARM64: and with ~((1<<fixnumshift)-1) = ~7; ldb wrap because Matt's
+  ;; encode-logical-immediate rejects negative lisp integers.
+  (and arg_z imm0 (:$ (ldb (byte 64 0) (lognot (1- (ash 1 arm64::fixnumshift))))))
+  (ret))
+
+;;; =====================================================================
+;;; %bignum-hash — from vendor/ccl/level-0/PPC/ppc-hash.lisp:121 (ppc64 arm)
+;;; =====================================================================
+;;;
+;;; Hash a bignum by XOR-accumulating 32-bit digits with rotate.
+;;; PPC64: rotldi (64-bit rotate left by 13), add accumulation, lwzx loads.
+;;; Loop over 32-bit digits (header-size gives count of 32-bit elements).
+
+(defarm64lapfunction %bignum-hash ((key arg_z))
+  (let ((header imm3)
+        (offset imm2)
+        (ndigits imm1)
+        (immhash imm0))
+    (mov immhash (:$ 0))
+    (mov offset (:$ arm64::misc-data-offset))
+    (getvheader header key)
+    (header-size ndigits header)
+    (let ((next header))           ; reuse header reg as temp for loaded word
+      @loop
+      ;; PPC64 uses cmpdi+bne with pre-decrement compare; ARM64: decrement
+      ;; then cbnz (equivalent: loop while count-after-decrement > 0).
+      (sub ndigits ndigits (:$ 1))
+      ;; (lwzx next key offset) — 32-bit digit load; w3 = W alias of
+      ;; next/header/imm3/x3 (Matt's arm64-asm.lisp:146); avoids
+      ;; over-reading past the last digit.
+      (add imm4 key offset)
+      (ldr w3 (:@ imm4 (:$ 0)))
+      ;; (rotldi immhash immhash 13) — 64-bit rotate left by 13 = ror #51
+      (ror immhash immhash (:$ 51))
+      ;; (addi offset offset 4)
+      (add offset offset (:$ 4))
+      ;; (add immhash immhash next)
+      (add immhash immhash next)
+      (cbnz ndigits @loop))
+    ;; (clrrdi arg_z immhash ppc64::fixnumshift) — clear low 3 bits for
+    ;; fixnum; ldb wrap for Matt's negative-immediate encoder restriction.
+    (and arg_z immhash (:$ (ldb (byte 64 0) (lognot (1- (ash 1 arm64::fixnumshift))))))
+    (ret)))
+
+;;; =====================================================================
+;;; %get-fwdnum — from vendor/ccl/level-0/PPC/ppc-hash.lisp:143
+;;; =====================================================================
+;;;
+;;; Return the GC forwarding generation number (a fixnum kernel global).
+
+(defarm64lapfunction %get-fwdnum ()
+  (ref-global arg_z fwdnum)
+  (ret))
+
+;;; =====================================================================
+;;; %get-gc-count — from vendor/ccl/level-0/PPC/ppc-hash.lisp:148
+;;; =====================================================================
+;;;
+;;; Return the GC call count (a fixnum kernel global).
+
+(defarm64lapfunction %get-gc-count ()
+  (ref-global arg_z gc-count)
+  (ret))
+
+;;; =====================================================================
+;;; %set-hash-table-vector-key — from vendor/ccl/level-0/PPC/ppc-hash.lisp:155
+;;; =====================================================================
+;;;
+;;; Setting a key needs to ensure the vector header gets memoized (GC barrier).
+;;; Tail-calls .SPset-hash-key subprim.
+
+(defarm64lapfunction %set-hash-table-vector-key ((vector arg_x) (index arg_y) (value arg_z))
+  (jump-subprim .SPset-hash-key))
+
+;;; =====================================================================
+;;; %set-hash-table-vector-key-conditional — from vendor/ccl/level-0/PPC/ppc-hash.lisp:158
+;;; =====================================================================
+;;;
+;;; Conditional key set — tail-calls .SPset-hash-key-conditional.
+;;; Note: has a stack arg (offset at vsp+0).
+
+(defarm64lapfunction %set-hash-table-vector-key-conditional ((offset 0) (vector arg_x) (old arg_y) (new arg_z))
+  (jump-subprim .SPset-hash-key-conditional))
+
+;;; =====================================================================
+;;; strip-tag-to-fixnum — from vendor/ccl/level-0/PPC/ppc-hash.lisp:162
+;;; =====================================================================
+;;;
+;;; Strip tag bits from x, producing a fixnum.
+;;; PPC64: (clrlri. imm0 arg_z (- nbits-in-word fixnumshift))
+;;;        (beq @done)                    ; already a fixnum (low bits zero)
+;;;        (clrrri arg_z x ntagbits)      ; clear low ntagbits
+;;;        (srri arg_z arg_z (- ntagbits fixnumshift))  ; shift to fixnum
+;;;        @done (blr)
+;;;
+;;; On arm64: ntagbits=4, fixnumshift=3, nbits-in-word=64.
+;;; clrlri. with n=(64-3)=61 clears the top 61 bits and sets flags:
+;;;   ands imm0, arg_z, #0x7 (tagmask)
+;;; If the low 3 bits are zero, it's already a fixnum — return as-is.
+;;; Otherwise: clear low 4 bits (fulltag), shift right by (4-3)=1.
+;;; = (arg_z & ~0xF) >> 1
+
+(defarm64lapfunction strip-tag-to-fixnum ((x arg_z))
+  ;; (clrlri. imm0 arg_z (- target::nbits-in-word target::fixnumshift))
+  ;; = ands imm0, arg_z, #((1<<fixnumshift)-1) = ands imm0, arg_z, #7
+  (ands imm0 arg_z (:$ arm64::fixnummask))
+  (b.eq @done)
+  ;; (clrrri arg_z x target::ntagbits) — clear low ntagbits bits
+  ;; = and arg_z, x, ~((1<<ntagbits)-1) = and arg_z, x, ~0xF;
+  ;; ldb wrap for Matt's negative-immediate encoder restriction.
+  (and arg_z x (:$ (ldb (byte 64 0) (lognot (1- (ash 1 arm64::ntagbits))))))
+  ;; (srri arg_z arg_z (- target::ntagbits target::fixnumshift))
+  ;; = lsr arg_z, arg_z, #(4-3) = lsr arg_z, arg_z, #1
+  (lsr arg_z arg_z (:$ (- arm64::ntagbits arm64::fixnumshift)))
+  @done
+  (ret))

--- a/level-0/ARM64/arm64-io.lisp
+++ b/level-0/ARM64/arm64-io.lisp
@@ -1,0 +1,52 @@
+;;;; -*- Mode: Lisp; Package: CCL -*-
+;;;;
+;;;; arm64-io.lisp — ARM64 LAP function drafts for I/O functions
+;;;;
+;;;; Ported line-by-line from vendor/ccl/level-0/PPC/ppc-io.lisp (PPC64 arm).
+;;;; Register map: Matt Emerson's upstream arm64 (arm64-asm.lisp).
+;;;; Tags: LOW tags, fixnumshift=3.
+;;;;
+;;;; STATUS: LEAD-VERIFIED 2026-07-08 (line-by-line vs PPC64; assemble-gate clean
+;;;; except DECIDE-blocked sites — see drafts/wave1-verify-report.md)
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; %get-errno — from vendor/ccl/level-0/PPC/ppc-io.lisp:23
+;;; =====================================================================
+;;;
+;;; PPC64 source:
+;;;   (ldr imm1 target::tcr.errno-loc target::rcontext)  ; load ptr to errno
+;;;   (lwz imm0 0 imm1)                                   ; load errno (32-bit int)
+;;;   (stw rzero 0 imm1)                                  ; clear errno
+;;;   (neg imm0 imm0)                                     ; negate (CCL convention)
+;;;   (box-fixnum arg_z imm0)                             ; return as fixnum
+;;;   (blr)
+;;;
+;;; Key offsets (arm64-arch.lisp):
+;;;   tcr.errno-loc = 128 (byte offset from rcontext)
+;;;
+;;; On ARM64: errno is a 32-bit signed int at the address stored in
+;;; tcr.errno-loc.  Matt's assembler has full W-register (32-bit)
+;;; ldr/str templates and parses w0-w30/wzr (asm.lisp:39,699), so lwz/stw
+;;; map directly — no width workaround needed.  Note wN in LAP names the
+;;; ARCHITECTURAL register N; imm0 = x0 upstream (arm64-asm.lisp:143
+;;; define-register-alias), so its W alias is w0.
+
+(defarm64lapfunction %get-errno ()
+  ;; (ldr imm1 target::tcr.errno-loc target::rcontext)
+  (ldr imm1 (:@ rcontext (:$ arm64::tcr.errno-loc)))
+  ;; (lwz imm0 0 imm1) — 32-bit zero-extending load, exactly ldr wN
+  (ldr w0 (:@ imm1 (:$ 0)))              ; w0 = W alias of imm0/x0
+  ;; (stw rzero 0 imm1) — clear errno with a true 32-bit store; an 8-byte
+  ;; str would overwrite the 4 bytes after errno.
+  (str wzr (:@ imm1 (:$ 0)))
+  ;; (neg imm0 imm0) — errno was zero-extended by the W load, so a small
+  ;; positive negates correctly in 64 bits.
+  (sub imm0 xzr imm0)
+  ;; (box-fixnum arg_z imm0) — shift left by fixnumshift
+  (box-fixnum arg_z imm0)
+  (ret))

--- a/level-0/ARM64/arm64-misc.lisp
+++ b/level-0/ARM64/arm64-misc.lisp
@@ -1,0 +1,917 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-misc.lisp — ACTIVE seed of level-0/ARM64/ for Matt Emerson's
+;;; upstream arm64 tree (pin 6b6540e).  Deployed into
+;;; $UPSTREAM_ROOT/level-0/ARM64/ by tools/upstream-compile-test.sh before
+;;; the xload dump; grows DEMAND-DRIVEN — each boot's cold-load fatal names
+;;; the next function to lift from upstream-port/level-0/drafts/arm64-misc.lisp.
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/ppc-misc.lisp)
+;;; Per-line citations: "; ppc:NNN" = line NNN of that file.
+;;;
+;;; TCR/area offsets resolve SYMBOLICALLY against his arm64-arch.lisp, which
+;;; the kernel's arm64-constants.h asserts itself in sync with (tcr.spare
+;;; static check) — W4-D20 reconciled at this pin.  Current values, for the
+;;; reader: tcr.save-vsp=32, tcr.vs-area=56; area.high=24, area.active=32.
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; %current-tcr — ppc:445
+;;; =====================================================================
+(defarm64lapfunction %current-tcr ()
+  (mov arg_z rcontext)                             ; ppc:446
+  (ret))                                           ; ppc:447
+
+;;; =====================================================================
+;;; %tcr-toplevel-function — ppc:449
+;;; =====================================================================
+;;; cr0 used twice (tcr vs rcontext; then high vs active/vsp).  Loads are
+;;; flag-safe so each (cmp) is placed just before its branch.
+(defarm64lapfunction %tcr-toplevel-function ((tcr arg_z))
+  (check-nargs 1)                                  ; ppc:450
+  (mov imm0 vsp)                                   ; ppc:452 (default vsp)
+  (ldr temp0 (:@ tcr (:$ arm64::tcr.vs-area)))     ; ppc:453 (vs-area=56)
+  (ldr imm1 (:@ temp0 (:$ arm64::area.high)))      ; ppc:454 (area.high=24)
+  (cmp tcr rcontext)                               ; ppc:451 (cmpr)
+  (b.eq @room)                                     ; ppc:455 (beq)
+  (ldr imm0 (:@ temp0 (:$ arm64::area.active)))    ; ppc:456 (area.active=32)
+  @room
+  (cmp imm1 imm0)                                  ; ppc:458 (cmpr)
+  (mov arg_z rnil)                                 ; ppc:459 (li nil — flag-safe)
+  (b.eq @done)                                     ; ppc:460 (beqlr)
+  (ldur arg_z (:@ imm1 (:$ (- arm64::node-size)))) ; ppc:461 ([high - node-size])
+  @done
+  (ret))                                           ; ppc:462
+
+;;; =====================================================================
+;;; %set-tcr-toplevel-function — ppc:464
+;;; =====================================================================
+(defarm64lapfunction %set-tcr-toplevel-function ((tcr arg_y) (fun arg_z))
+  (check-nargs 2)                                  ; ppc:465
+  (mov imm0 vsp)                                   ; ppc:467
+  (ldr temp0 (:@ tcr (:$ arm64::tcr.vs-area)))     ; ppc:468
+  (ldr imm1 (:@ temp0 (:$ arm64::area.high)))      ; ppc:469
+  (cmp tcr rcontext)                               ; ppc:466 (cmpr)
+  (b.eq @check-room)                               ; ppc:470 (beq)
+  (ldr imm0 (:@ temp0 (:$ arm64::area.active)))    ; ppc:471
+  @check-room
+  (cmp imm1 imm0)                                  ; ppc:473 (cmpr)
+  (push xzr imm1)                                  ; ppc:474 (push rzero imm1 — flag-safe)
+  (b.ne @have-room)                                ; ppc:475 (bne)
+  (str imm1 (:@ temp0 (:$ arm64::area.active)))    ; ppc:476
+  (str imm1 (:@ tcr (:$ arm64::tcr.save-vsp)))     ; ppc:477 (save-vsp=32)
+  @have-room
+  (str fun (:@ imm1 (:$ 0)))                       ; ppc:479
+  (ret))                                           ; ppc:480
+
+;;; =====================================================================
+;;; interrupt-level — ppc:409
+;;; =====================================================================
+(defarm64lapfunction interrupt-level ()
+  (ldr arg_z (:@ rcontext (:$ arm64::tcr.tlb-pointer)))            ; ppc:410
+  (ldr arg_z (:@ arg_z (:$ arm64::interrupt-level-binding-index))) ; ppc:411
+  (ret))                                           ; ppc:412
+
+;;; =====================================================================
+;;; disable-lisp-interrupts — ppc:415
+;;; =====================================================================
+(defarm64lapfunction disable-lisp-interrupts ()
+  (mov imm0 (:$ (ash -1 arm64::fixnumshift)))      ; ppc:416 (li imm0 '-1)
+  (ldr imm1 (:@ rcontext (:$ arm64::tcr.tlb-pointer)))             ; ppc:417
+  (ldr arg_z (:@ imm1 (:$ arm64::interrupt-level-binding-index)))  ; ppc:418
+  (str imm0 (:@ imm1 (:$ arm64::interrupt-level-binding-index)))   ; ppc:419
+  (ret))                                           ; ppc:420
+
+;;; =====================================================================
+;;; set-interrupt-level — ppc:422
+;;; =====================================================================
+(defarm64lapfunction set-interrupt-level ((new arg_z))
+  (ldr imm1 (:@ rcontext (:$ arm64::tcr.tlb-pointer)))             ; ppc:423
+  (trap-unless-lisptag= new arm64::tag-fixnum imm0)                ; ppc:424
+  (str new (:@ imm1 (:$ arm64::interrupt-level-binding-index)))    ; ppc:425
+  (ret))                                           ; ppc:426
+
+;;; =====================================================================
+;;; restore-interrupt-level — ppc:430
+;;; =====================================================================
+;;; Two CR fields (cr1: old vs 0; cr0: interrupt-pending vs 0) serialized:
+;;; loads are flag-safe, so both (cmp) sit right before their branches.
+(defarm64lapfunction restore-interrupt-level ((old arg_z))
+  (ldr imm0 (:@ rcontext (:$ arm64::tcr.interrupt-pending)))       ; ppc:432
+  (ldr imm1 (:@ rcontext (:$ arm64::tcr.tlb-pointer)))             ; ppc:433
+  (cmp old (:$ 0))                                 ; ppc:431 (cmpri cr1)
+  (b.ne @store)                                    ; ppc:435 (bne cr1)
+  (cmp imm0 (:$ 0))                                ; ppc:434 (cmpri cr0)
+  (b.eq @store)                                    ; ppc:436 (beq cr0)
+  (str xzr (:@ rcontext (:$ arm64::tcr.interrupt-pending)))        ; ppc:437
+  (mov old (:$ (ash 1 arm64::fixnumshift)))        ; ppc:438 (li old '1)
+  @store
+  (str old (:@ imm1 (:$ arm64::interrupt-level-binding-index)))    ; ppc:440
+  (ret))                                           ; ppc:441
+
+;;; =====================================================================
+;;; set-%gcable-macptrs% — ppc:505
+;;; =====================================================================
+;;; imm0 = &gcable-pointers (rnil + negative kernel-global offset → sub).
+;;; Push ptr onto the gcable list head atomically.  status=(:w temp4)
+;;; per the kernel ll/sc idiom (spentry-B:113-129).
+(defarm64lapfunction set-%gcable-macptrs% ((ptr arg_z))
+  (sub imm0 rnil (:$ (- (arm64::%kernel-global 'gcable-pointers)))) ; ppc:506
+  @again
+  (ldxr arg_y (:@ imm0))                           ; ppc:508 lrarx (old head)
+  (stur arg_y (:@ ptr (:$ arm64::xmacptr.link)))   ; ppc:509
+  (stxr (:w temp4) ptr (:@ imm0))                  ; ppc:510 strcx.
+  (cbnz (:w temp4) @again)                         ; ppc:511
+  (dmb (:$ 11))                                    ; ppc:512 isync → dmb ish
+  (ret))                                           ; ppc:513
+
+;;; =====================================================================
+;;; get-saved-register-values — ppc:933  (modern arch: plain DEFUN)
+;;; =====================================================================
+;;; The PPC LAP vpushes save0..save7 (8-NVR specific).  The x86-64 and
+;;; ARM32 twins both reduce this to (values) (x86-misc:805, arm-misc:1066);
+;;; call-check-regs (l1-readloop) then trivially passes.  Follow them.
+(defun get-saved-register-values ()
+  (values))
+
+;;; =====================================================================
+;;; %current-db-link — ppc:947
+;;; =====================================================================
+(defarm64lapfunction %current-db-link ()
+  (ldr arg_z (:@ rcontext (:$ arm64::tcr.db-link))) ; ppc:948
+  (ret))                                           ; ppc:949
+
+;;; =====================================================================
+;;; %no-thread-local-binding-marker — ppc:951
+;;; =====================================================================
+(defarm64lapfunction %no-thread-local-binding-marker ()
+  (mov arg_z (:$ arm64::subtag-no-thread-local-binding)) ; ppc:952
+  (ret))                                           ; ppc:953
+
+;;; =====================================================================
+;;; %store-node-conditional — ppc:483
+;;; =====================================================================
+;;; Whole body = TAIL jump to the EGC-memoizing subprim (PPC: ba).
+(defarm64lapfunction %store-node-conditional ((offset 0) (object arg_x) (old arg_y) (new arg_z))
+  (jump-subprim .SPstore-node-conditional))        ; ppc:484 (ba)
+
+;;; =====================================================================
+;;; %store-immediate-conditional — ppc:486
+;;; =====================================================================
+;;; ll/sc: current=temp1, status=(:w temp4).  offset vpop'd, unboxed, added
+;;; into imm1... base kept in imm2 ([Xn]-only; imm1 is macro scratch).
+(defarm64lapfunction %store-immediate-conditional ((offset 0) (object arg_x) (old arg_y) (new arg_z))
+  (vpop temp0)                                     ; ppc:487
+  (unbox-fixnum imm0 temp0)                        ; ppc:488
+  (add imm2 object imm0)                           ; base = object+offset
+  @again
+  (ldxr temp1 (:@ imm2))                           ; ppc:491 lrarx current
+  (cmp temp1 old)                                  ; ppc:492 cmpr
+  (b.ne @lose)                                     ; ppc:493 (bne)
+  (stxr (:w temp4) new (:@ imm2))                  ; ppc:494 strcx.
+  (cbnz (:w temp4) @again)                         ; ppc:495 (bne @again)
+  (dmb (:$ 11))                                    ; ppc:496 isync → dmb ish
+  (add arg_z rnil (:$ arm64::t-offset))            ; ppc:497 (li arg_z T)
+  (ret)                                            ; ppc:498
+  @lose
+  (clrex)                                          ; ppc:500-501 reservation-discharge
+  (mov arg_z rnil)                                 ; ppc:502 (li nil)
+  (ret))                                           ; ppc:503
+
+;;; =====================================================================
+;;; %atomic-incf-node — ppc:555
+;;; =====================================================================
+(defarm64lapfunction %atomic-incf-node ((by arg_x) (node arg_y) (disp arg_z))
+  (check-nargs 3)                                 ; ppc:556
+  (unbox-fixnum imm1 disp)                          ; ppc:557
+  (add imm0 node imm1)                             ; base = node+disp ([Xn]-only)
+  @again
+  (ldxr arg_z (:@ imm0))                           ; ppc:559 lrarx
+  (add arg_z arg_z by)                             ; ppc:560
+  (stxr (:w temp4) arg_z (:@ imm0))                ; ppc:561 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:562 (bne- @again)
+  (dmb (:$ 11))                                    ; ppc:563 isync
+  (ret))                                           ; ppc:564
+
+;;; =====================================================================
+;;; %atomic-incf-ptr — ppc:566
+;;; =====================================================================
+(defarm64lapfunction %atomic-incf-ptr ((ptr arg_z))
+  (macptr-ptr imm1 ptr)                            ; ppc:567 (base — [Xn] directly)
+  @again
+  (ldxr imm0 (:@ imm1))                            ; ppc:569 lrarx
+  (add imm0 imm0 (:$ 1))                           ; ppc:570 (addi raw +1)
+  (stxr (:w temp4) imm0 (:@ imm1))                 ; ppc:571 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:572
+  (dmb (:$ 11))                                    ; ppc:573 isync
+  (box-fixnum arg_z imm0)                           ; ppc:574
+  (ret))                                           ; ppc:575
+
+;;; =====================================================================
+;;; %atomic-incf-ptr-by — ppc:577
+;;; =====================================================================
+(defarm64lapfunction %atomic-incf-ptr-by ((ptr arg_y) (by arg_z))
+  (macptr-ptr imm1 ptr)                            ; ppc:578
+  (unbox-fixnum imm2 by)                            ; ppc:579
+  @again
+  (ldxr imm0 (:@ imm1))                            ; ppc:581 lrarx
+  (add imm0 imm0 imm2)                             ; ppc:582
+  (stxr (:w temp4) imm0 (:@ imm1))                 ; ppc:583 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:584
+  (dmb (:$ 11))                                    ; ppc:585 isync
+  (box-fixnum arg_z imm0)                           ; ppc:586
+  (ret))                                           ; ppc:587
+
+;;; =====================================================================
+;;; %atomic-decf-ptr — ppc:589
+;;; =====================================================================
+(defarm64lapfunction %atomic-decf-ptr ((ptr arg_z))
+  (macptr-ptr imm1 ptr)                            ; ppc:590
+  @again
+  (ldxr imm0 (:@ imm1))                            ; ppc:592 lrarx
+  (sub imm0 imm0 (:$ 1))                           ; ppc:593 (subi raw 1)
+  (stxr (:w temp4) imm0 (:@ imm1))                 ; ppc:594 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:595
+  (dmb (:$ 11))                                    ; ppc:596 isync
+  (box-fixnum arg_z imm0)                           ; ppc:597
+  (ret))                                           ; ppc:598
+
+;;; =====================================================================
+;;; %atomic-decf-ptr-if-positive — ppc:600
+;;; =====================================================================
+;;; cmp imm0 0 flags survive the flag-safe (sub) to b.eq (skip store when
+;;; the loaded value was 0).  Note PPC boxes the ALREADY-decremented imm0 on
+;;; the @done path (value was 0 → returns boxed -1) — preserved.
+(defarm64lapfunction %atomic-decf-ptr-if-positive ((ptr arg_z))
+  (macptr-ptr imm1 ptr)                            ; ppc:601
+  @again
+  (ldxr imm0 (:@ imm1))                            ; ppc:603 lrarx
+  (cmp imm0 (:$ 0))                               ; ppc:604 (cmpri cr1)
+  (sub imm0 imm0 (:$ 1))                           ; ppc:605 (subi 1 — flag-safe)
+  (b.eq @done)                                     ; ppc:606 (beq) value was 0
+  (stxr (:w temp4) imm0 (:@ imm1))                 ; ppc:607 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:608
+  (dmb (:$ 11))                                    ; ppc:609 isync
+  (box-fixnum arg_z imm0)                           ; ppc:610
+  (ret)                                            ; ppc:611
+  @done
+  (clrex)                                          ; ppc:613-615 reservation-discharge
+  (box-fixnum arg_z imm0)                           ; ppc:614
+  (ret))                                           ; ppc:616
+
+;;; =====================================================================
+;;; %atomic-swap-ptr — ppc:618
+;;; =====================================================================
+(defarm64lapfunction %atomic-swap-ptr ((ptr arg_y) (newval arg_z))
+  (dmb (:$ 11))                                    ; ppc:619 (sync → dmb ish)
+  (macptr-ptr imm1 ptr)                            ; ppc:620
+  (unbox-fixnum imm2 arg_z)                         ; ppc:621 (newval)
+  @again
+  (ldxr imm0 (:@ imm1))                            ; ppc:623 lrarx
+  (stxr (:w temp4) imm2 (:@ imm1))                 ; ppc:624 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:625
+  (dmb (:$ 11))                                    ; ppc:626 isync
+  (box-fixnum arg_z imm0)                           ; ppc:627
+  (ret))                                           ; ppc:628
+
+;;; =====================================================================
+;;; %ptr-store-conditional — ppc:632
+;;; =====================================================================
+(defarm64lapfunction %ptr-store-conditional ((ptr arg_x) (expected-oldval arg_y) (newval arg_z))
+  (macptr-ptr imm0 ptr)                            ; ppc:633 (base)
+  (unbox-fixnum imm1 expected-oldval)              ; ppc:634
+  (unbox-fixnum imm2 newval)                        ; ppc:635
+  @again
+  (ldxr imm3 (:@ imm0))                            ; ppc:637 lrarx
+  (cmp imm3 imm1)                                  ; ppc:638 cmpr
+  (b.ne @done)                                     ; ppc:639 (bne-)
+  (stxr (:w temp4) imm2 (:@ imm0))                 ; ppc:640 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:641 (bne- @again)
+  (dmb (:$ 11))                                    ; ppc:642 isync
+  (box-fixnum arg_z imm3)                           ; ppc:643
+  (ret)                                            ; ppc:644
+  @done
+  (clrex)                                          ; ppc:646-648 reservation-discharge
+  (box-fixnum arg_z imm3)                           ; ppc:647
+  (ret))                                           ; ppc:649
+
+;;; =====================================================================
+;;; %ptr-store-fixnum-conditional — ppc:651
+;;; =====================================================================
+;;; address=imm0, actual-oldval=imm1.  newval stored as-is (tagged fixnum).
+(defarm64lapfunction %ptr-store-fixnum-conditional ((ptr arg_x) (expected-oldval arg_y) (newval arg_z))
+  (macptr-ptr imm0 ptr)                            ; ppc:654 (base)
+  @again
+  (ldxr imm1 (:@ imm0))                            ; ppc:656 lrarx actual-oldval
+  (cmp imm1 expected-oldval)                        ; ppc:657 cmpr
+  (b.ne @done)                                     ; ppc:658 (bne-)
+  (stxr (:w temp4) newval (:@ imm0))               ; ppc:659 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:660 (bne- @again)
+  (dmb (:$ 11))                                    ; ppc:661 isync
+  (mov arg_z imm1)                                 ; ppc:662
+  (ret)                                            ; ppc:663
+  @done
+  (clrex)                                          ; ppc:665-667 reservation-discharge
+  (mov arg_z imm1)                                 ; ppc:666
+  (ret))                                           ; ppc:668
+
+;;; =====================================================================
+;;; %fixnum-truncate — ppc-numbers.lisp:251 (#+ppc64-target arm; placed
+;;; here like called-for-mv-p below, pending the numbers-file story vs
+;;; Matt's own arm64-numbers.lisp).  Promoted 16m14 from the wave-2
+;;; draft (drafts/arm64-numbers.lisp) on l1-lisp-threads demand; the
+;;; draft's DECIDE sites resolved to since-ratified idioms:
+;;; jump-subprim (PPC ba), load-nfn-constant (PPC `ld rd 'const nfn`).
+;;; Returns (values quotient remainder).  PPC's divdo. OV-on-zero has no
+;;; ARM64 analog: sdiv neither traps nor flags, so the unboxed divisor
+;;; is cbz-tested BEFORE dividing.  PPC's (mtxer rzero) XER-clearing
+;;; dropped (NZCV is not sticky).  negs supplies nego.'s V-on-overflow
+;;; (dividend = most-negative-fixnum); the ldur in load-nfn-constant
+;;; does not disturb NZCV, so the b.vc still tests the negs.
+;;; =====================================================================
+(defarm64lapfunction %fixnum-truncate ((dividend arg_y) (divisor arg_z))
+  (let ((unboxed-quotient imm0)
+        (unboxed-dividend imm1)
+        (unboxed-divisor imm2)
+        (unboxed-product imm3)
+        (boxed-quotient temp1)
+        (remainder temp2))
+    ;; (cmpdi divisor '-1) — boxed fixnum -1 = raw -8; cmp's aimm is
+    ;; unsigned, so compare via cmn #8 (Z iff divisor = -8).  ppc:259
+    (cmn divisor (:$ (ash 1 arm64::fixnumshift)))
+    (unbox-fixnum unboxed-dividend dividend)  ; ppc:260
+    (unbox-fixnum unboxed-divisor divisor)    ; ppc:261
+    (b.eq @neg)                               ; ppc:262
+    (cbz unboxed-divisor @div-by-zero)        ; ppc:263 (divdo. OV half)
+    (sdiv unboxed-quotient unboxed-dividend unboxed-divisor) ; ppc:263
+    (box-fixnum boxed-quotient unboxed-quotient) ; ppc:264
+    (mul unboxed-product unboxed-quotient unboxed-divisor) ; ppc:265 (mulld)
+    (b @ok)                                   ; ppc:266 (bns+ @ok)
+    @div-by-zero
+    ;; ppc:267 (mtxer rzero) — dropped, no XER
+    (save-lisp-context)                       ; ppc:268
+    (set-nargs 3)                             ; ppc:269
+    (load-constant arg_x truncate)            ; ppc:270
+    (call-symbol divide-by-zero-error)        ; ppc:271 — does not return
+    @ok                                       ; ppc:273
+    (sub imm0 unboxed-dividend unboxed-product) ; ppc:274 (subf)
+    (vpush boxed-quotient)                    ; ppc:275
+    (box-fixnum remainder imm0)               ; ppc:276
+    (vpush remainder)                         ; ppc:277
+    (set-nargs 2)                             ; ppc:278
+    ;; (la temp0 '2 vsp) — temp0 = entry vsp, the .SPvalues frame base
+    (add temp0 vsp (:$ (* 2 arm64::fixnumone))) ; ppc:279
+    (jump-subprim .SPvalues)                  ; ppc:280 (ba .SPvalues)
+    @neg
+    ;; ppc:282 (nego. dividend dividend) — V set iff dividend is
+    ;; most-negative-fixnum (raw #x8000000000000000)
+    (negs dividend dividend)
+    (load-nfn-constant arg_z *least-positive-bignum*) ; ppc:283 (ld ... nfn)
+    (b.vc @ret)                               ; ppc:284 (bns @ret)
+    ;; ppc:285 (mtxer rzero) — dropped, no XER
+    (ldur dividend (:@ arg_z (:$ arm64::symbol.vcell))) ; ppc:286
+    @ret
+    (mov temp0 vsp)                           ; ppc:288 (mr temp0 vsp)
+    (vpush dividend)                          ; ppc:289
+    ;; ppc:290 (vpush rzero) — raw 0 = boxed fixnum 0; xzr supplies it
+    (vpush xzr)
+    (set-nargs 2)                             ; ppc:291
+    (jump-subprim .SPvalues)))                ; ppc:292 (ba .SPvalues)
+
+;;; =====================================================================
+;;; called-for-mv-p — ppc-numbers.lisp:296 (placed here pending the
+;;; numbers-file story vs Matt's own arm64-numbers.lisp; the demand
+;;; loop only needs it deployed).  ARM32 arm-numbers.lisp:166 is the
+;;; nfp-design sibling: when sp == tcr.nfp an nfp frame is innermost
+;;; and its slot 0 is the BACKLINK to the caller's lisp frame (the
+;;; 16m5p header reshape guarantees that slot).  Answer: was my caller
+;;; invoked for multiple values — i.e. is its frame's savelr the magic
+;;; ret1valaddr kernel global?
+;;; =====================================================================
+(defarm64lapfunction called-for-mv-p ()
+  (ldr temp0 (:@ rcontext (:$ arm64::tcr.nfp)))    ; arm:167
+  (add imm1 sp (:$ 0))                             ; ppc:297 mr imm1,sp
+  (cmp temp0 imm1)                                 ; ppc:299
+  (b.ne @nonfp)                                    ; ppc:301 (bne @notnfp)
+  (ldr imm1 (:@ imm1 (:$ 0)))                      ; ppc:302 nfp backlink -> lisp frame
+  @nonfp
+  (ldr imm1 (:@ imm1 (:$ 24)))                     ; ppc:304 lisp-frame.savelr (@24)
+  (ref-global imm0 ret1valaddr)                    ; ppc:300
+  (eq->boolean arg_z imm0 imm1 imm2)               ; ppc:305
+  (ret))                                           ; ppc:306
+
+;;; =====================================================================
+;;; %truncate-short-float->fixnum / %round-nearest-short-float->fixnum —
+;;; ppc-numbers.lisp:141/:17x (PPC64 branches).  NAMING (mail item):
+;;; the level-0 callers use the PPC64 SHORT-float names; Matt's own
+;;; arm64-numbers.lisp:49/:62 defines the same bodies under
+;;; %truncate/%round-nearest-SINGLE-float->fixnum.  These twins carry
+;;; HIS bodies verbatim under the canonical names until he ratifies one
+;;; spelling (then one set dies).
+;;; =====================================================================
+(defarm64lapfunction %truncate-short-float->fixnum ((arg arg_z))
+  (get-single-float-bits imm0 arg)      ; his arm64-numbers.lisp:50
+  (fmov s0 (:w imm0))                   ; his :51
+  (fcvtzs imm0 s0)                      ; his :52 (= ppc:142 fctidz)
+  (box-fixnum arg_z imm0)               ; ppc:148
+  (ret))                                ; ppc:149
+
+(defarm64lapfunction %round-nearest-short-float->fixnum ((arg arg_z))
+  (get-single-float-bits imm0 arg)      ; his arm64-numbers.lisp:63
+  (fmov s0 (:w imm0))                   ; his :64
+  (fcvtns imm0 s0)                      ; his :65 (round-to-nearest-even)
+  (box-fixnum arg_z imm0)
+  (ret))
+
+;;; =====================================================================
+;;; %heap-bytes-allocated — ppc:285 (#+ppc64-target; the ppc32 twin @270 is
+;;; the same body over a hi/lo pair and is SKIPped)
+;;;
+;;; Same class as VALUES below and as 16m44's %ffi-exception-status: a
+;;; function every other port defines in its per-arch level-0 file, with no
+;;; arm64 arm anywhere (his tree, this overlay, the patches).  Cost: ANSI
+;;; TIME.1-8, all eight of them, because CL:TIME reports through
+;;; l0-misc.lisp's %heap-bytes-allocated and the tests assert that TIME
+;;; WRITES to *trace-output* -- so an undefined function there is eight
+;;; failures that say nothing about arm64.  Found by
+;;; tools/probes/ansi-tail-77-clusters.lisp, which named it directly.
+;;;
+;;; total_bytes_allocated is only current as of the last allocation-pointer
+;;; reset, so the live delta (last_allocptr - allocptr) has to be added back
+;;; -- unless there is no such delta to add:
+;;;   last_allocptr == 0            no allocation since the last reset
+;;;   allocptr == VOID_ALLOCPTR     the allocator is disabled
+;;; PPC64 spends two condition registers on those two tests; one NZCV does
+;;; here, serialized (cbz, then cmn).
+;;;
+;;; VOID_ALLOCPTR is -dnode_size = -16 on arm64 (gc.h:126); the 0x8000...-16
+;;; spelling at gc.h:124 is PPC64-only.  So `cmn allocptr #16' is right by
+;;; OUR arch, not by copying PPC's immediate -- which happens to agree.
+;;;
+;;; tcr.total-bytes-allocated is a single 64-bit slot here (his arch :757);
+;;; PPC64 reads its `-high' half, which IS the whole count on a 64-bit
+;;; machine.
+;;;
+;;; Promoted from upstream-port/level-0/drafts/arm64-misc.lisp:214 with the
+;;; one correction that draft promotion always needs on this lane: the draft
+;;; ended in (call-subprim .SPmakeu64), which LINKS, where ppc:295 is
+;;; `ba .SPmakeu64' -- a tail transfer, so .SPmakeu64's return goes to our
+;;; caller.  Getting that wrong is what produced the stage-11 udf #0
+;;; regression in apply+, and tools/draft-tail-subprim-lint.py exists to
+;;; name these sites; it named this one.
+;;; =====================================================================
+(defarm64lapfunction %heap-bytes-allocated ()
+  (ldr imm2 (:@ rcontext (:$ arm64::tcr.last-allocptr)))         ; ppc:286
+  (ldr imm0 (:@ rcontext (:$ arm64::tcr.total-bytes-allocated))) ; ppc:289
+  (cbz imm2 @go)                        ; ppc:291 (beq cr1) last-allocptr == 0
+  (cmn allocptr (:$ 16))                ; ppc:288 (cmpri allocptr,-16)
+  (b.eq @go)                            ; ppc:292 (beq) allocptr == VOID_ALLOCPTR
+  (sub imm2 imm2 allocptr)              ; ppc:290
+  (add imm0 imm0 imm2)                  ; ppc:293
+  @go
+  (jump-subprim .SPmakeu64))            ; ppc:295 (ba .SPmakeu64), imm0 in
+
+;;; =====================================================================
+;;; values — ppc:298
+;;;
+;;; VALUES had NO arm64 definition at all.  It is a per-architecture LAP
+;;; function on every other backend -- ppc-misc.lisp:298,
+;;; ARM/arm-misc.lisp:577, X86/x86-misc.lisp:394,
+;;; X86/X8632/x8632-misc.lisp:278 -- and neither Matt's tree (which has no
+;;; level-0/ARM64/arm64-misc.lisp) nor this overlay nor any patch supplied
+;;; one.  So (fboundp 'values) answered NIL in the running image, observed
+;;; live via tools/probes/ansi-aux-missing-defs.lisp.
+;;;
+;;; Why that was invisible until the ANSI suite: VALUES in operator position
+;;; is handled by the compiler, so (values a b) is fine everywhere and the
+;;; whole boot and REPL ladder never needed the FUNCTION.  Only #'values
+;;; does, and in compiled code that lowers to (%function 'values), resolved
+;;; against the fbinding -- hence "Undefined function VALUES".
+;;;
+;;; This is what stages 8 and 9 were both reporting.  ansi-aux.lsp's
+;;; eqt/eqlt/equalt/equalpt are each (apply #'values (mapcar #'notnot
+;;; (multiple-value-list ...))), so loading its fasl dies on the first of
+;;; them at line 74 and every later definition in the file -- including
+;;; def-fold-test at line 1172 -- is never installed.  That is why stage 8
+;;; said "Unbound variable: CL-TEST::CONS.FOLD.1": def-fold-test was not a
+;;; macro, so (def-fold-test cons.fold.1 ...) read as a function call and
+;;; evaluated its first argument as a variable.
+;;;
+;;; PPC64 is the line-port reference and ARM32 is identical to it here.
+;;; Promoted from upstream-port/level-0/drafts/arm64-misc.lisp:232 with one
+;;; correction: the draft ended in (call-subprim .SPvalues), which is `blr`
+;;; and LINKS.  PPC is `ba .SPvalues` -- a tail transfer, so .SPvalues'
+;;; return goes to VALUES' own caller -- which on this lane is
+;;; (jump-subprim ...), the spelling the rest of this file already uses for
+;;; ppc `ba` (see %store-node-conditional and the two .SPvalues jumps in
+;;; %fixnum-truncate).
+;;;
+;;; nargs is SCALED (a byte count, count << fixnumshift) -- vpush-argregs
+;;; compares it against (ash 2 arm64::fixnumshift) directly -- and
+;;; vpush-argregs has just decremented vsp by exactly that many bytes, so
+;;; nargs + vsp recovers the ENTRY vsp, which is .SPvalues' documented
+;;; temp0 input (the frame base).
+;;; =====================================================================
+(defarm64lapfunction values ()
+  (:arglist (&rest values))
+  (vpush-argregs)                                 ; ppc:300
+  (add temp0 nargs vsp)                           ; ppc:301 — temp0 = entry vsp
+  (jump-subprim .SPvalues))                       ; ppc:302 (ba .SPvalues)
+
+;;; =====================================================================
+;;; %setf-macptr-to-object — ppc:307 (#+ppc-target: covers ppc32 & ppc64)
+;;; =====================================================================
+(defarm64lapfunction %setf-macptr-to-object ((macptr arg_y) (object arg_z))
+  (check-nargs 2)                                 ; ppc:308
+  (trap-unless-typecode= arg_y arm64::subtag-macptr) ; ppc:309 (DECIDE-8 brk)
+  (stur arg_z (:@ arg_y (:$ arm64::macptr.address))) ; ppc:310 (str→stur, addr=-4)
+  (ret))                                          ; ppc:311
+
+;;; =====================================================================
+;;; %fixnum-from-macptr — ppc:313 (parity twin of the setter above)
+;;; =====================================================================
+(defarm64lapfunction %fixnum-from-macptr ((macptr arg_z))
+  (check-nargs 1)                                 ; ppc:314
+  (trap-unless-typecode= arg_z arm64::subtag-macptr) ; ppc:315
+  (ldur imm0 (:@ arg_z (:$ arm64::macptr.address))) ; ppc:316 (ldr→ldur)
+  (trap-unless-lisptag= imm0 arm64::tag-fixnum imm1) ; ppc:317 (DECIDE-8 brk)
+  (mov arg_z imm0)                                 ; ppc:318
+  (ret))                                          ; ppc:319
+
+;;; =====================================================================
+;;; fudge-heap-pointer — ppc:871 (#+ppc64-target; ppc32 twin @857 SKIP)
+;;; =====================================================================
+;;; Builds an ivector header inside a malloc'd block (16m15 demand:
+;;; %make-heap-ivector at *terminal-io* io-buffer setup).  clrrdi (clear
+;;; low 4 bits) → and ~15 (ldb-wrapped logimm).  subf rD,rA,rB = rB-rA.
+;;; sth halfword store → sturh (W-src, unscaled -2).  Header goes at the
+;;; untagged base (misc-header-offset = -fulltag-misc in his layout, so
+;;; [base+0] = [tagged-12]); MATCHED PAIR with %%make-disposable's
+;;; delta-halfword readback below.
+(defarm64lapfunction fudge-heap-pointer ((ptr arg_x) (subtype arg_y) (len arg_z))
+  (check-nargs 3)                                 ; ppc:872
+  (macptr-ptr imm1 ptr)                            ; ppc:873 (address)
+  (add imm0 imm1 (:$ 17))                          ; ppc:874 (+17: 2 delta + 15 align)
+  (and imm0 imm0 (:$ (ldb (byte 64 0) (lognot 15)))) ; ppc:875 (clrrdi 4)
+  (sub imm1 imm0 imm1)                             ; ppc:876 (subf: delta = imm0-imm1)
+  (sturh (:w imm1) (:@ imm0 (:$ -2)))              ; ppc:877 (sth delta @[base-2])
+  (unbox-fixnum imm1 subtype)                       ; ppc:878
+  (lsl imm2 len (:$ (- arm64::num-subtag-bits arm64::fixnumshift))) ; ppc:879 (sldi 5)
+  (orr imm1 imm2 imm1)                             ; ppc:880
+  (str imm1 (:@ imm0 (:$ 0)))                      ; ppc:881 (std header word)
+  (add arg_z imm0 (:$ arm64::fulltag-misc))        ; ppc:882 (tag it)
+  (ret))                                          ; ppc:883
+
+;;; =====================================================================
+;;; %%make-disposable — ppc:885 (MATCHED PAIR with fudge-heap-pointer)
+;;; =====================================================================
+(defarm64lapfunction %%make-disposable ((ptr arg_y) (vector arg_z))
+  (check-nargs 2)                                 ; ppc:886
+  (sub imm0 vector (:$ arm64::fulltag-misc))       ; ppc:887 (addr = vect less tag)
+  (ldurh (:w imm1) (:@ imm0 (:$ -2)))              ; ppc:888 (lhz delta halfword)
+  (sub imm0 imm0 imm1)                             ; ppc:889 (orig addr = addr - delta)
+  (stur imm0 (:@ ptr (:$ arm64::macptr.address)))  ; ppc:890 (str→stur)
+  (ret))                                          ; ppc:891
+
+;;; =====================================================================
+;;; %vect-data-to-macptr — ppc:913 (#+ppc64-target; ppc32 twin @894 SKIP)
+;;; =====================================================================
+;;; Promotion fix vs the wave-5 draft: la with negative misc-data-offset
+;;; → sub (the ratified idiom; add with a negative imm does not encode).
+(defarm64lapfunction %vect-data-to-macptr ((vect arg_y) (ptr arg_z))
+  (sub imm0 vect (:$ (- arm64::misc-data-offset))) ; ppc:914 (la → sub)
+  (stur imm0 (:@ ptr (:$ arm64::macptr.address)))  ; ppc:915 (std → stur)
+  (ret))                                          ; ppc:916
+
+;;; =====================================================================
+;;; %suspend-other-threads / %resume-other-threads — ppc:1006/:1018
+;;; (16m5w demand #3, via walk-dynamic-area's with-other-threads-
+;;; suspended).  uuo-interr kernel services (PPC UUO_INTERR ppc:1400/
+;;; 1406) are LIVE in arm64-exceptions.c (UUO_MISC_IS_INTERR dispatch);
+;;; the lapmacro emits the PROPOSED misc-format interr encoding.
+;;; =====================================================================
+(defarm64lapfunction %suspend-other-threads ()
+  (check-nargs 0)                                 ; ppc:1007
+  (uuo-interr arch::error-suspend-all)            ; ppc:1008
+  (mov arg_z rnil)                                ; ppc:1009 (li nil)
+  (ret))                                          ; ppc:1010
+
+(defarm64lapfunction %resume-other-threads ()
+  (check-nargs 0)                                 ; ppc:1019
+  (uuo-interr arch::error-resume-all)             ; ppc:1020
+  (mov arg_z rnil)                                ; ppc:1021 (li nil)
+  (ret))                                          ; ppc:1022
+
+;;; =====================================================================
+;;; 16m5y copy cluster — promoted from drafts/arm64-misc.lisp (wave-5
+;;; vetted) with the negative-immediate flips: misc-data-offset = -4 is
+;;; not an encodable add immediate, so (add X Y (:$ misc-data-offset))
+;;; becomes (sub X Y (:$ (- misc-data-offset))) — the active-seed
+;;; convention (arm64-array.lisp:312 etc.).  Register-offset ldrb/strb
+;;; take the possibly-negative computed offset in a REGISTER (fine).
+;;; =====================================================================
+
+;;; =====================================================================
+;;; %copy-ptr-to-ivector — ppc:29 (mirror of %copy-ivector-to-ptr: src is
+;;; a macptr, dest an ivector).
+;;; =====================================================================
+(defarm64lapfunction %copy-ptr-to-ivector ((src (* 1 arm64::node-size))
+                                           (src-byte-offset 0)
+                                           (dest arg_x)
+                                           (dest-byte-offset arg_y)
+                                           (nbytes arg_z))
+  (ldr temp0 (:@ vsp (:$ arm64::node-size)))       ; ppc:41 src macptr node
+  (ldur imm0 (:@ temp0 (:$ arm64::macptr.address))) ; ppc:42 macptr-ptr → address
+  (ldr imm1 (:@ vsp (:$ 0)))                        ; ppc:43 src-byte-offset (boxed)
+  (unbox-fixnum imm1 imm1)                           ; ppc:44
+  (unbox-fixnum imm2 dest-byte-offset)               ; ppc:45
+  (sub imm2 imm2 (:$ (- arm64::misc-data-offset)))   ; ppc:46 la dest-byteptr
+  (cmp nbytes (:$ 0))                                ; ppc:40
+  (b @test)                                          ; ppc:47
+  @loop
+  (subs nbytes nbytes (:$ (ash 1 arm64::fixnumshift))) ; ppc:49/50
+  (ldrb (:w imm3) (:@ imm0 imm1))                    ; ppc:51 lbzx
+  (add imm1 imm1 (:$ 1))                             ; ppc:52
+  (strb (:w imm3) (:@ dest imm2))                    ; ppc:53 stbx
+  (add imm2 imm2 (:$ 1))                             ; ppc:54
+  @test
+  (b.ne @loop)                                       ; ppc:56
+  (mov arg_z dest)                                   ; ppc:57
+  (add vsp vsp (:$ (ash 2 arm64::fixnumshift)))      ; ppc:58
+  (ret))
+
+;;; =====================================================================
+;;; %copy-ivector-to-ptr — ppc:61
+;;; =====================================================================
+(defarm64lapfunction %copy-ivector-to-ptr ((src (* 1 arm64::node-size))
+                                           (src-byte-offset 0)
+                                           (dest arg_x)
+                                           (dest-byte-offset arg_y)
+                                           (nbytes arg_z))
+  (ldr temp0 (:@ vsp (:$ arm64::node-size)))     ; ppc:66 src ivector
+  (ldr imm0 (:@ vsp (:$ 0)))                      ; ppc:68 src-byte-offset
+  (unbox-fixnum imm0 imm0)                         ; ppc:69
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset)))     ; ppc:70
+  (unbox-fixnum imm2 dest-byte-offset)             ; ppc:71
+  (ldur imm1 (:@ dest (:$ arm64::macptr.address))) ; ppc:72 (macptr.address=4 → ldur)
+  (cmp nbytes (:$ 0))                              ; ppc:67
+  (b @test)                                        ; ppc:73
+  @loop
+  (subs nbytes nbytes (:$ (ash 1 arm64::fixnumshift))) ; ppc:75/76
+  (ldrb (:w imm3) (:@ temp0 imm0))                 ; ppc:77 lbzx
+  (add imm0 imm0 (:$ 1))                           ; ppc:78
+  (strb (:w imm3) (:@ imm1 imm2))                  ; ppc:79 stbx
+  (add imm2 imm2 (:$ 1))                           ; ppc:80
+  @test
+  (b.ne @loop)                                     ; ppc:82
+  (mov arg_z dest)                                 ; ppc:83
+  (add vsp vsp (:$ (ash 2 arm64::fixnumshift)))    ; ppc:84
+  (ret))
+
+;;; =====================================================================
+;;; %copy-ivector-to-ivector — ppc:163 (#+ppc64-target; ppc32 twin @88 SKIP)
+;;; =====================================================================
+;;; Overlap-aware byte copy.  Three PPC CR fields: cr0 (loop count), cr1
+;;; (src vs dest), cr2 (offsets).  Single-NZCV: cr1/cr2 branch decisions
+;;; are resolved UP FRONT (sequentially) before either byte loop, which
+;;; then use their own (cmp nbytes 0).  cmpd/cmpdi are SIGNED → b.lt/b.ge.
+(defarm64lapfunction %copy-ivector-to-ivector ((src-offset 8)
+                                               (src-byte-offset-offset 0)
+                                               (dest arg_x)
+                                               (dest-byte-offset arg_y)
+                                               (nbytes arg_z))
+  (sub nbytes nbytes (:$ (ash 1 arm64::fixnumshift))) ; ppc:170 predecrement
+  (ldr imm0 (:@ vsp (:$ 0)))                      ; ppc:171 src-byte-offset (boxed)
+  (ldr temp0 (:@ vsp (:$ arm64::node-size)))      ; ppc:173 src
+  (add vsp vsp (:$ (ash 2 arm64::fixnumshift)))   ; ppc:174 (la vsp '2)
+  (cmp temp0 dest)                                ; ppc:175 cmpd cr1 (src==dest?)
+  (b.ne @setup-fwd)                               ; ppc:181 (bne cr1) different → forward
+  (cmp imm0 dest-byte-offset)                     ; ppc:176 cmpdi cr2 (offsets, SIGNED)
+  (b.eq @done)                                    ; ppc:183 (beq cr2) same vec+off → nothing
+  (b.lt @setup-back)                              ; ppc:184 (blt cr2) src-off<dest-off → backward
+  @setup-fwd
+  (unbox-fixnum imm0 imm0)                         ; ppc:177
+  (unbox-fixnum imm1 dest-byte-offset)             ; ppc:178
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset)))     ; ppc:179
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset)))     ; ppc:180
+  (b @test)                                        ; ppc:185
+  @loop
+  (sub nbytes nbytes (:$ (ash 1 arm64::fixnumshift))) ; ppc:187
+  (ldrb (:w imm3) (:@ temp0 imm0))                 ; ppc:188 lbzx
+  (add imm0 imm0 (:$ 1))                           ; ppc:190
+  (strb (:w imm3) (:@ dest imm1))                  ; ppc:191 stbx
+  (add imm1 imm1 (:$ 1))                           ; ppc:192
+  @test
+  (cmp nbytes (:$ 0))                              ; ppc:189 cmpdi
+  (b.ge @loop)                                     ; ppc:194 (bge)
+  @done
+  (mov arg_z dest)                                 ; ppc:196
+  (ret)                                            ; ppc:197
+  @setup-back
+  (unbox-fixnum imm0 imm0)                         ; ppc:177 (shared setup)
+  (unbox-fixnum imm1 dest-byte-offset)             ; ppc:178
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset)))     ; ppc:179
+  (sub imm1 imm1 (:$ (- arm64::misc-data-offset)))     ; ppc:180
+  (unbox-fixnum imm2 nbytes)                        ; ppc:200
+  (add imm0 imm0 imm2)                              ; ppc:201
+  (add imm1 imm1 imm2)                              ; ppc:202
+  (b @back-test)                                    ; ppc:203
+  @back-loop
+  (sub nbytes nbytes (:$ (ash 1 arm64::fixnumshift))) ; ppc:205
+  (ldrb (:w imm3) (:@ temp0 imm0))                 ; ppc:206 lbzx
+  (sub imm0 imm0 (:$ 1))                           ; ppc:208
+  (strb (:w imm3) (:@ dest imm1))                  ; ppc:209 stbx
+  (sub imm1 imm1 (:$ 1))                           ; ppc:210
+  @back-test
+  (cmp nbytes (:$ 0))                              ; ppc:207
+  (b.ge @back-loop)                                ; ppc:212
+  (mov arg_z dest)                                 ; ppc:213
+  (ret))
+
+;;; =====================================================================
+;;; %copy-gvector-to-gvector — ppc:217
+;;; =====================================================================
+;;; Node (8-byte) elements.  Boxed element index == byte offset (fixnumshift
+;;; == word-shift == 3), so misc-data-offset arithmetic matches PPC verbatim.
+;;; ldrx/strx → regoff (:@ base index).  cr1 (src vs dest) SIGNED; cr2
+;;; (elements) SIGNED.  Same single-NZCV restructuring as the ivector twin.
+(defarm64lapfunction %copy-gvector-to-gvector ((src (* 1 arm64::node-size))
+                                               (src-element 0)
+                                               (dest arg_x)
+                                               (dest-element arg_y)
+                                               (nelements arg_z))
+  (sub nelements nelements (:$ (ash 1 arm64::fixnumshift))) ; ppc:222 predecrement
+  (ldr imm0 (:@ vsp (:$ 0)))                      ; ppc:224 src-element (boxed)
+  (ldr temp0 (:@ vsp (:$ arm64::node-size)))      ; ppc:225 src
+  (add vsp vsp (:$ (ash 2 arm64::fixnumshift)))   ; ppc:226
+  (cmp temp0 dest)                                ; ppc:227 cmpr cr1
+  (b.ne @setup-fwd)                               ; ppc:231 (bne cr1)
+  (cmp imm0 dest-element)                         ; ppc:228 cmpri cr2 (SIGNED)
+  (b.eq @done)                                    ; ppc:233 (beq cr2)
+  (b.lt @setup-back)                              ; ppc:234 (blt cr2)
+  @setup-fwd
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset)))     ; ppc:229
+  (sub imm1 dest-element (:$ (- arm64::misc-data-offset))) ; ppc:230
+  (b @test)                                        ; ppc:235
+  @loop
+  (sub nelements nelements (:$ (ash 1 arm64::fixnumshift))) ; ppc:237
+  (ldr temp1 (:@ temp0 imm0))                      ; ppc:239 ldrx
+  (add imm0 imm0 (:$ (ash 1 arm64::fixnumshift)))  ; ppc:240 (addi '1 = one node)
+  (str temp1 (:@ dest imm1))                       ; ppc:241 strx
+  (add imm1 imm1 (:$ (ash 1 arm64::fixnumshift)))  ; ppc:242
+  @test
+  (cmp nelements (:$ 0))                           ; ppc:238
+  (b.ge @loop)                                     ; ppc:244
+  @done
+  (mov arg_z dest)                                 ; ppc:246
+  (ret)                                            ; ppc:247
+  @setup-back
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset)))     ; ppc:229 (shared setup)
+  (sub imm1 dest-element (:$ (- arm64::misc-data-offset))) ; ppc:230
+  (add imm1 imm1 nelements)                        ; ppc:250 (add imm1 nelements imm1)
+  (add imm0 imm0 nelements)                        ; ppc:251
+  (b @back-test)                                    ; ppc:252
+  @back-loop
+  (sub nelements nelements (:$ (ash 1 arm64::fixnumshift))) ; ppc:254
+  (ldr temp1 (:@ temp0 imm0))                      ; ppc:256 ldrx
+  (sub imm0 imm0 (:$ (ash 1 arm64::fixnumshift)))  ; ppc:257
+  (str temp1 (:@ dest imm1))                       ; ppc:258 strx
+  (sub imm1 imm1 (:$ (ash 1 arm64::fixnumshift)))  ; ppc:259
+  @back-test
+  (cmp nelements (:$ 0))                           ; ppc:255
+  (b.ge @back-loop)                                ; ppc:261
+  (mov arg_z dest)                                 ; ppc:262
+  (ret))
+
+;;; =====================================================================
+;;; %lock-gc-lock — ppc:517
+;;; =====================================================================
+;;; Atomically incf (or decf if negative) gc-inhibit-count.  PPC has NO
+;;; isync here (commented out) — omitted faithfully.  cmp flags (arg_y vs 0)
+;;; survive the flag-safe add to b.ge.
+(defarm64lapfunction %lock-gc-lock ()
+  (sub imm0 rnil (:$ (- (arm64::%kernel-global 'gc-inhibit-count)))) ; ppc:518 (&global)
+  @again
+  (ldxr arg_y (:@ imm0))                           ; ppc:520 lrarx
+  (cmp arg_y (:$ 0))                               ; ppc:521 (cmpri cr1)
+  (add arg_z arg_y (:$ (ash 1 arm64::fixnumshift))) ; ppc:522 (addi '1 — flag-safe)
+  (b.ge @store)                                    ; ppc:523 (bge cr1)
+  (sub arg_z arg_y (:$ (ash 1 arm64::fixnumshift))) ; ppc:524 (subi '1)
+  @store
+  (stxr (:w temp4) arg_z (:@ imm0))                ; ppc:526 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:527
+  (ret))                                           ; ppc:529 (no isync — see ppc:528)
+
+;;; =====================================================================
+;;; %unlock-gc-lock — ppc:534
+;;; =====================================================================
+;;; cr1 = (arg_y vs -1) via (cmn arg_y #1).  cbnz/stxr do NOT touch NZCV,
+;;; so the last iteration's cmn flags survive to the post-loop (b.ne) that
+;;; decides whether to fire the immediate-GC trap (DECIDE-3).
+(defarm64lapfunction %unlock-gc-lock ()
+  (sub imm0 rnil (:$ (- (arm64::%kernel-global 'gc-inhibit-count)))) ; ppc:536 (&global)
+  @again
+  (ldxr arg_y (:@ imm0))                           ; ppc:538 lrarx
+  (cmn arg_y (:$ (ash 1 arm64::fixnumshift)))      ; ppc:539 (cmpri cr1 arg_y -1)
+  (sub arg_z arg_y (:$ (ash 1 arm64::fixnumshift))) ; ppc:540 (subi '1 — flag-safe)
+  (b.gt @store)                                    ; ppc:541 (bgt cr1)
+  (add arg_z arg_y (:$ (ash 1 arm64::fixnumshift))) ; ppc:542 (addi '1)
+  @store
+  (stxr (:w temp4) arg_z (:@ imm0))                ; ppc:544 strcx.
+  (cbnz (:w temp4) @again)                          ; ppc:545
+  (b.ne @done)                                     ; ppc:546 (bnelr cr1) arg_y!=-1 → return
+  ;; count went -1 -> 0: try an immediate GC.
+  (mov imm0 (:$ arch::gc-trap-function-immediate-gc)) ; ppc:549 (li -1 → movn)
+  (uuo-gc-trap)                                    ; ppc:550 (trlgei → DECIDE-3; args imm1)
+  @done
+  (ret))                                           ; ppc:551
+
+;;; =====================================================================
+;;; %fixnum-gcd — ppc-numbers.lisp:355 (the #+ppc64-target arm; the
+;;; #+ppc32-target twin at ppc:310 is skipped).  Placed here, not in a
+;;; replacement for Matt's own level-0/ARM64/arm64-numbers.lisp, per the
+;;; %fixnum-truncate / called-for-mv-p precedent above: our overlay files
+;;; are COPIED OVER his tree, so owning a file he owns would mean carrying
+;;; his 8 LAP functions forward by hand at every pin advance.
+;;;
+;;; PROMOTED 16m34 from the wave-2 draft (drafts/arm64-numbers.lisp:164) on
+;;; LIVE REPL demand: (/ 1 3) died with "Undefined function
+;;; CCL::%FIXNUM-GCD called with arguments (1 3)", so no ratio could be
+;;; constructed.  Callers: l0-numbers.lisp:2066, l0-bignum64.lisp:892/:1998.
+;;;
+;;; Binary GCD.  n1, n2 must be positive nonzero fixnums (PPC's contract,
+;;; inherited — the ctz idiom below is undefined at 0).
+;;; ut0/vt0 = trailing-zero counts + fixnumshift, so the final left shift
+;;; re-boxes the result; u/v = odd parts.
+;;;
+;;; PPC keeps TWO compares live: cmpw cr2 ut0 vt0 BEFORE the loop and the
+;;; cr0 u/v compare inside it, resolving cr2 only at the equality exit
+;;; (blelr cr2 ⇒ shift by ut0, else fall through and shift by vt0).
+;;; AArch64 has ONE NZCV, so the cr2 result is materialized before the loop:
+;;;   (cmp ut0 vt0) (csel ut0 ut0 vt0 (:? le))   ; ut0 := min(ut0, vt0)
+;;; after which the equality exit is just the speculative (lsl arg_z u ut0)
+;;; already in flight, and PPC's second sld + blr collapse into one (ret).
+;;; VETTED equivalent: PPC's ut0 is read ONLY by that speculative shift and
+;;; by the blelr it resolves, vt0 ONLY by the else-shift, and neither is
+;;; written inside the loop — so pre-selecting the min changes the selection
+;;; POINT, not the value.  cmpw is a 32-bit compare but both operands are
+;;; ctz+3 ∈ [3,66], so the 64-bit cmp is equivalent.
+;;;
+;;; ctz idiom: PPC (neg temp u) (and temp temp u) (cntlzd) (subfic 63) =
+;;; 63 - clz(u & -u) = ctz(u).  Ported literally, with (- 63 clz) as
+;;; (eor #63) — equal for clz ∈ [0,63], which holds because u & -u is a
+;;; single set bit for u ≠ 0.  Matt uses the same trick in %fixnum-intlen.
+;;;
+;;; Flag safety (verified against his assembler): lsl/lsr with a register
+;;; or immediate count are the lslv/lsrv/UBFM aliases (arm64-asm.lisp:
+;;; 818-823) and set no flags, so every b.cond below still tests the cmp or
+;;; ands that precedes it — exactly as PPC's srd/srdi sit between cmpd and
+;;; the branches.
+;;; =====================================================================
+(defarm64lapfunction %fixnum-gcd ((n1 arg_y) (n2 arg_z))
+  (let ((temp imm0)
+        (u imm1)
+        (v imm2)
+        (ut0 imm3)
+        (vt0 imm4))
+    (unbox-fixnum u n1)                    ; ppc:361
+    (unbox-fixnum v n2)                    ; ppc:362
+    (neg temp u)                           ; ppc:363
+    (and temp temp u)                      ; ppc:364 — temp = u & -u
+    (clz ut0 temp)                         ; ppc:365 (cntlzd)
+    (eor ut0 ut0 (:$ 63))                  ; ppc:366 (subfic ut0 ut0 63)
+    (neg temp v)                           ; ppc:367
+    (and temp temp v)                      ; ppc:368
+    (clz vt0 temp)                         ; ppc:369 (cntlzd)
+    (eor vt0 vt0 (:$ 63))                  ; ppc:370 (subfic vt0 vt0 63)
+    (lsr u u ut0)                          ; ppc:372 (srd)
+    (lsr v v vt0)                          ; ppc:373 (srd)
+    (add ut0 ut0 (:$ arm64::fixnum-shift)) ; ppc:374 (addi)
+    (add vt0 vt0 (:$ arm64::fixnum-shift)) ; ppc:375 (addi)
+    (cmp ut0 vt0)                          ; ppc:371 (cmpw cr2) — moved here
+    (csel ut0 ut0 vt0 (:? le))             ; ppc:381 (blelr cr2) resolved: min
+    @loop
+    (cmp u v)                              ; ppc:377 (cmpd cr0)
+    (lsl arg_z u ut0)                      ; ppc:378 (sld) — speculative
+    (b.gt @u>v)                            ; ppc:379 (bgt cr0)
+    (b.lt @u<v)                            ; ppc:380 (blt cr0)
+    ;; u = v: arg_z already holds u << min(ut0,vt0), covering both
+    ;; ppc:381 (blelr cr2) and ppc:382-383 (sld arg_z u vt0 / blr).
+    (ret)
+    @u>v
+    (sub u u v)                            ; ppc:385
+    @shiftu
+    (ands temp u (:$ 2))                   ; ppc:387 (andi. temp u (ash 1 1))
+    (lsr u u (:$ 1))                       ; ppc:388 (srdi) — flag-safe
+    (b.eq @shiftu)                         ; ppc:389 (beq cr0)
+    (b @loop)                              ; ppc:390
+    @u<v
+    (sub v v u)                            ; ppc:392
+    @shiftv
+    (ands temp v (:$ 2))                   ; ppc:394 (andi.)
+    (lsr v v (:$ 1))                       ; ppc:395 (srdi) — flag-safe
+    (b.eq @shiftv)                         ; ppc:396 (beq cr0)
+    (b @loop)))                            ; ppc:397

--- a/level-0/ARM64/arm64-pred.lisp
+++ b/level-0/ARM64/arm64-pred.lisp
@@ -1,0 +1,212 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-pred.lisp — ACTIVE seed (demand-driven from cold-load fatals;
+;;; first demand: EQL, 16m5m boot).
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/ppc-pred.lisp)
+;;; Per-line citations: "; ppc:NNN" = line NNN of that file
+;;; (the #+ppc64-target branches).
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; eql — ppc:130 (PPC64 branch)
+;;; =====================================================================
+;;; PPC's parallel CR-field compares are re-serialized: each cmp/branch
+;;; pair is adjacent (same transform as %set-tcr-toplevel-function).
+;;; The @macptr dispatch happens BEFORE the full-header equality test
+;;; (ppc:153 sits above ppc:156): macptrs of different lengths are EQL
+;;; when their subtags and addresses match.
+(defarm64lapfunction eql ((x arg_y) (y arg_z))
+  "Return T if OBJ1 and OBJ2 represent the same object, otherwise NIL."
+  (check-nargs 2)                                    ; ppc:132
+  @tail
+  (cmp x y)                                          ; ppc:134
+  (b.eq @win)                                        ; ppc:139
+  (extract-fulltag imm0 x)                           ; ppc:135
+  (extract-fulltag imm1 y)                           ; ppc:136
+  (cmp imm0 (:$ arm64::fulltag-misc))                ; ppc:137
+  (b.ne @lose)                                       ; ppc:140
+  (cmp imm1 (:$ arm64::fulltag-misc))                ; ppc:138
+  (b.ne @lose)                                       ; ppc:141
+  ;; Objects are both fulltag-misc.  Headers must match exactly;
+  ;; dispatch on subtag.  (ppc:142-143)
+  (getvheader imm0 x)                                ; ppc:144
+  (getvheader imm1 y)                                ; ppc:145
+  (extract-lowbyte imm2 imm1)                        ; ppc:147 (y subtag; imm1 keeps the full header)
+  (cmp imm2 (:$ arm64::subtag-macptr))               ; ppc:148
+  (b.eq @macptr)                                     ; ppc:153
+  (cmp imm0 imm1)                                    ; ppc:146
+  (b.ne @lose)                                       ; ppc:156
+  (cmp imm2 (:$ arm64::subtag-bignum))               ; ppc:149
+  (b.eq @bignum)                                     ; ppc:157
+  (cmp imm2 (:$ arm64::subtag-complex-single-float)) ; ppc:151
+  (b.eq @complex-single)                             ; ppc:158
+  (cmp imm2 (:$ arm64::subtag-complex-double-float)) ; ppc:152
+  (b.eq @complex-double)                             ; ppc:159
+  (cmp imm2 (:$ arm64::subtag-double-float))         ; ppc:150
+  (b.eq @double-float)                               ; ppc:160
+  (cmp imm2 (:$ arm64::subtag-complex))              ; ppc:154
+  (b.eq @node)                                       ; ppc:161
+  (cmp imm2 (:$ arm64::subtag-ratio))                ; ppc:155
+  (b.eq @node)                                       ; ppc:162
+  @lose
+  (mov arg_z rnil)                                   ; ppc:164
+  (ret)                                              ; ppc:165
+  @double-float
+  ;; One 64-bit compare covers his two 32-bit value cells (ppc64 ld).
+  (ldur imm0 (:@ x (:$ arm64::double-float.value)))  ; ppc:167
+  (ldur imm1 (:@ y (:$ arm64::double-float.value)))  ; ppc:168
+  @test
+  (cmp imm0 imm1)                                    ; ppc:170
+  (b.ne @lose)                                       ; ppc:171
+  @win
+  (add arg_z rnil (:$ arm64::t-offset))              ; ppc:173
+  (ret)                                              ; ppc:174
+  ;; Macptr objects can have different lengths, but their subtags must
+  ;; match.  (ppc:175-176)
+  @macptr
+  (extract-lowbyte imm0 imm0)                        ; ppc:178
+  (cmp imm0 imm2)                                    ; ppc:179 (imm2 = y subtag)
+  (b.ne @lose)                                       ; ppc:180
+  (ldur imm0 (:@ x (:$ arm64::macptr.address)))      ; ppc:181
+  (ldur imm1 (:@ y (:$ arm64::macptr.address)))      ; ppc:182
+  (b @test)                                          ; ppc:183
+  ;; Ratio or complex: corresponding node parts of both objects must be
+  ;; EQL.  Recurse on numer/realpart; tail-call on denom/imagpart.
+  ;; complex.realpart == ratio.numer (slot 0) and complex.imagpart ==
+  ;; ratio.denom (slot 1) on his layout, as on PPC64 (ppc:189-190 aka
+  ;; comment).
+  @node                                              ; ppc:184-185 (@ratio/@complex)
+  (vpush x)                                          ; ppc:186
+  (vpush y)                                          ; ppc:187
+  (save-lisp-context)                                ; ppc:188
+  (ldur x (:@ x (:$ arm64::ratio.numer)))            ; ppc:189
+  (ldur y (:@ y (:$ arm64::ratio.numer)))            ; ppc:190
+  (bl @tail)                                         ; ppc:191
+  (cmp arg_z rnil)                                   ; ppc:192
+  (restore-full-lisp-context)                        ; ppc:193
+  (vpop y)                                           ; ppc:194
+  (vpop x)                                           ; ppc:195
+  (b.eq @lose)                                       ; ppc:196
+  (ldur x (:@ x (:$ arm64::ratio.denom)))            ; ppc:197
+  (ldur y (:@ y (:$ arm64::ratio.denom)))            ; ppc:198
+  (b @tail)                                          ; ppc:199
+  @complex-single
+  (mov imm0 (:$ 2))                                  ; ppc:201
+  (mov imm1 (:$ arm64::complex-single-float.realpart)) ; ppc:202
+  (b @bignum-next)                                   ; ppc:203
+  @complex-double
+  (mov imm0 (:$ 4))                                  ; ppc:205
+  (mov imm1 (:$ arm64::complex-double-float.realpart)) ; ppc:206
+  (b @bignum-next)                                   ; ppc:207
+  @bignum
+  ;; x's header is in imm0 and y's is identical (compared above); the
+  ;; element count controls the loop, which runs at least once — there
+  ;; is no 0-element bignum.  (ppc:209-212)
+  (header-size imm0 imm0)                            ; ppc:213
+  (mov imm1 (:$ arm64::misc-data-offset))            ; ppc:214
+  @bignum-next
+  ;; 32-bit digits; ldr(:w) zero-extends so the 64-bit cmp is exact.
+  (ldr (:w imm2) (:@ x imm1))                        ; ppc:217 (lwzx)
+  (ldr (:w imm3) (:@ y imm1))                        ; ppc:218 (lwzx)
+  (cmp imm2 imm3)                                    ; ppc:219
+  (b.ne @lose)                                       ; ppc:222
+  (subs imm0 imm0 (:$ 1))                            ; ppc:220 + ppc:216's last-time test
+  (add imm1 imm1 (:$ 4))                             ; ppc:221 (flags preserved)
+  (b.ne @bignum-next)                                ; ppc:223
+  (b @win))                                          ; ppc:224-225 (li arg_z t; blr)
+
+;;; =====================================================================
+;;; equal — ppc:302 (PPC64 branch)
+;;; =====================================================================
+;;; Demand: 16m8 l1-symhash wall — MAKE-HASH-TABLE's (eq test #'equal)
+;;; resolved EQUAL's fcell to the canonical udf object and stored it as
+;;; nhash.compareF; the first colliding %HASH-PROBE funcalled it (fatal
+;;; mis-named FAST-MOD-3 from stale temp3 — that fn was fine).
+;;; PPC's parallel CR-field compares re-serialized per the eql pattern
+;;; above.  ARM64-DEVIATION: ppc:339-340's cs-limit stack probe (tdllt)
+;;; omitted — the lane's type/trap UUOs are brk placeholders pending the
+;;; uuo-canon RATIFY sweep; a deep-recursion overflow dies loudly via the
+;;; P0 SEGV dump instead of a lisp error.
+;;; Named calls: linked = call-symbol (lapmacros-additions, offsets
+;;; verified there); the hairy-equal tail jump is the same sequence with
+;;; br (ppc:370-371 ld fname / ba .SPjmpsym).
+(defarm64lapfunction equal ((x arg_y) (y arg_z))
+  "Return T if X and Y are EQL or if they are structured components
+  whose elements are EQUAL. Strings and bit-vectors are EQUAL if they
+  are the same length and have identical components. Other arrays must be
+  EQ to be EQUAL.  Pathnames are EQUAL if their components are."
+  (check-nargs 2)                                    ; ppc:307
+  @top
+  (cmp x y)                                          ; ppc:309 (cr0)
+  (b.eq @win)                                        ; ppc:315
+  (extract-fulltag imm0 x)                           ; ppc:310
+  (extract-fulltag imm1 y)                           ; ppc:311
+  (cmp imm0 imm1)                                    ; ppc:312 (cr1)
+  (b.ne @lose)                                       ; ppc:316
+  (cmp imm0 (:$ arm64::fulltag-cons))                ; ppc:313 (cr2)
+  (b.eq @cons)                                       ; ppc:317
+  (cmp imm0 (:$ arm64::fulltag-misc))                ; ppc:314 (cr3)
+  (b.eq @misc)                                       ; ppc:318
+  @lose
+  (mov arg_z rnil)                                   ; ppc:320
+  (ret)                                              ; ppc:321
+  @win
+  (add arg_z rnil (:$ arm64::t-offset))              ; ppc:323
+  (ret)                                              ; ppc:324
+  @cons
+  ;; If the CARs are EQ, avoid saving context: tail-iterate on the CDRs.
+  (%car temp0 x)                                     ; ppc:328
+  (%car temp1 y)                                     ; ppc:329
+  (cmp temp0 temp1)                                  ; ppc:330
+  (b.ne @recurse)                                    ; ppc:331
+  (%cdr x x)                                         ; ppc:332
+  (%cdr y y)                                         ; ppc:333
+  (b @top)                                           ; ppc:334
+  @recurse
+  (vpush x)                                          ; ppc:336
+  (vpush y)                                          ; ppc:337
+  (save-lisp-context)                                ; ppc:338
+  (mov x temp0)                                      ; ppc:341
+  (mov y temp1)                                      ; ppc:342
+  (bl @top)                                          ; ppc:343
+  (cmp arg_z rnil)                                   ; ppc:344
+  ;; ppc:345 (mr nfn fn): fn = SELF for this frame's lifetime (save's
+  ;; mov fn nfn; callees restore fn); nfn may be clobbered (inner @misc
+  ;; leaves nfn = EQL's object).  Re-establish nfn = self BEFORE the
+  ;; restore flips fn back to the caller — the b @top loop's next
+  ;; save-lisp-context re-derives fn from nfn (16m8 KEY-fatal class).
+  (mov nfn fn)                                       ; ppc:345
+  (restore-full-lisp-context)                        ; ppc:346 (fn = CALLER after this)
+  (vpop y)                                           ; ppc:347
+  (vpop x)                                           ; ppc:348
+  (b.eq @lose)                                       ; ppc:349
+  (%cdr x x)                                         ; ppc:350
+  (%cdr y y)                                         ; ppc:351
+  (b @top)                                           ; ppc:352
+  @misc
+  ;; Both uvectors: try EQL; if that fails, tail-call HAIRY-EQUAL
+  ;; (late-bound by name — defined in level-1 sysutils).
+  (vpush x)                                          ; ppc:355
+  (vpush y)                                          ; ppc:356
+  (save-lisp-context)                                ; ppc:357
+  (set-nargs 2)                                      ; ppc:358/361
+  (call-symbol eql)                                  ; ppc:360+362 (bla .SPjmpsym)
+  (cmp arg_z rnil)                                   ; ppc:363
+  ;; ppc:364 (mr nfn fn): as at @recurse — after the restore below, fn is
+  ;; the CALLER's fn, and 16m8's boot proved it (fn-relative hairy-equal
+  ;; load fetched KEY from %HASH-PROBE's pool -> udf "KEY").  nfn = self
+  ;; makes the donor's nfn-relative constant load (ppc:370) work.
+  (mov nfn fn)                                       ; ppc:364
+  (restore-full-lisp-context)                        ; ppc:365 (fn = CALLER after this)
+  (vpop y)                                           ; ppc:366
+  (vpop x)                                           ; ppc:367
+  (b.ne @win)                                        ; ppc:368
+  (set-nargs 2)                                      ; ppc:369
+  (load-nfn-constant fname hairy-equal)              ; ppc:370 (ld fname 'hairy-equal nfn)
+  (ldur nfn (:@ fname (:$ arm64::symbol.fcell)))     ; ppc:371 (ba .SPjmpsym, no-link)
+  (ldur imm0 (:@ nfn (:$ arm64::misc-function-offset)))
+  (br imm0))

--- a/level-0/ARM64/arm64-symbol.lisp
+++ b/level-0/ARM64/arm64-symbol.lisp
@@ -1,0 +1,349 @@
+;;;; -*- Mode: Lisp; Package: CCL -*-
+;;;;
+;;;; arm64-symbol.lisp — ARM64 LAP function drafts for symbol functions
+;;;;
+;;;; Ported line-by-line from vendor/ccl/level-0/PPC/ppc-symbol.lisp (PPC64 arms).
+;;;; Register map: Matt Emerson's upstream arm64 (arm64-asm.lisp).
+;;;; Tags: LOW tags, fixnumshift=3, misc-data-offset=4, misc-header-offset=-4.
+;;;;
+;;;; STATUS: LEAD-VERIFIED 2026-07-08 (line-by-line vs PPC64; assemble-gate clean
+;;;; except DECIDE-blocked sites — see drafts/wave1-verify-report.md)
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-ARCH")
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; %function — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:49 (ppc64 arm)
+;;; =====================================================================
+;;;
+;;; Assumes macros & special-operators have something that's not FUNCTIONP
+;;; in their function-cells.
+;;; PPC64 version: type-check sym as symbol, load fcell, check if function.
+;;;
+;;; Key layout (arm64-arch.lisp):
+;;;   subtag-symbol = 22, symbol.fcell = 17, subtag-function = 150
+;;;   error-udf (arch::error-udf) — undefined function error
+
+;;; 16m5v REWRITE to the x8664 donor (x86-symbol.lisp:29) — Matt's tag
+;;; model: a symbol POINTER has fulltag-symbol(7); extract-typecode only
+;;; yields subtag-symbol(22) for the MISC-tagged symvector alias, so the
+;;; old trap-unless-typecode= brk'd on every real symbol (observed live:
+;;; typecode=7 vs 22 at the #xf0ff brk).  The fcell functionp check is
+;;; the PPC typecode test again since the fulltag-function removal
+;;; (patch 0055): a function is misc + subtag-function.  NIL maps to
+;;; NILSYM, the real NRS symbol at rnil+t-offset+symbol.size (= rnil+92;
+;;; VERIFIED live: pname @0x13067 = "NIL").
+(defarm64lapfunction %function ((sym arg_z))
+  (check-nargs 1)
+  (let ((symaddr temp0))
+    (add symaddr rnil (:$ (+ arm64::t-offset arm64::symbol.size))) ; x86:32 nilsym
+    (cmp sym rnil)                                   ; x86:33
+    (csel symaddr sym symaddr (:? ne))               ; x86:34 (cmovneq)
+    (trap-unless-fulltag= symaddr arm64::fulltag-symbol) ; x86:35
+    (mov arg_y sym)                                  ; x86:36
+    (ldur arg_z (:@ symaddr (:$ arm64::symbol.fcell))) ; x86:37
+    (extract-typecode imm0 arg_z)                    ; x86:38
+    (cmp imm0 (:$ arm64::subtag-function))           ; x86:39
+    (b.eq @ok)                                       ; x86:40
+    (uuo-error-udf arg_y)                            ; x86:41
+    @ok
+    (ret)))
+
+;;; =====================================================================
+;;; %symbol->symptr — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:67
+;;; =====================================================================
+;;;
+;;; ⚠ The NILSYM mapping IS REQUIRED on arm64 (16m14; an earlier draft of
+;;; this header claimed otherwise and that claim leaked into the w9
+;;; %symbol->symptr VINSN, which shredded T's symbol struct whenever lisp
+;;; wrote a symbol slot of NIL).  NIL has fulltag-nil(0xb): the blind
+;;; symptr→symvector retag (+5) is only valid for fulltag-symbol(7)
+;;; pointers, so NIL must first map to NILSYM — the real NRS symbol at
+;;; rnil+t-offset+symbol.size (=rnil+92=0x13067; pname "NIL", verified
+;;; live in w4 and again in 16m14).
+
+;;; 16m5v REWRITE to the x8664 donor (x86-symbol.lisp:47) — see %function
+;;; above for the tag-model rationale.  NIL → NILSYM (a real symbol), so
+;;; downstream symvector ops (SYMBOL-NAME et al.) work on the result;
+;;; the old version passed NIL through and typecode-trapped real symbols.
+(defarm64lapfunction %symbol->symptr ((sym arg_z))
+  (let ((tag imm0))
+    (add tag rnil (:$ (+ arm64::t-offset arm64::symbol.size))) ; x86:49 nilsym
+    (cmp sym rnil)                                   ; x86:50
+    (csel sym tag sym (:? eq))                       ; x86:51 (cmoveq)
+    (b.eq @done)                                     ; x86:52
+    (trap-unless-fulltag= sym arm64::fulltag-symbol) ; x86:53
+    @done
+    (ret)))                                          ; x86:55
+
+;;; =====================================================================
+;;; %symptr->symbol — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:80
+;;; =====================================================================
+;;;
+;;; Traps unless symptr is a symbol.  On arm64, also need to handle the
+;;; NIL case (return rnil if symptr is NIL).
+
+;;; 16m5v REWRITE to the x8664 donor (x86-symbol.lisp:58) — typecheck the
+;;; symptr (fulltag-symbol), then NILSYM → NIL (inverse of %symbol->symptr).
+(defarm64lapfunction %symptr->symbol ((symptr arg_z))
+  (trap-unless-fulltag= symptr arm64::fulltag-symbol) ; x86:59-62
+  (let ((nilsym imm0))
+    (add nilsym rnil (:$ (+ arm64::t-offset arm64::symbol.size)))
+    (cmp symptr nilsym)                              ; x86:64
+    (csel symptr rnil symptr (:? eq))                ; x86:65-68
+    (ret)))                                          ; x86:69
+
+;;; =====================================================================
+;;; %symptr->symvector / %symvector->symptr — x8664 donors
+;;; (x86-symbol.lisp:75/:79); pure retags between the fulltag-symbol
+;;; pointer and its fulltag-misc uvector alias (same object).  PPC has
+;;; no analog (16m5v family seed; SYMBOL-NAME et al. call these).
+;;; =====================================================================
+(defarm64lapfunction %symptr->symvector ((symptr arg_z))
+  ;; x86:76 is (subb (- fulltag-symbol fulltag-misc)) = subtract −5;
+  ;; arm64 immediates are unsigned — flip to add (misc−symbol = +5).
+  (add arg_z symptr (:$ (- arm64::fulltag-misc arm64::fulltag-symbol)))
+  (ret))                                             ; x86:77
+
+(defarm64lapfunction %symvector->symptr ((symbol-vector arg_z))
+  (sub arg_z symbol-vector (:$ (- arm64::fulltag-misc arm64::fulltag-symbol))) ; x86:80 (addb −5 → sub +5)
+  (ret))                                             ; x86:81
+
+;;; =====================================================================
+;;; %symptr-value — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:92
+;;; =====================================================================
+;;;
+;;; Tail-call to .SPspecref subprim.
+
+(defarm64lapfunction %symptr-value ((symptr arg_z))
+  (jump-subprim .SPspecref))
+
+;;; =====================================================================
+;;; %set-symptr-value — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:95
+;;; =====================================================================
+;;;
+;;; Tail-call to .SPspecset subprim.
+
+(defarm64lapfunction %set-symptr-value ((symptr arg_y) (val arg_z))
+  (jump-subprim .SPspecset))
+
+;;; =====================================================================
+;;; %symptr-binding-address — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:98
+;;; =====================================================================
+;;;
+;;; Returns the binding address: if the symbol has a thread-local binding,
+;;; return (values tlb-pointer binding-index); otherwise return
+;;; (values symptr symbol.vcell-offset).
+;;;
+;;; Key offsets (arm64-arch.lisp):
+;;;   symbol.binding-index = 49
+;;;   tcr.tlb-limit = 296, tcr.tlb-pointer = 304
+;;;   subtag-no-thread-local-binding = (logior fulltag-imm-1 (ash 4 4)) = 74
+;;;   symbol.vcell = 9
+
+(defarm64lapfunction %symptr-binding-address ((symptr arg_z))
+  ;; (ldr imm3 target::symbol.binding-index symptr)
+  (ldur imm3 (:@ symptr (:$ arm64::symbol.binding-index)))
+  ;; (ldr imm2 target::tcr.tlb-limit target::rcontext)
+  (ldr imm2 (:@ rcontext (:$ arm64::tcr.tlb-limit)))
+  ;; (ldr imm4 target::tcr.tlb-pointer target::rcontext)
+  (ldr imm4 (:@ rcontext (:$ arm64::tcr.tlb-pointer)))
+  ;; (cmplr imm3 imm2) — unsigned compare: binding-index >= tlb-limit?
+  (cmp imm3 imm2)
+  (b.hs @sym)
+  ;; (ldrx temp0 imm4 imm3) — load from tlb at index
+  (ldr temp0 (:@ imm4 imm3))
+  ;; (cmpdi temp0 target::subtag-no-thread-local-binding)
+  (cmp temp0 (:$ arm64::subtag-no-thread-local-binding))
+  ;; (slri imm3 imm3 target::fixnumshift) — slri = sldi = shift LEFT
+  ;; (vendor/ccl/compiler/PPC/ppc-lapmacros.lisp:173): boxes the raw
+  ;; binding-index as a fixnum before vpush.  Same shift on arm64
+  ;; (fixnumshift=3 on both).
+  (lsl imm3 imm3 (:$ arm64::fixnumshift))
+  (b.eq @sym)
+  ;; Thread-local binding exists — return (values tlb-pointer index)
+  (vpush imm4)
+  (vpush imm3)
+  (set-nargs 2)
+  ;; (la temp0 '2 vsp) — temp0 = vsp + 2*fixnumone = vsp + 16
+  ;; This is the "values frame" base for .SPvalues
+  (add temp0 vsp (:$ 16))
+  (jump-subprim .SPvalues)
+  @sym
+  ;; No thread-local binding — return (values symptr symbol.vcell-offset)
+  ;; PPC64: (li arg_y '#.target::symbol.vcell)
+  ;; symbol.vcell = 9 on arm64; as a fixnum-tagged constant:
+  ;; the offset itself is what gets pushed, not a fixnum-encoded version.
+  ;; Actually looking at PPC64: (li arg_y '#.target::symbol.vcell) where
+  ;; #. reads the constant at read-time.  On PPC64 symbol.vcell = 32 (a
+  ;; fixnum since fixnumshift=3 and 32 is divisible by 8).  On arm64
+  ;; symbol.vcell = 9 which is NOT a fixnum (not multiple of 8).
+  ;; This is a layout mismatch — the field offset isn't fixnum-aligned.
+  ;; We need to pass the fixnum-tagged cell index instead.
+  ;; PPC64 symbol.vcell IS a fixnum (all field offsets are multiples of 8
+  ;; on PPC64 because node-size=8 and bias doesn't break alignment).
+  ;; On arm64, symbol.vcell = 9 (= -fulltag-symbol + 2*8 = -7 + 16).
+  ;; Hmm, not a fixnum.  The caller uses this to index into the object.
+  ;; DECIDE-BLOCKED: symbol.vcell offset not fixnum-aligned on arm64;
+  ;; need to understand how callers use this return value (raw offset
+  ;; vs fixnum-tagged cell index).  For now, pass the raw offset.
+  (mov arg_y (:$ arm64::symbol.vcell))
+  (vpush arg_z)
+  (vpush arg_y)
+  (set-nargs 2)
+  (add temp0 vsp (:$ 16))
+  (jump-subprim .SPvalues))
+
+;;; =====================================================================
+;;; %tcr-binding-location — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:121
+;;; =====================================================================
+;;;
+;;; Returns the address of a symbol's thread-local binding in tcr's TLB,
+;;; or NIL if no thread-local binding.
+
+(defarm64lapfunction %tcr-binding-location ((tcr arg_y) (sym arg_z))
+  ;; (ldr imm3 target::symbol.binding-index sym)
+  (ldur imm3 (:@ sym (:$ arm64::symbol.binding-index)))
+  ;; (ldr imm2 target::tcr.tlb-limit tcr)
+  (ldr imm2 (:@ tcr (:$ arm64::tcr.tlb-limit)))
+  ;; (ldr imm4 target::tcr.tlb-pointer tcr)
+  (ldr imm4 (:@ tcr (:$ arm64::tcr.tlb-pointer)))
+  ;; (li arg_z nil)
+  (mov arg_z rnil)
+  ;; (cmplr imm3 imm2) — unsigned: if binding-index >= tlb-limit, return nil
+  (cmp imm3 imm2)
+  (b.hs @done)
+  ;; (ldrx temp0 imm4 imm3) — load from TLB
+  (ldr temp0 (:@ imm4 imm3))
+  ;; (cmpri temp0 target::subtag-no-thread-local-binding)
+  (cmp temp0 (:$ arm64::subtag-no-thread-local-binding))
+  (b.eq @done)
+  ;; (add arg_z imm4 imm3) — return address = tlb-pointer + index
+  (add arg_z imm4 imm3)
+  @done
+  (ret))
+
+;;; =====================================================================
+;;; %pname-hash — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:135
+;;; =====================================================================
+;;;
+;;; Hash a pname string.  PPC64 uses rotlwi (32-bit rotate-left-immediate,
+;;; even on PPC64) and XOR accumulation over 32-bit chunks, then
+;;; (slri accum 5) + (srri arg_z accum (- 5 fixnumshift)) — net << 3 —
+;;; to box the 32-bit hash as a fixnum.
+;;;
+;;; On arm64 there is no 32-bit rotate of an X register; a 64-bit
+;;; (ror #59) is WRONG because bits 27-31 must wrap into bits 0-4 but
+;;; ror64 moves them into bits 32-36, polluting later iterations.
+;;; Emulate rotl32 exactly (upper 32 bits of accum are zero at loop
+;;; entry): tmp = accum >> 27; accum = (accum << 5 | tmp) & #xffffffff.
+
+(defarm64lapfunction %pname-hash ((str arg_y) (len arg_z))
+  (let ((nextw imm1)
+        (accum imm0)
+        (offset imm2))
+    ;; (cmpwi cr0 len 0)
+    (cbz len @done)
+    (mov offset (:$ arm64::misc-data-offset))
+    (mov accum (:$ 0))
+    @loop
+    ;; PPC64: (cmpri cr1 len '1) + (bne cr1 @loop) at end = loop while len>1.
+    ;; ARM64: decrement first, branch on nonzero result (equivalent).
+    (sub len len (:$ arm64::fixnumone))
+    ;; (lwzx nextw str offset) — 32-bit load; w1 = W alias of nextw/imm1/x1
+    ;; (Matt's arm64-asm.lisp:144); avoids over-reading past the last char.
+    (add imm3 str offset)
+    (ldr w1 (:@ imm3 (:$ 0)))
+    ;; (addi offset offset 4)
+    (add offset offset (:$ 4))
+    ;; (rotlwi accum accum 5) — 32-bit rotate left by 5, emulated
+    (lsr imm4 accum (:$ 27))
+    (lsl accum accum (:$ 5))
+    (orr accum accum imm4)
+    (and accum accum (:$ #xffffffff))
+    ;; (xor accum accum nextw)
+    (eor accum accum nextw)
+    ;; loop while len > 0 (decremented above)
+    (cbnz len @loop)
+    ;; Produce fixnum result:
+    ;; PPC64: (slri accum accum 5) then (srri arg_z accum (- 5 fixnumshift)).
+    ;; Those are 64-bit shifts (sldi/srdi) of a 32-bit-clean value: net
+    ;; effect is accum << fixnumshift with nothing dropped (35-bit result,
+    ;; a positive fixnum).  accum is 32-bit clean here, so same two shifts.
+    (lsl accum accum (:$ 5))
+    (lsr arg_z accum (:$ (- 5 arm64::fixnumshift)))
+    @done
+    (ret)))
+
+;;; =====================================================================
+;;; %string-hash — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:155
+;;; =====================================================================
+;;;
+;;; Same as %pname-hash but with a start offset parameter.
+;;; PPC64: (srwi offset start 1) then (la offset misc-data-offset offset)
+;;; On 64-bit-target, start is a character index (fixnum); chars are 32-bit,
+;;; so byte offset = start * 4 / 8 * 4 = start >> 1 (since start is fixnum,
+;;; char-size = 4 bytes, fixnumshift = 3: byte-offset = (start >> 3) * 4
+;;; = start >> 1... wait.  Let me re-derive.
+;;; start is a fixnum character index.  To get byte offset into the string
+;;; data:  byte_offset = (unbox start) * char-size = (start >> fixnumshift) * 4
+;;; = (start >> 3) * 4 = start >> 1.  Then add misc-data-offset.
+;;; PPC64: (srwi offset start 1) — this is the same as (lsr offset start 1).
+;;; Then (la offset misc-data-offset offset) = offset += misc-data-offset.
+
+(defarm64lapfunction %string-hash ((start arg_x) (str arg_y) (len arg_z))
+  (let ((nextw imm1)
+        (accum imm0)
+        (offset imm2))
+    (cbz len @done)
+    ;; Compute starting byte offset: start >> 1 + misc-data-offset
+    ;; (start is fixnum-tagged char index; chars are 32-bit = 4 bytes;
+    ;; byte offset = (start / fixnumone) * 4 = start * 4 / 8 = start / 2)
+    (lsr offset start (:$ 1))
+    (sub offset offset (:$ (- arm64::misc-data-offset)))
+    (mov accum (:$ 0))
+    @loop
+    (sub len len (:$ arm64::fixnumone))
+    ;; (lwzx nextw str offset) — 32-bit load via w1 (see %pname-hash)
+    (add imm3 str offset)
+    (ldr w1 (:@ imm3 (:$ 0)))
+    (add offset offset (:$ 4))
+    ;; (rotlwi accum accum 5) — 32-bit rotate left by 5, emulated
+    ;; (see %pname-hash: 64-bit ror would leak bits 27-31 into 32-36)
+    (lsr imm4 accum (:$ 27))
+    (lsl accum accum (:$ 5))
+    (orr accum accum imm4)
+    (and accum accum (:$ #xffffffff))
+    (eor accum accum nextw)
+    (cbnz len @loop)
+    ;; Produce fixnum result (same as %pname-hash)
+    (lsl accum accum (:$ 5))
+    (lsr arg_z accum (:$ (- 5 arm64::fixnumshift)))
+    @done
+    (ret)))
+
+;;; =====================================================================
+;;; %ensure-tlb-index — from vendor/ccl/level-0/PPC/ppc-symbol.lisp:183
+;;; =====================================================================
+;;;
+;;; Ensure the TLB has room for binding-index IDX.
+;;; PPC64: load tlb-limit, trap if limit <= idx, return tlb-pointer.
+;;; The trap (trlle) causes the kernel to extend the TLB.
+
+(defarm64lapfunction %ensure-tlb-index ((idx arg_z))
+  ;; (ldr arg_y target::tcr.tlb-limit target::rcontext)
+  (ldr arg_y (:@ rcontext (:$ arm64::tcr.tlb-limit)))
+  ;; (trlle arg_y idx) — trap if arg_y <= idx (unsigned)
+  ;; ARM64: cmp arg_y, idx; if arg_y <= idx (i.e. idx >= arg_y), trap.
+  ;; DECIDE-BLOCKED: trap convention for TLB extension (trlle equivalent).
+  ;; Using cmp + b.hi skip + brk placeholder.
+  (cmp arg_y idx)
+  (b.hi @ok)
+  (uuo-error-tlb-too-small idx)           ; TLB extension trap placeholder
+  @ok
+  ;; (ldr arg_z target::tcr.tlb-pointer target::rcontext)
+  (ldr arg_z (:@ rcontext (:$ arm64::tcr.tlb-pointer)))
+  (ret))

--- a/level-0/ARM64/arm64-utils.lisp
+++ b/level-0/ARM64/arm64-utils.lisp
@@ -1,0 +1,585 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;;
+;;; arm64-utils.lisp — ACTIVE seed (demand-driven from cold-load fatals;
+;;; lifted from upstream-port/level-0/drafts/arm64-utils.lisp wave-3).
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-0/PPC/ppc-utils.lisp)
+;;; Per-line citations: "; ppc:NNN" = line NNN of that file.
+
+(in-package "CCL")
+
+(eval-when (:compile-toplevel :execute)
+  (require "ARM64-LAPMACROS"))
+
+;;; =====================================================================
+;;; %kernel-import — ppc:619
+;;; =====================================================================
+;;; offset is a boxed fixnum, one of the target::kernel-import-xxx BYTE
+;;; offsets; unboxing yields the raw byte offset.
+(defarm64lapfunction %kernel-import ((offset arg_z))
+  (ref-global imm0 kernel-imports)      ; ppc:621
+  (unbox-fixnum imm1 arg_z)             ; ppc:622
+  (ldr arg_z (:@ imm0 imm1))            ; ppc:623 (ldrx)
+  (ret))                                ; ppc:624
+
+;;; =====================================================================
+;;; %get-unboxed-ptr — ppc:626
+;;; =====================================================================
+(defarm64lapfunction %get-unboxed-ptr ((macptr arg_z))
+  (macptr-ptr imm0 arg_z)               ; ppc:627
+  (ldr arg_z (:@ imm0 (:$ 0)))          ; ppc:628
+  (ret))                                ; ppc:629
+
+;;; =====================================================================
+;;; true / false — ppc:664/673
+;;; =====================================================================
+;;; nargs is boxed and fixnumshift=3=word-shift: the boxed count IS the
+;;; byte count, so (add vsp vsp imm0) needs no scaling.  PPC's blelr
+;;; (return if nargs <= 3, unsigned) becomes b.hi-over-ret.
+(defarm64lapfunction true ()
+  (cmp nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:666
+  (add arg_z rnil (:$ arm64::t-offset)) ; ppc:667 (li arg_z t)
+  (b.hi @pop)                           ; ppc:668 (blelr inverted)
+  (ret)
+  @pop
+  (sub imm0 nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:669
+  (add vsp vsp imm0)                    ; ppc:670
+  (ret))                                ; ppc:671
+
+(defarm64lapfunction false ()
+  (cmp nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:674
+  (mov arg_z rnil)                      ; ppc:675
+  (b.hi @pop)                           ; ppc:676 (blelr inverted)
+  (ret)
+  @pop
+  (sub imm0 nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:677
+  (add vsp vsp imm0)                    ; ppc:678
+  (ret))                                ; ppc:679
+
+;;; constant-ref — ppc:681 (16m13 demand: CONSTANTLY does
+;;; (%copy-function #'constant-ref) + set-nth-immediate; with
+;;; constant-ref undefined, every (constantly x) initfunction was a
+;;; copied UDF placeholder that trapped "undefined function" when
+;;; %early-shared-initialize funcalled it).  Constant-pool slot via
+;;; nfn-relative quoted-symbol syntax (DECIDE-14 precedent,
+;;; arm64-clos.lisp).  ldur does not disturb NZCV.
+(defarm64lapfunction constant-ref ()
+  (cmp nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:682
+  (ldur arg_z (:@ nfn (:$ 'constant)))  ; ppc:683 (ldr arg_z 'constant nfn)
+  (b.hi @pop)                           ; ppc:684 (blelr inverted)
+  (ret)
+  @pop
+  (sub imm0 nargs (:$ (ash 3 arm64::fixnumshift))) ; ppc:685
+  (add vsp vsp imm0)                    ; ppc:686
+  (ret))                                ; ppc:687
+
+;;; =====================================================================
+;;; %address-of — from vendor/ccl/level-0/PPC/ppc-utils.lisp:35
+;;; (#+ppc64-target arm; ppc32 twin ppc:21 skipped).  16m21b demand:
+;;; the error/object printer (l1-io.lisp:388 "BOGUS object @ #x…" and
+;;; the #<CODE-VECTOR …> print path) funcalls %address-of; it was left
+;;; unpromoted in drafts, so a compile-time error's printer hit
+;;; "Undefined function %ADDRESS-OF" -> recursive printing error.
+;;; =====================================================================
+;;;
+;;; %address-of a fixnum is the fixnum itself; anything else is its
+;;; (tagged) address as an integer — a fixnum if it fits in 60 bits, else
+;;; a bignum via .SPmakeu64.  Low-tag arithmetic is identical to PPC64
+;;; (fixnumshift 3 both).  Bignum path: TAIL (jump-subprim .SPmakeu64,
+;;; imm0 = its input), the canonical no-link idiom already used at
+;;; arm64-def.lisp:103 / x86-utils.lisp:29 — NOT the draft's call-subprim
+;;; (whose dispatch scratch collides with imm0; DECIDE W4-D11).
+;;; .SPmakeu64 IS in Matt's subprims table (Matt's own impl @ 115b7aa,
+;;; spentry-A-alloc-numbers.s:187).
+
+(defarm64lapfunction %address-of ((arg arg_z))
+  (ands imm0 arg (:$ arm64::tagmask))   ; ppc:38 (clrldi. — low 3 tag bits)
+  (b.ne @nonfixnum)                     ; ppc:39 (beqlr — fixnum: unchanged)
+  (ret)
+  @nonfixnum
+  (mov imm0 arg_z)                      ; ppc:40
+  ;; ppc:42 (clrrdi.): EQ iff the address fits in a fixnum (top 4 bits
+  ;; clear).  Mask #xF000000000000000 is a single ones-run = valid
+  ;; logical immediate; ldb wrap for the no-negative-immediate encoder.
+  (ands imm1 imm0 (:$ (ldb (byte 64 0)
+                           (lognot (1- (ash 1 (- 63 arm64::fixnumshift)))))))
+  (box-fixnum arg_z imm0)               ; ppc:43 (lsl — NZCV-safe)
+  (b.ne @bignum)                        ; ppc:44 (beqlr+ — boxed fixnum done)
+  (ret)
+  @bignum
+  (jump-subprim .SPmakeu64))            ; ppc:45 (ba — TAIL no-link)
+
+;;; =====================================================================
+;;; %normalize-areas — from vendor/ccl/level-0/PPC/ppc-utils.lisp:59
+;;; (16m5v demand; promoted from drafts/arm64-utils.lisp:72)
+;;; =====================================================================
+;;;
+;;; Update the current thread's stack-area "active" pointers, then return
+;;; the active dynamic area (successor of the all-areas list header).
+;;; Matt's design has a tsp register (x24), so the tsp store is direct.
+;;; (mov imm1 sp) is the ADD alias (arm64-asm.lisp:467) — SP legal as Rn.
+
+(defarm64lapfunction %normalize-areas ()
+  (let ((address imm0))
+    ;; update active pointer for tsp area.  ppc:64-65
+    (ldr address (:@ rcontext (:$ arm64::tcr.ts-area)))
+    (str tsp (:@ address (:$ arm64::area.active)))
+    ;; update active pointer for vsp area.  ppc:68-69
+    (ldr address (:@ rcontext (:$ arm64::tcr.vs-area)))
+    (str vsp (:@ address (:$ arm64::area.active)))
+    ;; update active pointer for SP area.  ppc:72-73
+    (ldr arg_z (:@ rcontext (:$ arm64::tcr.cs-area)))
+    (mov imm1 sp)                       ; (str sp …) not encodable; stage
+    (str imm1 (:@ arg_z (:$ arm64::area.active)))
+    (ref-global arg_z all-areas)        ; ppc:76
+    (ldr arg_z (:@ arg_z (:$ arm64::area.succ)))  ; ppc:77
+    (ret)))                             ; ppc:79 (blr)
+
+;;; =====================================================================
+;;; %active-dynamic-area — from vendor/ccl/level-0/PPC/ppc-utils.lisp:81
+;;; (same donor cluster; trivial sibling)
+;;; =====================================================================
+
+(defarm64lapfunction %active-dynamic-area ()
+  (ref-global arg_z all-areas)          ; ppc:82
+  (ldr arg_z (:@ arg_z (:$ arm64::area.succ)))  ; ppc:83
+  (ret))                                ; ppc:84 (blr)
+
+;;; =====================================================================
+;;; %walk-dynamic-area — from vendor/ccl/level-0/PPC/ppc-utils.lisp:366
+;;; (16m5w demand; promoted from drafts/arm64-utils.lisp:288 with three
+;;; promotion fixes: (1) ppc:376 (:regsave sentinel 0) dropped — his lap
+;;; DSL has no :regsave (DECIDE-7, 16m5q precedent arm64-array.lisp:287);
+;;; (2) draft's stray temp1 at the loop-head load unified to the imm5
+;;; scan pointer (x5 free — nargs is x6); (3) alloc-trap branch b.hi →
+;;; b.hs, the canonical Misc_Alloc shape (w1:340).)
+;;; =====================================================================
+;;;
+;;; Like walk-static-area but objects may be consed while walking:
+;;; terminate at a freshly-allocated sentinel cons.  The sentinel is
+;;; allocated by FORCING the allocation trap (allocbase set to a huge
+;;; value so the no-trap branch is never taken) — the kernel completes
+;;; the allocation exactly as PPC's tdlt-always-traps idiom did; the
+;;; allocation request is conveyed by allocptr's fulltag (cons).
+;;; PPC's cr0 (tenured-area zero test, ppc:381) stays live across the
+;;; sentinel allocation; our alloc protocol contains a cmp, so the
+;;; selection is resolved FIRST with csel — same value, earlier point.
+
+(defarm64lapfunction %walk-dynamic-area ((a arg_y) (f arg_z))
+  (let ((fun save0)
+        (obj save1)
+        (sentinel save2)
+        (header imm0)
+        (tag imm1)
+        (subtag imm2)
+        (bytes imm3)
+        (elements imm4))
+    (save-lisp-context)                 ; ppc:375
+    ;; ppc:376 (:regsave sentinel 0) — no :regsave in his lap DSL (DECIDE-7)
+    (vpush fun)                         ; ppc:377
+    (vpush obj)                         ; ppc:378
+    (vpush sentinel)                    ; ppc:379
+    (ref-global imm0 tenured-area)      ; ppc:380
+    (cmp imm0 (:$ 0))                   ; ppc:381 (cmpdi cr0)
+    (csel a imm0 a (:? ne))             ; ppc:390-391 (if :ne (mr a imm0)) — moved up
+    ;; allocbase := #x8000_0000_0000 - 16 so the trap below always fires.
+    (movz allocbase (:$ #x8000 :lsl 32)) ; ppc:382-383 (lwi #x8000; sldi 32)
+    (sub allocbase allocbase (:$ 16))   ; ppc:384 (subi allocbase allocbase 16)
+    ;; tagged-cons allocptr, then the canonical alloc-trap protocol.
+    (sub allocptr allocptr (:$ (- arm64::cons.size arm64::fulltag-cons))) ; ppc:385 (la)
+    (cmp allocptr allocbase)            ; ppc:386 (tdlt allocptr allocbase) …
+    (b.hs @no-trap)                     ; … canonical Misc_Alloc shape (w1:340)
+    (uuo-alloc-trap)
+    @no-trap
+    (mov sentinel allocptr)             ; ppc:387 (mr)
+    (and allocptr allocptr (:$ (ldb (byte 64 0) (lognot arm64::fulltagmask)))) ; ppc:388 (clrrdi ntagbits)
+    (mov fun f)                         ; ppc:389 (mr)
+    (ldr imm5 (:@ a (:$ arm64::area.low))) ; ppc:392 (ld imm5 …)
+    @loop
+    (ldr header (:@ imm5 (:$ 0)))       ; ppc:394
+    ;; ppc:395-399 — header-vs-cons discrimination on the header fulltag
+    (and tag header (:$ arm64::fulltagmask))
+    (cmp tag (:$ arm64::fulltag-immheader-0))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-immheader-1))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-immheader-2))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-nodeheader-0))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-nodeheader-1))
+    (b.eq @misc)
+    ;; cons
+    (add obj imm5 (:$ arm64::fulltag-cons))    ; ppc:400 (la)
+    (cmp obj sentinel)                  ; ppc:401 (cmpd cr0)
+    (mov arg_z obj)                     ; ppc:402 — mov/set-nargs preserve NZCV
+    (set-nargs 1)                       ; ppc:403
+    (mov temp0 fun)                     ; ppc:404
+    (b.eq @done)                        ; ppc:405 (beq cr0)
+    (call-subprim .SPfuncall)           ; ppc:406 (bla .SPfuncall)
+    (add imm5 obj (:$ (- arm64::cons.size arm64::fulltag-cons))) ; ppc:407 (la)
+    (b @loop)                           ; ppc:408
+    @misc
+    (add obj imm5 (:$ arm64::fulltag-misc))    ; ppc:410 (la)
+    (mov arg_z obj)                     ; ppc:411
+    (set-nargs 1)                       ; ppc:412
+    (mov temp0 fun)                     ; ppc:413
+    (call-subprim .SPfuncall)           ; ppc:414
+    (getvheader header obj)             ; ppc:415
+    ;; ppc:416-438 — size dispatch on ivector class / subtag
+    (and tag header (:$ arm64::fulltagmask))    ; ppc:416 (extract-lowtag)
+    (header-size elements header)       ; ppc:425
+    (cmp tag (:$ arm64::fulltag-nodeheader-0))  ; ppc:418 (cr1)
+    (b.eq @8bytes)                      ; ppc:427 (beq cr1)
+    (cmp tag (:$ arm64::fulltag-nodeheader-1))  ; ppc:418 (cr1)
+    (b.eq @8bytes)                      ; ppc:427
+    (cmp tag (:$ arm64::ivector-class-64-bit))  ; ppc:420 (cr2)
+    (b.eq @8bytes)                      ; ppc:428 (beq cr2)
+    (cmp tag (:$ arm64::ivector-class-32-bit))  ; ppc:422 (cr4)
+    (b.eq @4bytes)                      ; ppc:432 (beq cr4)
+    (and subtag header (:$ #xff))       ; ppc:419 (extract-lowbyte)
+    (cmp subtag (:$ arm64::subtag-bit-vector))  ; ppc:423 (cr5)
+    (b.eq @bit)                         ; ppc:436
+    (cmp subtag (:$ arm64::subtag-complex-double-float-vector)) ; ppc:424 (cr6)
+    (b.eq @16bytes)                     ; ppc:434 (beq cr6)
+    (cmp subtag (:$ arm64::min-8-bit-ivector-subtag))
+    (b.hs @1byte)                       ; ppc:430 (beq cr3 — 8-bit class)
+    (lsl bytes elements (:$ 1))         ; ppc:435 (sldi bytes elements 1)
+    (b @bump)
+    @1byte
+    (mov bytes elements)                ; ppc:429 (mr bytes elements)
+    (b @bump)
+    @bit
+    (add bytes elements (:$ 7))         ; ppc:437 (la elements 7 elements)
+    (lsr bytes bytes (:$ 3))            ; ppc:438 (srdi bytes elements 3)
+    (b @bump)
+    @16bytes
+    (lsl bytes elements (:$ 4))         ; ppc:433 (sldi bytes elements 4)
+    (b @bump)
+    @4bytes
+    (lsl bytes elements (:$ 2))         ; ppc:431 (sldi bytes elements 2)
+    (b @bump)
+    @8bytes
+    (lsl bytes elements (:$ 3))         ; ppc:426 (sldi bytes elements 3)
+    @bump
+    (add bytes bytes (:$ (+ 8 15)))     ; ppc:440 (la bytes (+ 8 15) bytes)
+    (and bytes bytes (:$ (ldb (byte 64 0) (lognot 15)))) ; ppc:441 (clrrdi 4)
+    (sub imm5 obj (:$ arm64::fulltag-misc))    ; ppc:442 (subi)
+    (add imm5 imm5 bytes)               ; ppc:443
+    (b @loop)                           ; ppc:444
+    @done
+    (mov arg_z rnil)                    ; ppc:446 (li arg_z nil)
+    (vpop sentinel)                     ; ppc:447
+    (vpop obj)                          ; ppc:448
+    (vpop fun)                          ; ppc:449
+    (restore-full-lisp-context)         ; ppc:450
+    (ret)))                             ; ppc:451 (blr)
+
+;;; ppc:453-455 — plain lisp, carried verbatim.
+(defun walk-dynamic-area (area func)
+  (with-other-threads-suspended
+      (%walk-dynamic-area area func)))
+
+;;; =====================================================================
+;;; walk-static-area — from vendor/ccl/level-0/PPC/ppc-utils.lisp:184
+;;; (#+ppc64-target arm; the #+ppc32-target twin at ppc:111 is skipped)
+;;; =====================================================================
+;;; (16m5y demand; promoted from drafts/arm64-utils.lisp:138 — :regsave
+;;; dropped per DECIDE-7, otherwise verbatim.)
+;;;
+;;; Call f on every object in static area a.  Structure is the PPC64
+;;; line-port; TWO tag-scheme adaptations (both mirrored from the x86-64
+;;; twin, vendor/ccl/level-0/X86/x86-utils.lisp:92, whose tag scheme Matt's
+;;; design copies):
+;;;  1. header-vs-cons: PPC64 tests a 2-bit lowtag (lowtag-immheader /
+;;;     lowtag-nodeheader).  Matt's design has FIVE header fulltags
+;;;     {immheader-0=5, nodeheader-0=6, immheader-1=12, immheader-2=13,
+;;;     nodeheader-1=14} with no common low-bit pattern — each is tested.
+;;;     Header fulltags are disjoint from every valid node fulltag, so a
+;;;     cons's cdr word (at [base+0]) can never be misread as a header.
+;;;  2. element-size dispatch: PPC64's ivector classes (64/8/32-bit)
+;;;     differ from Matt's (64-bit / 32-bit / other-bit, where "other"
+;;;     mixes 16-bit, 8-bit, bit, and complex-double-float vectors);
+;;;     dispatch rewritten per HIS arm64-arch.lisp constants.
+;;; PPC64 keeps 6 CRs live across the dispatch; ARM64's single NZCV forces
+;;; sequential cmp/branch — the subtag byte is therefore extracted while
+;;; header is still live, and elements lives in imm4 (NOT PPC's imm0=header
+;;; alias) so header survives until the subtag extraction.
+;;;
+;;; .SPfuncall convention: callee in temp0 (matches PPC; confirmed against
+;;; our upstream-port spentry draft, spentry-D-call-builtins.s:159).
+
+(defarm64lapfunction walk-static-area ((a arg_y) (f arg_z))
+  (let ((fun save0)
+        (obj save1)
+        (limit save2)
+        (header imm0)
+        (tag imm1)
+        (subtag imm2)
+        (bytes imm3)
+        (elements imm4))
+    (save-lisp-context)                 ; ppc:193
+    ;; ppc:194 (:regsave limit 0) — no :regsave in his lap DSL (DECIDE-7)
+    (vpush fun)                         ; ppc:195
+    (vpush obj)                         ; ppc:196
+    (vpush limit)                       ; ppc:197
+    (mov fun f)                         ; ppc:198 (mr)
+    (ldr limit (:@ a (:$ arm64::area.active)))  ; ppc:199
+    (ldr obj (:@ a (:$ arm64::area.low)))       ; ppc:200
+    (b @test)                           ; ppc:201
+    @loop
+    (ldr header (:@ obj (:$ 0)))        ; ppc:203
+    ;; ppc:204-208 — header-vs-cons (adaptation 1 above)
+    (and tag header (:$ arm64::fulltagmask))
+    (cmp tag (:$ arm64::fulltag-immheader-0))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-immheader-1))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-immheader-2))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-nodeheader-0))
+    (b.eq @misc)
+    (cmp tag (:$ arm64::fulltag-nodeheader-1))
+    (b.eq @misc)
+    ;; cons
+    (add arg_z obj (:$ arm64::fulltag-cons))    ; ppc:209 (la)
+    (set-nargs 1)                       ; ppc:210
+    (mov temp0 fun)                     ; ppc:211 (mr temp0 fun)
+    ;; ppc:212 (bla .SPFuncall) — DECIDE: in our spentry drafts
+    ;; (spentry-D), not yet in Matt's *subprims* table.
+    (call-subprim .SPfuncall)
+    (add obj obj (:$ arm64::cons.size)) ; ppc:213 (la obj cons.size obj)
+    (b @test)                           ; ppc:214
+    @misc
+    (add arg_z obj (:$ arm64::fulltag-misc))    ; ppc:216 (la)
+    (set-nargs 1)                       ; ppc:217
+    (mov temp0 fun)                     ; ppc:218
+    (call-subprim .SPfuncall)           ; ppc:219 — same DECIDE
+    (ldr header (:@ obj (:$ 0)))        ; ppc:220
+    ;; ppc:221-243 — size dispatch (adaptation 2 above)
+    (and tag header (:$ arm64::fulltagmask))    ; ppc:221 (extract-lowtag)
+    (header-size elements header)       ; ppc:230
+    (cmp tag (:$ arm64::fulltag-nodeheader-0))  ; ppc:223 (cr1)
+    (b.eq @8bytes)                      ; ppc:232 (beq cr1)
+    (cmp tag (:$ arm64::fulltag-nodeheader-1))  ; ppc:223 (cr1)
+    (b.eq @8bytes)                      ; ppc:232
+    (cmp tag (:$ arm64::ivector-class-64-bit))  ; ppc:225 (cr2)
+    (b.eq @8bytes)                      ; ppc:233 (beq cr2)
+    (cmp tag (:$ arm64::ivector-class-32-bit))  ; ppc:227 (cr4)
+    (b.eq @4bytes)                      ; ppc:237 (beq cr4)
+    ;; ivector-class-other-bit: dispatch on the full subtag byte
+    (and subtag header (:$ #xff))       ; ppc:224 (extract-lowbyte)
+    (cmp subtag (:$ arm64::subtag-bit-vector))  ; ppc:228 (cr5)
+    (b.eq @bit)                         ; ppc:241
+    (cmp subtag (:$ arm64::subtag-complex-double-float-vector)) ; ppc:229 (cr6)
+    (b.eq @16bytes)                     ; ppc:239 (beq cr6)
+    ;; 8-bit ivectors have the largest other-bit array subtags except
+    ;; bit-vector (already dispatched): subtag >= min-8-bit-ivector-subtag
+    ;; means 1 byte/element, else 16-bit (2 bytes) — x86-utils.lisp:160-167.
+    (cmp subtag (:$ arm64::min-8-bit-ivector-subtag))
+    (b.hs @1byte)                       ; ppc:235 (beq cr3 — 8-bit class)
+    (lsl bytes elements (:$ 1))         ; ppc:240 (sldi bytes elements 1)
+    (b @bump)
+    @1byte
+    (mov bytes elements)                ; ppc:234 (mr bytes elements)
+    (b @bump)
+    @bit
+    (add bytes elements (:$ 7))         ; ppc:242 (la elements 7 elements)
+    (lsr bytes bytes (:$ 3))            ; ppc:243 (srdi bytes elements 3)
+    (b @bump)
+    @16bytes
+    (lsl bytes elements (:$ 4))         ; ppc:238 (sldi bytes elements 4)
+    (b @bump)
+    @4bytes
+    (lsl bytes elements (:$ 2))         ; ppc:236 (sldi bytes elements 2)
+    (b @bump)
+    @8bytes
+    (lsl bytes elements (:$ 3))         ; ppc:231 (sldi bytes elements 3)
+    @bump
+    ;; header word + round up to a 16-byte dnode.  ppc:245-246
+    (add bytes bytes (:$ (+ 8 15)))     ; ppc:245 (la bytes (+ 8 15) bytes)
+    (and bytes bytes (:$ (ldb (byte 64 0) (lognot 15)))) ; ppc:246 (clrrdi 4)
+    (add obj obj bytes)                 ; ppc:247
+    @test
+    (cmp obj limit)                     ; ppc:249 (cmpld — unsigned)
+    (b.lo @loop)                        ; ppc:250 (blt)
+    (vpop limit)                        ; ppc:251
+    (vpop obj)                          ; ppc:252
+    (vpop fun)                          ; ppc:253
+    (restore-full-lisp-context)         ; ppc:254
+    (ret)))                             ; ppc:255 (blr)
+
+;;; =====================================================================
+;;; %revive-macptr — ppc-utils.lisp:632 (unguarded)
+;;; =====================================================================
+;;; Demand: 16m9a l1-aprims (revives the pointer defloadvars around
+;;; l1-aprims:50).  Store subtag-macptr into the object's subtag byte —
+;;; his misc-subtag-offset = misc-header-offset = -12 (LE low byte of
+;;; the header word), arm64-arch.lisp:251-253.
+(defarm64lapfunction %revive-macptr ((p arg_z))
+  (mov imm0 (:$ arm64::subtag-macptr))     ; ppc:633 (li)
+  ;; misc-subtag-offset is NEGATIVE (-12): byte stores need the unscaled
+  ;; STURB form (the seeds' "-4 unscaled STUR" class, byte flavor).
+  (sturb (:w imm0) (:@ p (:$ arm64::misc-subtag-offset))) ; ppc:634 (stb)
+  (ret))                                   ; ppc:635 (blr)
+
+;;; =====================================================================
+;;; %class-of-instance — ppc-utils.lisp:459
+;;; =====================================================================
+;;; Sibling of class-of (same donor block): *class-table* routes
+;;; standard-instances here, so the 16m10 demand pulls both.
+;;; instance.class-wrapper and %wrapper-class are CCL-package constants
+;;; from library/lispequ.lisp def-accessors — target-independent slot
+;;; indices; the svref lapmacro supplies the misc-data-offset/ldur shape.
+(defarm64lapfunction %class-of-instance ((i arg_z))
+  (svref arg_z instance.class-wrapper i)  ; ppc:460
+  (svref arg_z %wrapper-class arg_z)      ; ppc:461
+  (ret))                                  ; ppc:462 (blr)
+
+;;; =====================================================================
+;;; class-of — ppc-utils.lisp:464
+;;; =====================================================================
+;;; Demand: 16m10 frontier — l1-clos-boot toplevels die at
+;;; `undefined function CLASS-OF` (uuo 0x23d udf-call, nargs 1).
+;;;
+;;; Dispatch index into *class-table* (256-entry vector filled by
+;;; l1-clos-boot under patch 0001's arm64 branch): subtag byte for
+;;; fulltag-misc objects, else the low byte of the object itself — the
+;;; per-slice fills cover every fulltag whose payload reaches the low
+;;; byte (fixnum payload / cons+nil address bits in bits 4-7), and
+;;; immediates/single-floats keep their payload above bit 7 so their
+;;; low byte IS the canonical typecode (patch 0001 U-RATIFY note).
+;;;
+;;; ARM64-DEVIATION (symbols, misc SUBTAGS on PPC64, carry their own
+;;; POINTER fulltag here — 7; functions are ordinary miscobjs since the
+;;; fulltag-function removal, patch 0055):
+;;;  1. arg dispatch: a symbol pointer's ADDRESS bits reach the low byte
+;;;     and patch 0001 deliberately leaves those slices unfilled —
+;;;     canonicalize to the BARE fulltag (the table holds the class at
+;;;     v[fulltag-symbol]; functions go through @misc to
+;;;     v[subtag-function] like every other uvector).
+;;;  2. table-entry functionp: PPC's own extract-typecode vs
+;;;     subtag-function test (ppc:482-483), valid again under unified
+;;;     tags.
+;;; Tail transfers (entry fn / no-class-error) use the EQUAL canon
+;;; (arm64-pred.lisp:209-212): fcell + slot-0 load + br; PPC's
+;;; `ba .SPjmpsym` has no upstream subprim.
+(defarm64lapfunction class-of ((x arg_z))
+  (check-nargs 1)                        ; ppc:465
+  (extract-fulltag imm0 x)               ; ppc:466
+  (cmp imm0 (:$ arm64::fulltag-misc))    ; ppc:467 (cmpri)
+  (b.eq @misc)                           ; ppc:468
+  (cmp imm0 (:$ arm64::fulltag-symbol))  ; deviation 1: bare fulltag
+  (b.eq @done)                           ; (functions are misc-tagged now:
+                                         ;  fulltag-function removed, 0055)
+  (extract-lowbyte imm0 x)               ; ppc:469
+  (b @done)                              ; ppc:470
+  @misc
+  (extract-subtag imm0 x)                ; ppc:472
+  @done
+  (lsl imm0 imm0 (:$ arm64::word-shift)) ; ppc:474 (slri)
+  (load-nfn-constant temp1 *class-table*) ; ppc:475 (ldr temp1 '*class-table* nfn)
+  (sub imm0 imm0 (:$ (- arm64::misc-data-offset))) ; ppc:476 (addi; negative imm ⇒ sub)
+  (ldur temp1 (:@ temp1 (:$ arm64::symbol.vcell))) ; ppc:477 (vcell = 9, unscaled)
+  (ldr temp0 (:@ temp1 imm0))            ; ppc:478 (ldrx — reg-offset load)
+  (cmp temp0 rnil)                       ; ppc:479 (cmpri cr0 temp0 nil)
+  (b.eq @bad)                            ; ppc:480
+  ;; functionp? — deviation 2 (PPC shape restored, patch 0055)
+  (extract-typecode imm1 temp0)          ; ppc:482
+  (cmp imm1 (:$ arm64::subtag-function)) ; ppc:483 (cmpri subtag-function)
+  (b.ne @ret)                            ; ppc:484 — not function: return entry
+  ;; tail-call the entry with x still in arg_z  ppc:486-490
+  (mov nfn temp0)                        ; ppc:486 (mr)
+  (ldur imm0 (:@ nfn (:$ arm64::misc-function-offset))) ; ppc:487 (ldr misc-data-offset)
+  (set-nargs 1)                          ; ppc:488
+  (br imm0)                              ; ppc:489-490 (mtctr/bctr)
+  @bad
+  (load-nfn-constant fname no-class-error) ; ppc:492
+  ;; ppc:493 (ba .spjmpsym) — no-link tail jump per the EQUAL canon;
+  ;; nargs still 1 from entry (as on PPC), arg_z still x.
+  (ldur nfn (:@ fname (:$ arm64::symbol.fcell)))
+  (ldur imm0 (:@ nfn (:$ arm64::misc-function-offset)))
+  (br imm0)
+  @ret
+  (mov arg_z temp0)                      ; ppc:495 — return frob from table
+  (ret))                                 ; ppc:496 (blr)
+
+;;; =====================================================================
+;;; gc — ppc-utils.lisp:507.  PROMOTED 16m34 from the wave-3 draft
+;;; (drafts/arm64-utils.lisp:514) on LIVE REPL demand: rung 17 of the
+;;; capability ladder reported "Undefined function GC called with
+;;; arguments () ", the only failure in an otherwise 18/19-green run.
+;;;
+;;; Only `gc` is lifted, not the rest of the ppc:507-616 GC-trap family
+;;; (egc, %configure-egc, gc-verbose, ...), per this file's demand-driven
+;;; convention stated in the header — those come when a boot names them.
+;;;
+;;; PPC's (trlgei allocptr 0) is an always-true conditional trap the
+;;; kernel decodes as the GC trap, with the selector in imm0.  AArch64
+;;; has Matt's dedicated uuo-gc-trap template instead, the same way the
+;;; x86-64 version uses its own (x86-utils.lisp:367).
+;;;
+;;; TRAP ENCODING VERIFIED END-TO-END (this was the one real risk, since a
+;;; selector the kernel does not recognize would crash the REPL instead of
+;;; erroring cleanly):
+;;;   - canon: lisp-kernel/arm64-uuo.s — misc-format UUOs are
+;;;     `udf #((info << 2) | uuo_format_misc)` with uuo_format_misc = 0,
+;;;     and `uuo_gc_trap` is `uuo_misc 2`, i.e. the word 0x08.
+;;;   - compiler: Matt's arm64-asm.lisp:438 still carries a STALE 3-bit
+;;;     format ((ash 2 3)|#x7 = 0x17), but OUR patch
+;;;     0012-arm64-asm-uuo-templates-renumber.patch rewrites it to
+;;;     (ash 2 2) = 0x08, matching the canon.
+;;;   - kernel: arm64-exceptions.c:229 GC_TRAP_INSTRUCTION = 0x00000008,
+;;;     tested at :1244, dispatching handle_gc_trap (:611), which reads the
+;;;     selector from imm0 and the arg from imm1 — exactly what this
+;;;     function sets up.  (Note that uuo_misc_gc_trap has no case in the
+;;;     handle_uuo misc switch, and correctly so: the GC trap is caught by
+;;;     the GC_TRAP_INSTRUCTION test BEFORE handle_uuo is reached.)
+;;; =====================================================================
+(defarm64lapfunction gc ()
+  (check-nargs 0)                           ; ppc:508
+  (mov imm0 (:$ arch::gc-trap-function-gc)) ; ppc:509 (li)
+  (uuo-gc-trap)                             ; ppc:510 (trlgei allocptr 0)
+  (mov arg_z rnil)                          ; ppc:511 (li arg_z target-nil)
+  (ret))                                    ; ppc:512 (blr)
+
+;;; =====================================================================
+;;; %allocate-list — PPC64 line-port of ppc-utils.lisp:602 (16m48).
+;;; PROMOTED from drafts/arm64-utils.lisp with both of the corrections the
+;;; drafting protocol names, each now a LIVE facility rather than a DECIDE:
+;;;
+;;;   * the draft's `(brk (:$ #xf012))' placeholder becomes the real
+;;;     `(uuo-interr arch::error-allocate-list)'.  The lapmacro is defined
+;;;     (drafts/arm64-lapmacros-additions.lisp:660) and already carries two
+;;;     PROMOTED callers in arm64-misc.lisp:598/604 (%suspend-other-threads,
+;;;     %resume-other-threads), so the misc-format interr encoding is proven
+;;;     end to end; the kernel decodes error_allocate_list (=18,
+;;;     compiler/arch.lisp:68) at arm64-exceptions.c:1664 and services it
+;;;     with allocate_list() at :522, which builds the whole list — GCing at
+;;;     most once — and returns it in arg_z.
+;;;   * `(call-subprim .SPnvalret)' becomes `(jump-subprim .SPnvalret)'.
+;;;     PPC's `ba' is a TAIL branch, and every donor agrees: ARM32 spjump
+;;;     (arm-utils.lisp:337), x86-64 jmp-subprim (x86-utils.lisp:469).
+;;;     .SPnvalret is in Matt's own subprim table (arm64-arch.lisp:447).
+;;;     This was the 29th and last entry in tools/draft-tail-subprim-lint.py.
+;;;
+;;; WHY IT MATTERS: l0-aprims.lisp:222 routes MAKE-LIST here for
+;;; (>= size (ash 1 16)) — 65536 — and nothing smaller.  Undefined, that is
+;;; a CCL::UNDEFINED-FUNCTION-CALL naming CCL::%ALLOCATE-LIST, which is
+;;; exactly what LENGTH.LIST.3 `(length (make-list 200000))' signalled; the
+;;; measured 16m48 size ladder puts the cliff between 50000 and 100000,
+;;; straddling 65536.  One test in 21679 reaches it, which is why a whole
+;;; missing definition survived this long.
+;;;
+;;; Two values are returned and the caller keeps one — l0-aprims wraps the
+;;; call in (values ...).  Faithful to every donor: PPC pushes arg_z then
+;;; arg_y, ARM32 the same, x86-64 pushes arg_z then allocptr.  PPC64 is our
+;;; donor, so arg_y it is.
+;;; =====================================================================
+(defarm64lapfunction %allocate-list ((initial-element arg_y) (nconses arg_z))
+  (check-nargs 2)                             ; ppc:603
+  (save-lisp-context)                         ; ppc:604
+  (uuo-interr arch::error-allocate-list)      ; ppc:605 uuo_interr ... rzero
+  (vpush arg_z)                               ; ppc:606 (the list)
+  (vpush arg_y)                               ; ppc:607
+  (set-nargs 2)                               ; ppc:608
+  (jump-subprim .SPnvalret))                  ; ppc:609 (ba — TAIL branch)

--- a/level-1/arm64-callback-support.lisp
+++ b/level-1/arm64-callback-support.lisp
@@ -1,0 +1,55 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;; ARM64-SPECIFIC — a callback trampoline is raw machine code, so the
+;;; body is inherently per-ISA; no PPC64 or Clozure-WIP analog encoding
+;;; exists (PPC64 `ba' / ARM32 `ldr pc,[pc,#-4]` — see below).
+;;;
+;;; arm64-callback-support.lisp — callback trampoline generator for Matt
+;;; Emerson's upstream ARM64 (low-tag) design.
+;;;
+;;; ISA-specific by nature (the body is raw machine code): the LOGIC
+;;; mirrors arm-callback-support.lisp:19 and x86-callback-support.lisp:21
+;;; (allocate a callback pointer, stamp the callback index into the
+;;; register the kernel's _SPcallback reads, jump there, make the stub
+;;; executable, return the pointer).  PPC64 reaches the subprim with a
+;;; `ba' absolute branch and ARM32 with an `ldr pc,[pc,#-4]' literal
+;;; jump; neither encoding exists on AArch64, hence the x16 literal jump.
+;;;
+;;; Trampoline layout (32 bytes, entered by FOREIGN code under AAPCS64;
+;;; x8 (indirect-result reg, caller-saved for our purposes — _SPcallback
+;;; consumes it immediately) and x16 (IP0 scratch) are safe to clobber):
+;;;
+;;;    0: movz x8, #lo16(index)         ; unboxed callback index
+;;;    4: movk x8, #hi16(index), lsl 16
+;;;    8: ldr  x16, .+16                ; load _SPcallback address
+;;;   12: br   x16                      ;   from the literal at +24
+;;;   16: nop                           ; pad literal to 8-byte alignment
+;;;   20: nop
+;;;   24: .quad <_SPcallback kernel address>
+;;;
+;;; MATCHED PAIR: _SPcallback (upstream-port/lisp-kernel/spentry-E-ffi.s)
+;;; reads the index from arg_w = x8 (`mov save0, arg_w`).  Change this
+;;; generator and that entry together.
+
+(in-package "CCL")
+
+(defun make-callback-trampoline (index &optional info)
+  (declare (ignorable info))
+  (let* ((p (%allocate-callback-pointer 32))
+         (addr (%lookup-subprim-address
+                #.(arm64::subprimitive-offset ".SPcallback"))))
+    (setf (%get-unsigned-long p 0)          ; movz x8,#lo16(index)
+          (logior #xd2800008 (ash (ldb (byte 16 0) index) 5))
+          (%get-unsigned-long p 4)          ; movk x8,#hi16(index),lsl #16
+          (logior #xf2a00008 (ash (ldb (byte 16 16) index) 5))
+          (%get-unsigned-long p 8)  #x58000090   ; ldr x16,.+16
+          (%get-unsigned-long p 12) #xd61f0200   ; br x16
+          (%get-unsigned-long p 16) #xd503201f   ; nop
+          (%get-unsigned-long p 20) #xd503201f   ; nop
+          (%%get-unsigned-longlong p 24) addr)
+    ;; I/D-cache sync — REQUIRED on arm64 before the stub is executed
+    ;; (same idiom as %make-code-executable, arm64-def.lisp).
+    (ff-call (%kernel-import #.arm64::kernel-import-makedataexecutable)
+             :address p
+             :unsigned-fullword 32
+             :void)
+    p))

--- a/level-1/arm64-error-signal.lisp
+++ b/level-1/arm64-error-signal.lisp
@@ -1,0 +1,155 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-1/ppc-error-signal.lisp,
+;;; cited "; ppc:NNN").
+;;;
+;;; arm64-error-signal.lisp — %XERR-DISP (the nrs_ERRDISP callback) for
+;;; Matt Emerson's upstream ARM64 (low-tag) design, linuxarm64 only.
+;;;
+;;; The kernel side is upstream-port/lisp-kernel/arm64-exceptions.c
+;;; handle_error → callback_for_trap(errdisp, xp, where, errnum, rb,
+;;; continuable): the same PPC-shaped pre-decoded contract as the donor
+;;; (errnum-style errors come here; raw trap words go to XCMAIN in
+;;; arm64-trap-support.lisp).
+;;;
+;;; Deviations from the donor (cited in place):
+;;;  - PPC's FPU-exception branch (ppc:67-99) back-decodes a PPC FP
+;;;    instruction; AArch64 FP exceptions are untrapped on shipping
+;;;    cores (arm64-exceptions.c handle_sigfpe) and the fpu uuo route
+;;;    goes to XCMAIN, so the branch has no analog here.
+;;;  - handle-udf-call's PC redirect requires the kernel NOT to bump
+;;;    the resume PC (PPC kernel: ppc-exceptions.c:1424-1429).  The
+;;;    arm64 kernel's uuo_unary_udf_call case gains the same bump
+;;;    suppression; until the next ARM kernel rebuild picks that up,
+;;;    the redirect lands 4 bytes past the code-vector entry (path is
+;;;    only reachable by continuing from an undefined-function-call
+;;;    restart).
+
+(in-package "CCL")
+
+;;; callback here from C exception handler (ppc:20-24).
+;;; pc-or-index widened to :unsigned-doubleword: when fn-reg is 0 it
+;;; carries a raw 64-bit PC (the donor's :unsigned-fullword predates
+;;; 64-bit naturals).
+(defcallback %xerr-disp
+    (:address xp
+     :unsigned-fullword fn-reg
+     :unsigned-doubleword pc-or-index
+     :signed-fullword errnum
+     :unsigned-fullword rb
+     :signed-fullword continuable)
+  (declare (ignorable pc-or-index))
+  (block %err-disp
+    (let ((fn (unless (eql fn-reg 0) (xp-gpr-lisp xp fn-reg)))
+          (err-fn (if (eql continuable 0) '%err-disp-internal '%kernel-restart-internal)))
+      (if (eql errnum arch::error-stack-overflow)
+        (handle-stack-overflow xp fn rb)
+        (with-xp-stack-frames (xp fn frame-ptr) ; execute body with dummy stack frame(s)
+          (with-error-reentry-detection
+              (let* ((rb-value (xp-gpr-lisp xp rb))
+                     (res
+                      (cond ((< errnum 0)
+                             (%err-disp-internal errnum nil frame-ptr))
+                            ((logtest errnum arch::error-type-error)
+                             (funcall err-fn
+                                      #.(car (rassoc 'type-error *kernel-simple-error-classes*))
+                                      (list rb-value (logandc2 errnum arch::error-type-error))
+                                      frame-ptr))
+                            ((eql errnum arch::error-udf)
+                             (funcall err-fn $xfunbnd (list rb-value) frame-ptr))
+                            ((eql errnum arch::error-throw-tag-missing)
+                             (%error (make-condition 'cant-throw-error
+                                                     :tag rb-value)
+                                     nil frame-ptr))
+                            ((eql errnum arch::error-cant-call)
+                             (%error (make-condition 'type-error
+                                                     :datum rb-value
+                                                     :expected-type '(or symbol function)
+                                                     :format-control
+                                                     "~S is not of type ~S, and can't be FUNCALLed or APPLYed")
+                                     nil frame-ptr))
+                            ((eql errnum arch::error-udf-call)
+                             (return-from %err-disp
+                               (handle-udf-call xp frame-ptr)))
+                            ;; arm64:: (not arch::): the frozen cross-host
+                            ;; image bakes arch.lisp, so a NEW arch::
+                            ;; constant reads as an undeclared free variable
+                            ;; and the fasl's ARCH-package symbol kills cold
+                            ;; load ($XNOPKG "ARCH" -- observed 16m45b).
+                            ((eql errnum arm64::error-apply-macro-or-special)
+                             ;; Funcalled a symbol naming a macro/special
+                             ;; operator (the fcell 2-elt vector's slot 0 =
+                             ;; %macro-code% fired uuo_error_apply_macro;
+                             ;; rb = fname).  PPC delivers exactly
+                             ;; ($XNOTFUN fname args) via ksignalerr
+                             ;; (xppcfasload.lisp:37); condition class
+                             ;; call-special-operator-or-macro, a subclass
+                             ;; of undefined-function.
+                             (%err-disp-internal $xnotfun
+                                                 (list (maybe-setf-name rb-value)
+                                                       (xp-argument-list xp))
+                                                 frame-ptr))
+                            ((eql errnum arch::error-alloc-failed)
+                             (%error (make-condition
+                                      'simple-storage-condition
+                                      :format-control (%rsc-string $xmemfull))
+                                     nil frame-ptr))
+                            ((eql errnum arch::error-memory-full)
+                             (%error (make-condition
+                                      'simple-storage-condition
+                                      :format-control (%rsc-string $xnomem))
+                                     nil frame-ptr))
+                            ((eql errnum arch::error-excised-function-call)
+                             (%error "~s: code has been excised." (list (xp-gpr-lisp xp arm64::nfn)) frame-ptr))
+                            ((eql errnum arch::error-too-many-values)
+                             (%err-disp-internal $xtoomanyvalues (list rb-value) frame-ptr))
+                            (t (%error "Unknown error #~d with arg: ~d" (list errnum rb-value) frame-ptr)))))
+                (setf (xp-gpr-lisp xp rb) res) ; munge register for continuation
+                )))))))
+
+;;; ppc:110-126.  The trampoline function f is entered by writing its
+;;; code vector (function slot 0) into the resume PC, exactly the value
+;;; _SPjmpnfn branches through (spentry-D-call-builtins.s jmpnfn).
+(defun handle-udf-call (xp frame-ptr)
+  (let* ((args (xp-argument-list xp))
+         (values (multiple-value-list
+                  (%kernel-restart-internal
+                   $xudfcall
+                   (list (maybe-setf-name (xp-gpr-lisp xp arm64::fname)) args)
+                   frame-ptr)))
+         (stack-argcnt (max 0 (- (length args) 3)))
+         (vsp (%i+ (xp-gpr-lisp xp arm64::vsp) stack-argcnt))
+         (f #'(lambda (values) (apply #'values values))))
+    (setf (xp-gpr-lisp xp arm64::vsp) vsp
+          (xp-gpr-lisp xp arm64::nargs) 1
+          (xp-gpr-lisp xp arm64::arg_z) values
+          (xp-gpr-lisp xp arm64::nfn) f)
+    ;; handle_uuo() (in the lisp kernel) must not bump the PC here —
+    ;; see the header deviation note.
+    ;; Since the fulltag-function removal (patch 0055) a function IS its
+    ;; misc-tagged uvector; %function-to-function-vector is
+    ;; identity-with-typecheck.
+    (setf (xp-pc-lisp xp) (uvref (%function-to-function-vector f) 0))))
+
+;;; ppc:133-153.  rb is the register number of the stack that
+;;; overflowed: the kernel's Rsp selector 31 for the control stack
+;;; (arm64-exceptions.c:112 — NOT arm64::sp, which is a *registers*
+;;; table index), else vsp/tsp GPR numbers.
+(defun handle-stack-overflow (xp fn rb)
+  (unwind-protect
+       (with-xp-stack-frames (xp fn frame-ptr) ; execute body with dummy stack frame(s)
+         (%error
+          (make-condition
+           'stack-overflow-condition
+           :format-control "Stack overflow on ~a stack."
+           :format-arguments (list
+                              (if (eql rb 31)
+                                "control"
+                                (if (eql rb arm64::vsp)
+                                  "value"
+                                  (if (eql rb arm64::tsp)
+                                    "temp"
+                                    "unknown")))))
+          nil frame-ptr))
+    (ff-call (%kernel-import target::kernel-import-restore-soft-stack-limit)
+             :unsigned-fullword rb
+             :void)))

--- a/level-1/arm64-threads-utils.lisp
+++ b/level-1/arm64-threads-utils.lisp
@@ -1,0 +1,149 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;; ARM64-SPECIFIC — upstream (Matt Emerson low-tag) lane file; the tag
+;;; geometry mirrors x8664, so the donor is level-1/x86-threads-utils.lisp
+;;; (#+x8664-target branches), not PPC64.  Declared doctrine exception:
+;;; PPC64's file assumes PPC tag/register models with no analog here.
+;;;
+;;; arm64-threads-utils.lisp — per-arch threads/frames predicates for Matt
+;;; Emerson's upstream ARM64 (low-tag) design.
+;;;
+;;; Donor: level-1/x86-threads-utils.lisp (#+x8664-target branches) — the
+;;; arm64 tag geometry mirrors x8664's (5 header classes split across
+;;; fulltag-immheader-0/1/2 + fulltag-nodeheader-0/1; dedicated symbol and
+;;; function pointer fulltags), cited "; x86:NNN".  Deviations:
+;;;  - NO tagged-return-address (TRA) cases: AArch64 return addresses live
+;;;    in lr/stack frames, untagged, as on PPC (x8664's fulltag-tra-0/1
+;;;    clauses in valid-header-p/bogus-thing-p have no analog).
+;;;  - catch-frame-sp is the PPC shape (ppc-threads-utils.lisp:84): catch
+;;;    frames are misc-tagged uvectors on the temp stack with an explicit
+;;;    csp slot (kernel ground truth: spentry-C-bind-catch-throw.s
+;;;    _structf catch_frame + mkcatch), not x8664's stack-consed
+;;;    rbp-cell frame.
+;;;
+;;; The lfun-bits &optional fixups are the PPC file's canonical four
+;;; (ppc-threads-utils.lisp:25-55; the x86 file duplicates the first pair).
+
+(in-package "CCL")
+
+;;; %frame-backlink and lisp-frame-p live in lib/arm64-backtrace.lisp
+;;; (16m17): they need the fake-stack-frame accessor macros at compile
+;;; time, and the cross gate compiles each file in a host image that
+;;; only gets those macros inside that compile unit.  (The x86-donor
+;;; versions that used to sit here checked the VALUE stack — an x8664
+;;; frame model; this design's lisp frames are marker frames on the
+;;; CONTROL stack, kernel arm64-gc.c mark_cstack_area.)
+
+;;; %%frame-backlink (one step toward the parent/older frame) is a
+;;; LEVEL-0 LAP primitive (level-0/ARM64/arm64-def.lisp:~300, promoted
+;;; 16m21).  Under the DECIDED cstack-walk design (Option A,
+;;; comms/ARM64-CSTACK-WALK-DECISION.md), the cstack is a HOMOGENEOUS
+;;; chain of 32-byte marker frames (nfp + stack-cons live on the TSP),
+;;; so the walk is a plain +32 stride — NOT the ARM32-twin heterogeneous
+;;; ivector-skip decode (Option B, explicitly not chosen).  It carries a
+;;; marker@0 rather than a stored backlink, unlike PPC's one-load
+;;; %%frame-backlink (ppc-def.lisp:227-230).
+
+(defun bottom-of-stack-p (p context)            ; ppc-threads-utils:87-92
+  (and (fixnump p)
+       (locally (declare (fixnum p))
+	 (let* ((tcr (if context (bt.tcr context) (%current-tcr)))
+                (cs-area (%fixnum-ref tcr target::tcr.cs-area)))
+	   (not (%ptr-in-area-p p cs-area))))))
+
+;;; Catch frames are misc-tagged temp-stack uvectors with a csp slot, as
+;;; on PPC (kernel: spentry-C-bind-catch-throw.s mkcatch); ppc:84 shape.
+(defun catch-frame-sp (catch)
+  (uvref catch target::catch-frame.csp-cell))
+
+;;; Sure would be nice to have &optional in defarm64lapfunction arglists
+;;; Sure would be nice not to do this at runtime.
+
+(let ((bits (lfun-bits #'(lambda (x &optional y) (declare (ignore x y))))))
+  (lfun-bits #'%fixnum-ref
+             (dpb (ldb $lfbits-numreq bits)
+                  $lfbits-numreq
+                  (dpb (ldb $lfbits-numopt bits)
+                       $lfbits-numopt
+                       (lfun-bits #'%fixnum-ref)))))
+
+(let ((bits (lfun-bits #'(lambda (x &optional y) (declare (ignore x y))))))
+  (lfun-bits #'%fixnum-ref-natural
+             (dpb (ldb $lfbits-numreq bits)
+                  $lfbits-numreq
+                  (dpb (ldb $lfbits-numopt bits)
+                       $lfbits-numopt
+                       (lfun-bits #'%fixnum-ref-natural)))))
+
+(let ((bits (lfun-bits #'(lambda (x y &optional z) (declare (ignore x y z))))))
+  (lfun-bits #'%fixnum-set
+             (dpb (ldb $lfbits-numreq bits)
+                  $lfbits-numreq
+                  (dpb (ldb $lfbits-numopt bits)
+                       $lfbits-numopt
+                       (lfun-bits #'%fixnum-set)))))
+
+(let ((bits (lfun-bits #'(lambda (x y &optional z) (declare (ignore x y z))))))
+  (lfun-bits #'%fixnum-set-natural
+             (dpb (ldb $lfbits-numreq bits)
+                  $lfbits-numreq
+                  (dpb (ldb $lfbits-numopt bits)
+                       $lfbits-numopt
+                       (lfun-bits #'%fixnum-set-natural)))))
+
+(defun valid-subtag-p (subtag)                  ; x86:115 (#+x8664-target)
+  (declare (fixnum subtag))
+  (let* ((tagval (logand arm64::fulltagmask subtag))
+         (high4 (ash subtag (- arm64::ntagbits))))
+    (declare (fixnum tagval high4))
+    (not (eq 'bogus
+             (case tagval
+               (#.arm64::fulltag-immheader-0
+                (%svref *immheader-0-types* high4))
+               (#.arm64::fulltag-immheader-1
+                (%svref *immheader-1-types* high4))
+               (#.arm64::fulltag-immheader-2
+                (%svref *immheader-2-types* high4))
+               (#.arm64::fulltag-nodeheader-0
+                (%svref *nodeheader-0-types* high4))
+               (#.arm64::fulltag-nodeheader-1
+                (%svref *nodeheader-1-types* high4))
+               (t 'bogus))))))
+
+(defun valid-header-p (thing)                   ; x86:144 (#+x8664-target)
+  (let* ((fulltag (fulltag thing)))
+    (declare (fixnum fulltag))
+    (case fulltag
+      ((#.arm64::fulltag-even-fixnum
+        #.arm64::fulltag-odd-fixnum
+        #.arm64::fulltag-single-float
+        #.arm64::fulltag-imm-0
+        #.arm64::fulltag-imm-1)
+       t)
+      ;; (fulltag-function removed, patch 0055: functions are ordinary
+      ;;  miscobjs and take the fulltag-misc clause below.)
+      (#.arm64::fulltag-symbol
+       (= arm64::subtag-symbol (typecode (%symptr->symvector thing))))
+      (#.arm64::fulltag-misc
+       (valid-subtag-p (typecode thing)))
+      ;; x8664's fulltag-tra-0/tra-1 clauses have no arm64 analog.
+      (#.arm64::fulltag-cons t)
+      (#.arm64::fulltag-nil (null thing))
+      (t nil))))
+
+(defun bogus-thing-p (x)                        ; x86:190 (#+x8664-target)
+  (when x
+    (or (not (valid-header-p x))
+        (let* ((tag (lisptag x)))
+          (unless (or (eql tag arm64::tag-fixnum)
+                      (eql tag arm64::tag-single-float)
+                      (eql tag arm64::tag-imm)
+                      (in-any-consing-area-p x)
+                      (temporary-cons-p x)
+                      (and (or (typep x 'function)
+                               (typep x 'gvector))
+                           (on-any-tsp-stack x))
+                      ;; x8664's tag-tra clause has no arm64 analog.
+                      (and (typep x 'ivector)
+                           (on-any-csp-stack x))
+                      (%heap-ivector-p x))
+            t)))))

--- a/level-1/arm64-trap-support.lisp
+++ b/level-1/arm64-trap-support.lisp
@@ -1,0 +1,500 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;; PPC64 LINE-PORT (source: vendor/ccl/level-1/ppc-trap-support.lisp,
+;;; #+ppc64-target + #+linuxppc-target branches, cited "; ppc:NNN").
+;;;
+;;; arm64-trap-support.lisp — XCMAIN (the nrs_CMAIN callback) and the
+;;; exception-context (xp) accessors for Matt Emerson's upstream ARM64
+;;; (low-tag) design, linuxarm64 only.
+;;;
+;;; Structural deviations from the PPC64 donor (each cited in place):
+;;;  - PPC conditional traps under-encode, so PPC's xcmain back-scans the
+;;;    code vector for the load that fed the trap (%scan-for-instr,
+;;;    match-instr).  ARM64 uuos (udf #imm16) are self-describing —
+;;;    format in imm16 bits 1:0, operand registers and info inline
+;;;    (arm64-uuo.s:16-65) — so the decode is a dispatch on the trap
+;;;    word and the scan machinery has no analog here.
+;;;  - The kernel routes to lisp cmain exactly: unary unbound, unary
+;;;    slot_unbound (which also forwards its uuo_extra_registers
+;;;    companion word as arg0), all binary infos 0-6, wrong_type, misc
+;;;    interrupt_now/too_few/too_many/wrong_number, and SIGBUS faults
+;;;    (upstream-port/lisp-kernel/arm64-exceptions.c handle_uuo,
+;;;    callback_for_trap).  Everything errnum-shaped goes to
+;;;    nrs_ERRDISP instead (see arm64-error-signal.lisp), as on PPC.
+;;;  - ucontext geometry is linux-aarch64 (arm64-headers64 interface db,
+;;;    ucontext.ffi: uc_mcontext at 176; mcontext = {fault_address@0,
+;;;    regs[31]@8, sp@256, pc@264, pstate@272}).
+;;;
+;;; Register-number convention: every register field here (uuo operand
+;;; fields, the kernel's fn-reg argument, handle-stack-overflow's rb)
+;;; uses the KERNEL/hardware GPR numbering 0-30, plus 31 = SP (the
+;;; kernel's Rsp selector, arm64-exceptions.c:112).  The arm64::
+;;; register constants x0-x30 and the lisp aliases (arm64::fn = 7,
+;;; arm64::arg_z = 11, ...) match that numbering, but arm64::sp is 32
+;;; (an index into the assembler's *registers* table, after xzr at 31)
+;;; — never pass arm64::sp to these accessors.
+
+(in-package "CCL")
+
+;; regs[0] within uc_mcontext (ucontext.ffi: mcontext regs @8); sp/pc/
+;; pstate follow the regs array contiguously, so they are reachable
+;; from the same base: sp = 256-8, pc = 264-8, pstate = 272-8.
+(defconstant xp-sp-offset-in-regs 248)
+(defconstant xp-pc-offset-in-regs 256)
+(defconstant xp-pstate-offset-in-regs 264)
+
+(eval-when (:compile-toplevel :execute)
+  ;; ppc:223-236.  registers = macptr to mcontext.regs[0].
+  (defmacro with-xp-registers-and-gpr-offset ((xp register-number)
+                                              (registers offset) &body body)
+    `(with-macptrs ((,registers (pref ,xp :ucontext_t.uc_mcontext.regs)))
+       (let ((,offset (xp-gpr-offset ,register-number)))
+         ,@body)))
+
+  ;; uuo field extractors, arm64-uuo.s:16-65 (mirrored by the C decode
+  ;; macros, arm64-exceptions.c:184-197).
+  (defmacro uuo-format (the-trap) `(ldb (byte 2 0) ,the-trap))
+  (defmacro uuo-unary-gpr (the-trap) `(ldb (byte 5 2) ,the-trap))
+  (defmacro uuo-unary-info (the-trap) `(ldb (byte 9 7) ,the-trap))
+  (defmacro uuo-binary-ra (the-trap) `(ldb (byte 5 2) ,the-trap))
+  (defmacro uuo-binary-rb (the-trap) `(ldb (byte 5 7) ,the-trap))
+  (defmacro uuo-binary-info (the-trap) `(ldb (byte 4 12) ,the-trap))
+  (defmacro uuo-misc-info (the-trap) `(ldb (byte 14 2) ,the-trap))
+  (defmacro uuo-wt-gpr (the-trap) `(ldb (byte 5 2) ,the-trap))
+  (defmacro uuo-wt-continuable (the-trap) `(ldb (byte 1 7) ,the-trap))
+  (defmacro uuo-wt-xtype (the-trap) `(ldb (byte 8 8) ,the-trap)))
+
+;;; ppc:268-276.  0-30 = x0-x30 in mcontext.regs; 31 = SP (kernel Rsp
+;;; selector), stored contiguously after the regs array.
+(defun xp-gpr-offset (register-number)
+  (unless (and (fixnump register-number)
+               (<= 0 (the fixnum register-number))
+               (< (the fixnum register-number) 32))
+    (setq register-number (require-type register-number '(integer 0 (32)))))
+  (the fixnum
+    (if (eql register-number 31)
+      xp-sp-offset-in-regs
+      (* (the fixnum register-number) target::node-size))))
+
+(defun xp-gpr-lisp (xp register-number)          ; ppc:280
+  (with-xp-registers-and-gpr-offset (xp register-number) (registers offset)
+    (values (%get-object registers offset))))
+
+(defun (setf xp-gpr-lisp) (value xp register-number) ; ppc:284
+  (with-xp-registers-and-gpr-offset (xp register-number) (registers offset)
+    (%set-object registers offset value)))
+
+(defun xp-gpr-signed-long (xp register-number)   ; ppc:288
+  (with-xp-registers-and-gpr-offset (xp register-number) (registers offset)
+    (values (%get-signed-long registers offset))))
+
+(defun xp-gpr-signed-doubleword (xp register-number) ; ppc:292
+  (with-xp-registers-and-gpr-offset (xp register-number) (registers offset)
+    (values (%%get-signed-longlong registers offset))))
+
+(defun xp-gpr-macptr (xp register-number)        ; ppc:297
+  (with-xp-registers-and-gpr-offset (xp register-number) (registers offset)
+    (values (%get-ptr registers offset))))
+
+;;; The saved PC is not a GPR on AArch64 (mcontext.pc, past the regs
+;;; array); PPC read/wrote it as regs[PT_NIP] (ppc:391-398).
+(defun xp-pc-lisp (xp)
+  (with-macptrs ((registers (pref xp :ucontext_t.uc_mcontext.regs)))
+    (values (%get-object registers xp-pc-offset-in-regs))))
+
+(defun (setf xp-pc-lisp) (value xp)
+  (with-macptrs ((registers (pref xp :ucontext_t.uc_mcontext.regs)))
+    (%set-object registers xp-pc-offset-in-regs value)))
+
+;;; NZCV lives in mcontext.pstate bits 31-28 (C = bit 29).  The ARM32
+;;; port reads CPSR the same way to sign a failed nargs compare
+;;; (arm-error-signal.lisp:216-220).
+(defun xp-pstate (xp)
+  (with-macptrs ((registers (pref xp :ucontext_t.uc_mcontext.regs)))
+    (values (%%get-unsigned-longlong registers xp-pstate-offset-in-regs))))
+
+;;; ppc:301-315, register names remapped (nargs is fixnum-tagged here
+;;; too — arm64-asm.lisp:185).
+(defun xp-argument-list (xp)
+  (let ((nargs (xp-gpr-lisp xp arm64::nargs))
+        (arg-x (xp-gpr-lisp xp arm64::arg_x))
+        (arg-y (xp-gpr-lisp xp arm64::arg_y))
+        (arg-z (xp-gpr-lisp xp arm64::arg_z)))
+    (cond ((eql nargs 0) nil)
+          ((eql nargs 1) (list arg-z))
+          ((eql nargs 2) (list arg-y arg-z))
+          (t (let ((args (list arg-x arg-y arg-z)))
+               (if (eql nargs 3)
+                 args
+                 (let ((vsp (xp-gpr-macptr xp arm64::vsp)))
+                   (dotimes (i (- nargs 3))
+                     (push (%get-object vsp (* i target::node-size)) args))
+                   args)))))))
+
+;;; ppc:371-380.  machine-state-offset is relative to mcontext.regs[0].
+;;; Codevector is function slot 0, as on PPC64 (kernel ground truth:
+;;; spentry-D-call-builtins.s _function.codevector).
+(defconstant lr-offset-in-register-context (* 30 target::node-size)) ;x30
+(defconstant pc-offset-in-register-context xp-pc-offset-in-regs)
+
+(defun return-address-offset (xp fn machine-state-offset)
+  (with-macptrs ((regs (pref xp :ucontext_t.uc_mcontext.regs)))
+    (if (functionp fn)
+      ;; Since the fulltag-function removal (patch 0055) a function IS
+      ;; its misc-tagged uvector (PPC64 shape); the
+      ;; %function-to-function-vector below is identity-with-typecheck.
+      (or (%code-vector-pc (uvref (%function-to-function-vector fn) 0)
+                           (%inc-ptr regs machine-state-offset))
+          (%get-ptr regs machine-state-offset))
+      (%get-ptr regs machine-state-offset))))
+
+;;; ppc:400-459 — verbatim shape (fake-stack-frame istructs chained
+;;; through *fake-stack-frames*, the PPC model; the ARM32 gvector/
+;;; %dnode-address-of model needs LAP with no donor here).  See the
+;;; case analysis at ppc:400-418.
+;;; *fake-stack-frames*'s def-standard-initial-binding lives in
+;;; lib/arm64-backtrace.lisp, mirroring lib/ppc-backtrace.lisp:33; that
+;;; file loads (l1-boot-2 bin set) before cmain is armed (l1-boot-3).
+(defvar *fake-stack-frames*)
+
+(defun funcall-with-xp-stack-frames (xp trap-function thunk)
+  (cond ((null trap-function)
+         ;; Maybe inside a subprim from a lisp function
+         (let* ((fn (xp-gpr-lisp xp arm64::fn))
+                (lr (return-address-offset
+                     xp fn lr-offset-in-register-context)))
+           (if (fixnump lr)
+             (let* ((sp (xp-gpr-lisp xp 31)) ;SP, kernel Rsp numbering
+                    (vsp (xp-gpr-lisp xp arm64::vsp))
+                    (frame (%cons-fake-stack-frame sp sp fn lr vsp xp *fake-stack-frames*))
+                    (*fake-stack-frames* frame))
+               (declare (dynamic-extent frame))
+               (funcall thunk frame))
+             (funcall thunk (xp-gpr-lisp xp 31)))))
+        ((eq trap-function (xp-gpr-lisp xp arm64::fn))
+         (let* ((sp (xp-gpr-lisp xp 31))
+                (fn trap-function)
+                (lr (return-address-offset
+                     xp fn pc-offset-in-register-context))
+                (vsp (xp-gpr-lisp xp arm64::vsp))
+                (frame (%cons-fake-stack-frame sp sp fn lr vsp xp *fake-stack-frames*))
+                (*fake-stack-frames* frame))
+           (declare (dynamic-extent frame))
+           (funcall thunk frame)))
+        ((eq trap-function (xp-gpr-lisp xp arm64::nfn))
+         (let* ((sp (xp-gpr-lisp xp 31))
+                (fn (xp-gpr-lisp xp arm64::fn))
+                (lr (return-address-offset
+                     xp fn lr-offset-in-register-context))
+                (vsp (xp-gpr-lisp xp arm64::vsp))
+                (lr-frame (%cons-fake-stack-frame sp sp fn lr vsp xp))
+                (pc-fn trap-function)
+                (pc-lr (return-address-offset
+                        xp pc-fn pc-offset-in-register-context))
+                (pc-frame (%cons-fake-stack-frame sp lr-frame pc-fn pc-lr vsp xp *fake-stack-frames*))
+                (*fake-stack-frames* pc-frame))
+           (declare (dynamic-extent lr-frame pc-frame))
+           (funcall thunk pc-frame)))
+        (t (funcall thunk (xp-gpr-lisp xp 31)))))
+
+;;; xtype code -> type specifier, indexed by the wrong_type uuo's 8-bit
+;;; expected-type field.  Donor: arm-error-signal.lisp:18-85 (the ARM32
+;;; twin of this table — PPC decodes types from trap immediates
+;;; instead), 64-bit entries adjusted; arm64-arch.lisp:195-230 declares
+;;; these codes "used in *arm64-xtype-specifiers*".
+(defparameter *arm64-xtype-specifiers* (make-array 256 :initial-element nil))
+
+(macrolet ((init-arm64-xtype-table (&rest pairs)
+             (let* ((table (gensym)))
+               (collect ((body))
+                 (dolist (pair pairs)
+                   (destructuring-bind (code . spec) pair
+                     (body `(setf (svref ,table ,code) ',spec))))
+                 `(let* ((,table *arm64-xtype-specifiers*))
+                    ,@(body))))))
+  (init-arm64-xtype-table
+   (arm64::tag-fixnum . fixnum)
+   (arm64::tag-list . list)
+   (arm64::xtype-integer . integer)
+   (arm64::xtype-s64 . (signed-byte 64))
+   (arm64::xtype-u64 . (unsigned-byte 64))
+   (arm64::xtype-s32 . (signed-byte 32))
+   (arm64::xtype-u32 . (unsigned-byte 32))
+   (arm64::xtype-s16 . (signed-byte 16))
+   (arm64::xtype-u16 . (unsigned-byte 16))
+   (arm64::xtype-s8  . (signed-byte 8))
+   (arm64::xtype-u8  . (unsigned-byte 8))
+   (arm64::xtype-bit . bit)
+   (arm64::xtype-rational . rational)
+   (arm64::xtype-real . real)
+   (arm64::xtype-number . number)
+   (arm64::xtype-cons . cons)
+   (arm64::xtype-char-code . (mod #x110000))
+   (arm64::xtype-unsigned-byte-24 . (unsigned-byte 24))
+   (arm64::xtype-array2d . (array * (* *)))
+   (arm64::xtype-array3d . (array * (* * *)))
+   (arm64::xtype-null . null)
+   (arm64::subtag-character . character)
+   (arm64::subtag-bignum . bignum)
+   (arm64::subtag-ratio . ratio)
+   (arm64::subtag-single-float . single-float)
+   (arm64::subtag-double-float . double-float)
+   (arm64::subtag-complex . complex)
+   (arm64::subtag-macptr . macptr)
+   (arm64::subtag-code-vector . code-vector)
+   (arm64::subtag-xcode-vector . xcode-vector)
+   (arm64::subtag-catch-frame . catch-frame)
+   (arm64::subtag-function . function)
+   (arm64::subtag-basic-stream . basic-stream)
+   (arm64::subtag-symbol . symbol)
+   (arm64::subtag-lock . lock)
+   (arm64::subtag-hash-vector . hash-vector)
+   (arm64::subtag-pool . pool)
+   (arm64::subtag-weak . population)
+   (arm64::subtag-package . package)
+   (arm64::subtag-slot-vector . slot-vector)
+   (arm64::subtag-instance . standard-object)
+   (arm64::subtag-struct . structure-object)
+   (arm64::subtag-istruct . istruct)
+   (arm64::subtag-value-cell . value-cell)
+   (arm64::subtag-xfunction . xfunction)
+   (arm64::subtag-arrayH . array-header)
+   (arm64::subtag-vectorH . vector-header)
+   (arm64::subtag-simple-vector . simple-vector)
+   (arm64::subtag-single-float-vector . (simple-array single-float (*)))
+   (arm64::subtag-u64-vector . (simple-array (unsigned-byte 64) (*)))
+   (arm64::subtag-s64-vector . (simple-array (signed-byte 64) (*)))
+   (arm64::subtag-u32-vector . (simple-array (unsigned-byte 32) (*)))
+   (arm64::subtag-s32-vector . (simple-array (signed-byte 32) (*)))
+   (arm64::subtag-fixnum-vector . (simple-array fixnum (*)))
+   (arm64::subtag-simple-base-string . simple-base-string)
+   (arm64::subtag-u16-vector . (simple-array (unsigned-byte 16) (*)))
+   (arm64::subtag-s16-vector . (simple-array (signed-byte 16) (*)))
+   (arm64::subtag-u8-vector . (simple-array (unsigned-byte 8) (*)))
+   (arm64::subtag-s8-vector . (simple-array (signed-byte 8) (*)))
+   (arm64::subtag-double-float-vector . (simple-array double-float (*)))
+   (arm64::subtag-bit-vector . simple-bit-vector)
+   (arm64::subtag-complex-single-float-vector . (simple-array (complex single-float) (*)))
+   (arm64::subtag-complex-double-float-vector . (simple-array (complex double-float) (*)))
+   ;; 16m40: the SCALAR complex floats.  The two *-vector entries above were
+   ;; here but not these, so trap-unless-complex-single-float /
+   ;; -complex-double-float would have reported a raw integer code instead of
+   ;; a type -- (or typespec xtype) below falls back to the number.
+   (arm64::subtag-complex-single-float . (complex single-float))
+   (arm64::subtag-complex-double-float . (complex double-float))
+   ;; 16m40: bare FULLTAGS.  arm64-arch.lisp:189-196 states the expected-type
+   ;; field holds "either a lisptag, a fulltag, a uvector subtag byte, or an
+   ;; xtype code" in ONE 256-entry namespace, and tag-fixnum/tag-list above
+   ;; are the lisptag half of that.  These are the fulltag half, needed by the
+   ;; trap-unless-fulltag= sites.  No collision: fulltags are 0-15 and every
+   ;; xtype is >= #x10 by that file's own compile-time assert.
+   ;; (fulltag-function removed, patch 0055: function checks are
+   ;; typecode-based and report via the subtag-function row above.)
+   (arm64::fulltag-symbol . symbol)
+   (arm64::fulltag-nil . null)))
+
+;;; Enter here from the kernel's callback_for_trap
+;;; (arm64-exceptions.c:1695-1714; the PPC comment block at ppc:463-475
+;;; describes the same contract): xp is the exception context; fn-reg
+;;; is arm64::fn, arm64::nfn or 0 depending on whose code vector holds
+;;; the PC; pc-or-index is the instruction index into that code vector,
+;;; or the raw PC when fn-reg is 0; the-trap is the raw udf instruction
+;;; word (equal to its low-16 immediate), or a signal number for memory
+;;; faults; arg0/arg1 are per-trap extras (SIGBUS: fault address and
+;;; write-flag).
+;;;
+;;; #$SIGBUS (7) can in principle collide with udf #7 = wrong_type
+;;; reg=x1 xtype=0; x1 is imm1, an unboxed scratch register no type
+;;; check ever encodes, so the SIGBUS test may safely come first (PPC
+;;; had no such overlap because trap words carry opcode bits,
+;;; ppc:750).
+(defcallback xcmain (:without-interrupts t
+                     :address xp
+                     :unsigned-fullword fn-reg
+                     :address pc-or-index
+                     :unsigned-fullword the-trap
+                     :signed-doubleword arg0
+                     :signed-doubleword arg1)
+  (let ((fn (unless (eql fn-reg 0) (xp-gpr-lisp xp fn-reg))))
+    (with-xp-stack-frames (xp fn frame-ptr)
+      ;; udf #16 = uuo_misc interrupt_now: periodic event polling, the
+      ;; common case, tested first (ppc:719-725 tdgti nargs 0).  The
+      ;; kernel synthesizes the same word for a deferred process
+      ;; interrupt (arm64-exceptions.c:232/1262).
+      (if (eql the-trap #x10)
+        (cmain)
+        (with-error-reentry-detection
+          (let ((pc-index (if (eql fn-reg 0) pc-or-index (%ptr-to-int pc-or-index))))
+            (cond
+              ((eql the-trap #$SIGBUS)  ; ppc:750-755
+               (%error (make-condition 'invalid-memory-access
+                                       :address arg0
+                                       :write-p (not (zerop arg1)))
+                       ()
+                       frame-ptr))
+              ;; unary unbound: gpr holds the SYMBOL (handler contract,
+              ;; arm64-exceptions.c uuo_unary_unbound; the emit sites are
+              ;; spentry-A specrefcheck and spentry-C's binding path).
+              ;; PPC continues from this trap by writing the restart's
+              ;; value over the register that held the unbound marker
+              ;; (ppc:905-915); the ARM64 uuo encodes only the symbol
+              ;; register, so the value cannot be delivered to the
+              ;; resume site — signal the standard unbound-variable
+              ;; error, but refuse to continue if a restart returns.
+              ;; RATIFY: continuing needs a following uuo_extra_registers
+              ;; (binary info 7) naming the value register at both emit
+              ;; sites, plus a handler-side PC adjustment.
+              ((and (eql (uuo-format the-trap) 1)  ;uuo_format_unary
+                    (eql (uuo-unary-info the-trap) 2)) ;unary_info_unbound
+               (%kernel-restart-internal
+                $xvunbnd
+                (list (xp-gpr-lisp xp (uuo-unary-gpr the-trap)))
+                frame-ptr)
+               (%error "Can't continue from an unbound-variable trap on ARM64 (the resume site's value register is not encoded in the trap)."
+                       nil frame-ptr))
+              ;; unary slot_unbound (patch 0052 assigns the code): a
+              ;; THREE-register error, so the primary uuo names only the
+              ;; SLOT VECTOR and the kernel hands us its
+              ;; uuo_extra_registers companion in arg0 -- ra = index,
+              ;; rb = dest (doc/porting/arm64.md "Errors that need three
+              ;; registers"; the kernel validated the companion and will
+              ;; resume past BOTH words).
+              ;;
+              ;; Unlike the unbound-variable trap above, this one really
+              ;; does continue: CL's SLOT-UNBOUND may RETURN a value,
+              ;; which becomes the value of the slot reference, so store
+              ;; it into dest.  Same contract as ARM32's
+              ;; (uuo-error-slot-unbound dest instance index),
+              ;; arm-error-signal.lisp:257-263 -- including its reset of
+              ;; the reentry count, because a handler that returns makes
+              ;; this a NORMAL occurrence that must not accumulate
+              ;; toward the error-reentry guard.
+              ((and (eql (uuo-format the-trap) 1)   ;uuo_format_unary
+                    (eql (uuo-unary-info the-trap) 6)) ;unary_info_slot_unbound
+               (let ((slotv (xp-gpr-lisp xp (uuo-unary-gpr the-trap)))
+                     (index (xp-gpr-lisp xp (uuo-binary-ra arg0)))
+                     (dest  (uuo-binary-rb arg0)))
+                 (setq *error-reentry-count* 0)
+                 (setf (xp-gpr-lisp xp dest)
+                       (%slot-unbound-trap slotv index frame-ptr))))
+              ((eql (uuo-format the-trap) 2)       ;uuo_format_binary
+               (let* ((info (uuo-binary-info the-trap))
+                      (ra (uuo-binary-ra the-trap))
+                      (rb (uuo-binary-rb the-trap)))
+                 (case info
+                   ((0 1)  ; vector/array bounds: ra = index, rb = the
+                           ; vector (convention: uuo_error_vector_bounds
+                           ; emit sites; ppc:653-665 reports (index vector))
+                    (%error (%rsc-string $xarroob)
+                            (list (xp-gpr-lisp xp ra)
+                                  (xp-gpr-lisp xp rb))
+                            frame-ptr))
+                   (2      ; integer divide by zero (no emitter yet —
+                           ; level-0 calls divide-by-zero-error directly)
+                    (%error (make-condition 'division-by-zero
+                                            :operation 'truncate
+                                            :operands (list (xp-gpr-lisp xp ra)
+                                                            (xp-gpr-lisp xp rb)))
+                            nil frame-ptr))
+                   (3      ; eep/fv unresolved: ra = destination reg,
+                           ; rb = the eep or foreign-variable object
+                           ; (arm-error-signal.lisp:274-285 twin;
+                           ; ppc:730-749 resolves and stores the address)
+                    (let* ((eep-or-fv (xp-gpr-lisp xp rb)))
+                      (etypecase eep-or-fv
+                        (external-entry-point
+                         (resolve-eep eep-or-fv)
+                         (setf (xp-gpr-lisp xp ra)
+                               (eep.address eep-or-fv)))
+                        (foreign-variable
+                         (resolve-foreign-variable eep-or-fv)
+                         (setf (xp-gpr-lisp xp ra)
+                               (fv.addr eep-or-fv))))))
+                   (4      ; fpu exception.  No emitter yet; AArch64 FP
+                           ; exceptions are untrapped (handle_sigfpe) —
+                           ; RATIFY operand decode when an emitter lands.
+                    (%error "FPU exception (uuo #x~x, registers ~d/~d: #x~x #x~x)"
+                            (list the-trap ra rb
+                                  (xp-gpr-signed-doubleword xp ra)
+                                  (xp-gpr-signed-doubleword xp rb))
+                            frame-ptr))
+                   (5      ; array rank: ra = expected rank (fixnum),
+                           ; rb = the array (ppc:666-677 reports
+                           ; (array rank); convention fixed here — no
+                           ; emitter yet)
+                    (%err-disp-internal $xndims
+                                        (list (xp-gpr-lisp xp rb)
+                                              (xp-gpr-lisp xp ra))
+                                        frame-ptr))
+                   (6      ; array flags: ra = the flags value seen,
+                           ; rb = the (purported) array header
+                           ; (arm-error-signal.lisp:304-323 twin)
+                    (let* ((array (xp-gpr-lisp xp rb))
+                           (flags (xp-gpr-lisp xp ra))
+                           (subtag (ldb target::arrayH.flags-cell-subtag-byte flags))
+                           (element-type
+                            (type-specifier
+                             (array-ctype-element-type
+                              (specifier-type (svref *arm64-xtype-specifiers* subtag))))))
+                      (%error (make-condition
+                               'type-error
+                               :datum array
+                               :expected-type `(,(if (logbitp $arh_simple_bit flags) 'simple-array 'array) ,element-type))
+                              nil
+                              frame-ptr)))
+                   (t      ; 7 = two_registers extends a preceding uuo and
+                           ; never faults alone (kernel refuses it)
+                    (%error "Unknown binary trap: #x~x~%xp: ~s, fn: ~s, pc: #x~x"
+                            (list the-trap xp fn pc-index)
+                            frame-ptr)))))
+              ((eql (uuo-format the-trap) 3)       ;uuo_format_wrong_type
+               (let* ((regno (uuo-wt-gpr the-trap))
+                      (datum (xp-gpr-lisp xp regno))
+                      (xtype (uuo-wt-xtype the-trap))
+                      (typespec (or (svref *arm64-xtype-specifiers* xtype)
+                                    xtype)))
+                 (if (eql (uuo-wt-continuable the-trap) 1)
+                   ;; continuable: store the restart's value back into
+                   ;; the trapping register and resume past the udf
+                   ;; (arm64-uuo.s:57-63; ppc:27/105's err-fn +
+                   ;; register-munge idiom)
+                   (setf (xp-gpr-lisp xp regno)
+                         (%kernel-restart-internal $xwrongtype
+                                                   (list datum typespec)
+                                                   frame-ptr))
+                   (%error (make-condition 'type-error
+                                           :datum datum
+                                           :expected-type typespec)
+                           nil
+                           frame-ptr))))
+              ((eql (uuo-format the-trap) 0)       ;uuo_format_misc
+               (let* ((info (uuo-misc-info the-trap))
+                      (nargs (xp-gpr-lisp xp arm64::nargs)))
+                 (case info
+                   (6                    ;uuo_too_few_args
+                    (%error 'too-few-arguments
+                            (list :nargs nargs :fn fn)
+                            frame-ptr))
+                   (7                    ;uuo_too_many_args
+                    (%error 'too-many-arguments
+                            (list :nargs nargs :fn fn)
+                            frame-ptr))
+                   (8                    ;uuo_wrong_number_of_args
+                    ;; The emit site compares nargs against the exact
+                    ;; required count and branches around the udf on
+                    ;; equality, so NZCV still holds that compare: C set
+                    ;; (and Z clear) = nargs above the requirement.  The
+                    ;; ARM32 port signs its nargs trap from CPSR the
+                    ;; same way (arm-error-signal.lisp:216-220).
+                    (%error (if (logbitp 29 (xp-pstate xp))
+                              'too-many-arguments
+                              'too-few-arguments)
+                            (list :nargs nargs :fn fn)
+                            frame-ptr))
+                   (t
+                    (%error "Unknown misc trap: #x~x~%xp: ~s, fn: ~s, pc: #x~x"
+                            (list the-trap xp fn pc-index)
+                            frame-ptr)))))
+              ;; Unknown trap (ppc:706-709)
+              (t (%error "Unknown trap: #x~x~%xp: ~s, fn: ~s, pc: #x~x"
+                         (list the-trap xp fn pc-index)
+                         frame-ptr)))))))))

--- a/lib/arm64-backtrace.lisp
+++ b/lib/arm64-backtrace.lisp
@@ -1,0 +1,271 @@
+;;; -*- Mode: Lisp; Package: CCL -*-
+;;; PPC64 LINE-PORT (source: vendor/ccl/lib/ppc-backtrace.lisp, cited
+;;; "; ppc:NNN"; scope per lib/arm-backtrace.lisp — see below).
+;;;
+;;; arm64-backtrace.lisp — arch-side backtrace support (the CFP-LFUN
+;;; cluster) for Matt Emerson's upstream ARM64 (low-tag) design.
+;;;
+;;; Model: PPC fake-stack-frames (heap istructs chained through
+;;; *fake-stack-frames*, built by arm64-trap-support's
+;;; funcall-with-xp-stack-frames) walking ARM32-style MARKER lisp
+;;; frames (kernel ground truth: arm64-gc.c mark_cstack_area — frames
+;;; are {marker@0, savevsp@8, savefn@16, savelr@24} identified by
+;;; lisp-frame-marker, NOT chained through a stored backlink as on
+;;; PPC).
+;;;
+;;; Scope follows the shipped ARM32 port (lib/arm-backtrace.lisp): the
+;;; saved-register machinery (registers-used-by encodings, srv vectors,
+;;; frame-restartable-p, %apply-in-frame and its PPC-instruction
+;;; branch-tree parser, ppc:379-736) has no analog because this design
+;;; keeps NO non-volatile lisp registers (lib/arm64env.lisp R1:
+;;; empty save pool) — the compiler can never record a saved-register
+;;; variable location.  APPLY-IN-FRAME is therefore unimplemented, as
+;;; on ARM32.  LATENT: revisit if save0-3 ever enter the register
+;;; pool.
+;;;
+;;; %frame-backlink and lisp-frame-p live HERE, not in
+;;; arm64-threads-utils.lisp as on PPC: they need the
+;;; fake-stack-frame accessor macros at compile time, and the cross
+;;; gate compiles each file in an x86 host image that only has this
+;;; file's macros once they are defined in the same compile unit.
+
+(in-package "CCL")
+
+;;; ppc:20-29.  Slot order is pinned by %cons-fake-stack-frame
+;;; (library/lispequ.lisp:211).
+(def-accessors (fake-stack-frame) %svref
+  nil                           ; 'fake-stack-frame
+  %fake-stack-frame.sp          ; fixnum. The stack pointer where this frame "should" be
+  %fake-stack-frame.next-sp     ; Either sp or another fake-stack-frame
+  %fake-stack-frame.fn          ; The current function
+  %fake-stack-frame.lr          ; fixnum offset from fn (nil if fn is not functionp)
+  %fake-stack-frame.vsp         ; The value stack pointer
+  %fake-stack-frame.xp          ; Exception frame.
+  %fake-stack-frame.link        ; next in *fake-stack-frames* list
+  )
+
+;;; Linked list of fake stack frames.
+;;; %frame-backlink looks here (ppc:31-33).
+(def-standard-initial-binding *fake-stack-frames* nil)
+
+(defun fake-stack-frame-p (x)   ; ppc:36
+  (istruct-typep x 'fake-stack-frame))
+
+;;; ppc-threads-utils.lisp:67-79 (see placement note in the header).
+(defun %frame-backlink (p &optional context)
+  (cond ((fake-stack-frame-p p)
+         (%fake-stack-frame.next-sp p))
+        ((fixnump p)
+         (let ((backlink (%%frame-backlink p))
+               (fake-frame
+                (if context (bt.fake-frames context) *fake-stack-frames*)))
+           (loop
+             (when (null fake-frame) (return backlink))
+             (when (eq backlink (%fake-stack-frame.sp fake-frame))
+               (return fake-frame))
+             (setq fake-frame (%fake-stack-frame.link fake-frame)))))
+        (t (error "~s is not a valid stack frame" p))))
+
+;;; arm-threads-utils.lisp:61-65 shape (marker frames); PPC instead
+;;; validates frame size + savefn because its frames carry no marker.
+(defun lisp-frame-p (p context)
+  (if (fake-stack-frame-p p)
+    (values t nil)
+    (if (bottom-of-stack-p p context)
+      (values nil t)
+      (values (eql (%fixnum-ref-natural p) arm64::lisp-frame-marker)
+              nil))))
+
+(defun cfp-lfun (p)             ; ppc:39-47
+  (if (fake-stack-frame-p p)
+    (let* ((fn (%fake-stack-frame.fn p))
+           (lr (%fake-stack-frame.lr p)))
+      (if (and (typep fn 'function)
+               (typep lr 'fixnum))
+        (values fn lr)
+        (values nil nil)))
+    (%cfp-lfun p)))
+
+(defun %stack< (index1 index2 &optional context) ; ppc:50-64
+  (cond ((fake-stack-frame-p index1)
+         (let ((sp1 (%fake-stack-frame.sp index1)))
+           (declare (fixnum sp1))
+           (if (fake-stack-frame-p index2)
+             (or (%stack< sp1 (%fake-stack-frame.sp index2) context)
+                 (eq index2 (%fake-stack-frame.next-sp index1)))
+             (%stack< sp1 (%i+ index2 1) context))))
+        ((fake-stack-frame-p index2)
+         (%stack< index1 (%fake-stack-frame.sp index2) context))
+        (t (let* ((tcr (if context (bt.tcr context) (%current-tcr)))
+                  (cs-area (%fixnum-ref tcr target::tcr.cs-area)))
+             (and (%ptr-in-area-p index1 cs-area)
+                  (%ptr-in-area-p index2 cs-area)
+                  (< (the fixnum index1) (the fixnum index2)))))))
+
+;;; No non-volatile lisp registers in this design (header note), so no
+;;; register-save encoding exists to decode — the ARM32 answer
+;;; (arm-backtrace.lisp:49-51), not PPC's LWZ-trailer scheme
+;;; (ppc:101-134).
+(defun registers-used-by (lfun &optional at-pc)
+  (declare (ignore lfun at-pc))
+  (values nil nil))
+
+(defun %frame-savefn (p)        ; ppc:153-156
+  (if (fake-stack-frame-p p)
+    (%fake-stack-frame.fn p)
+    (%%frame-savefn p)))
+
+(defun %frame-savevsp (p)       ; ppc:158-161
+  (if (fake-stack-frame-p p)
+    (%fake-stack-frame.vsp p)
+    (%%frame-savevsp p)))
+
+(defun frame-vsp (frame)        ; ppc:163-164
+  (%frame-savevsp frame))
+
+;;; Return two values: the vsp of p and the vsp of p's "parent" frame.
+;;; The "parent" frame vsp might actually be the end of p's segment,
+;;; if the real "parent" frame vsp is in another segment.
+(defun vsp-limits (p context)   ; ppc:169-200
+  (let* ((vsp (%frame-savevsp p))
+         parent)
+    (when (eql vsp 0)
+      ;; This frame is where the code continues after an unwind-protect cleanup form
+      (setq vsp (%frame-savevsp (child-frame p context))))
+    (flet ((grand-parent (frame)
+             (let ((parent (parent-frame frame context)))
+               (when (and parent (eq parent (%frame-backlink frame context)))
+                 (let ((grand-parent (parent-frame parent context)))
+                   (when (and grand-parent (eq grand-parent (%frame-backlink parent context)))
+                     grand-parent))))))
+      (declare (dynamic-extent #'grand-parent))
+      (let* ((frame p)
+             grand-parent)
+        (loop
+          (setq grand-parent (grand-parent frame))
+          (when (or (null grand-parent) (not (eql 0 (%frame-savevsp grand-parent))))
+            (return))
+          (setq frame grand-parent))
+        (setq parent (parent-frame frame context)))
+      (let* ((parent-vsp (if parent (%frame-savevsp parent) vsp))
+             (tcr (if context (bt.tcr context) (%current-tcr)))
+             (vsp-area (%fixnum-ref tcr target::tcr.vs-area)))
+        (if (eql 0 parent-vsp)
+          (values vsp vsp)              ; p is the kernel frame pushed by an unwind-protect cleanup form
+          (progn
+            (unless vsp-area
+              (error "~s is not a stack frame pointer for context ~s" p tcr))
+            (unless (%ptr-in-area-p parent-vsp vsp-area)
+              (setq parent-vsp (%fixnum-ref vsp-area target::area.high)))
+            (values vsp parent-vsp)))))))
+
+(defun catch-csp-p (p context)  ; ppc:203-212
+  (let ((catch (if context
+                 (bt.top-catch context)
+                 (%catch-top (%current-tcr)))))
+    (loop
+      (when (null catch) (return nil))
+      (let ((sp (catch-frame-sp catch)))
+        (when (eql sp p)
+          (return t)))
+      (setq catch (next-catch catch)))))
+
+(defun last-catch-since (sp context) ; ppc:214-223
+  (let* ((tcr (if context (bt.tcr context) (%current-tcr)))
+         (catch (%catch-top tcr))
+         (last-catch nil))
+    (loop
+      (unless catch (return last-catch))
+      (let ((csp (uvref catch target::catch-frame.csp-cell)))
+        (when (%stack< sp csp context) (return last-catch))
+        (setq last-catch catch
+              catch (next-catch catch))))))
+
+;;; With no saved registers (see registers-used-by) the compiler never
+;;; records a saved-register variable location, so these are
+;;; unreachable — the ARM32 answer (arm-backtrace.lisp:131-139).
+(defun %find-register-argument-value (context cfp regval bad)
+  (declare (ignore context cfp regval))
+  bad)
+
+(defun %set-register-argument-value (context cfp regval new)
+  (declare (ignore context cfp regval))
+  new)
+
+(defun %raw-frame-ref (cfp context idx bad) ; ppc:276-297
+  (declare (fixnum idx))
+  (multiple-value-bind (frame base)
+      (vsp-limits cfp context)
+    (let* ((raw-size (- base frame)))
+      (declare (fixnum frame base raw-size))
+      (if (and (>= idx 0)
+               (< idx raw-size))
+        (let* ((addr (- (the fixnum (1- base))
+                        idx)))
+          (multiple-value-bind (db-count first-db last-db)
+              (count-db-links-in-frame frame base context)
+            (let* ((is-db-link
+                    (unless (zerop db-count)
+                      (do* ((last last-db (previous-db-link last first-db)))
+                           ((null last))
+                        (when (= addr last)
+                          (return t))))))
+              (if is-db-link
+                (oldest-binding-frame-value context addr)
+                (%fixnum-ref addr)))))
+        bad))))
+
+(defun %raw-frame-set (cfp context idx new) ; ppc:299-320
+  (declare (fixnum idx))
+  (multiple-value-bind (frame base)
+      (vsp-limits cfp context)
+    (let* ((raw-size (- base frame)))
+      (declare (fixnum frame base raw-size))
+      (if (and (>= idx 0)
+               (< idx raw-size))
+        (let* ((addr (- (the fixnum (1- base))
+                        idx)))
+          (multiple-value-bind (db-count first-db last-db)
+              (count-db-links-in-frame frame base context)
+            (let* ((is-db-link
+                    (unless (zerop db-count)
+                      (do* ((last last-db (previous-db-link last first-db)))
+                           ((null last))
+                        (when (= addr last)
+                          (return t))))))
+              (if is-db-link
+                (setf (oldest-binding-frame-value context addr) new)
+                (setf (%fixnum-ref addr) new))))
+          t)))))
+
+;;; Used for printing only (ppc:322-326).
+(defun index->address (p)
+  (when (fake-stack-frame-p p)
+    (setq p (%fake-stack-frame.sp p)))
+  (ldb (byte 64 0) (ash p target::fixnumshift)))
+
+(defun match-local-name (cellno info pc) ; ppc:329-338
+  (when info
+    (let* ((syms (%car info))
+           (ptrs (%cdr info)))
+      (dotimes (i (length syms))
+        (let ((j (%i+ i (%i+ i i))))
+          (and (eq (uvref ptrs j) (%ilogior (%ilsl (+ 6 target::word-shift) cellno) #o77))
+               (%i>= pc (uvref ptrs (%i+ j 1)))
+               (%i< pc (uvref ptrs (%i+ j 2)))
+               (return (aref syms i))))))))
+
+(defun exception-frame-p (frame) ; ppc:877
+  (fake-stack-frame-p frame))
+
+(defun arg-check-call-arguments (frame function) ; ppc:880-882
+  (declare (ignore function))
+  (xp-argument-list (%fake-stack-frame.xp frame)))
+
+;;; arm-backtrace.lisp:173-178 (see the scope note in the header).
+(defun apply-in-frame (frame function arglist &optional context)
+  (declare (ignore frame function arglist context))
+  (error "APPLY-IN-FRAME isn't implemented on ARM64."))
+
+(defun return-from-frame (frame &rest values)
+  (apply-in-frame frame #'values values nil))

--- a/lib/arm64-callback-frame-constants.lisp
+++ b/lib/arm64-callback-frame-constants.lisp
@@ -1,0 +1,48 @@
+;;; SPDX-License-Identifier: Apache-2.0
+;;;
+;;; PROPOSED — callback-frame contract constants (FFI lane, msg-28 item).
+;;;
+;;; ⚠ These describe OUR spentry-E callback trampoline's frame layout,
+;;; NOT anything in Matt's tree: he has no callback design yet
+;;; (msg-18/19 — "FF-calls not thought about").  They exist so that
+;;; lib/ffi-linuxarm64.lisp generate-callback-bindings compiles in the
+;;; level-1 gate (l1-lisp-threads defcallback splices
+;;; callback-frame.savelr-offset / callback-frame.fp-save-offset at
+;;; macroexpansion time).  When Matt specs his callback trampoline,
+;;; these constants MUST travel with it — re-derive or ratify then;
+;;; do not treat these values as upstream-agreed.
+;;;
+;;; The contract (CBF = &x0save, 16-aligned; verified against THREE
+;;; agreeing sources, 2026-07-16):
+;;;   1. lib/ffi-linuxarm64.lisp section (3) header: "x0..x7 saves at
+;;;      +0..56, the C caller's stack args CONTIGUOUS at +64, d0..d7
+;;;      saves at -64..-8, saved LR at -152".
+;;;   2. v2 arch constants (compiler/ARM64/arm64-arch.lisp:1047-1049):
+;;;      fp-save-offset -64, savelr-offset -152, stack-args-offset 64.
+;;;   3. The actual push sequence in BOTH trampolines:
+;;;      v2 kernel lisp-kernel/arm64-spentry.s:4464-4490 (boot-validated
+;;;      s89) and our low-tag draft upstream-port/lisp-kernel/
+;;;      spentry-E-ffi.s:404-427 — x0..x7 pushed (CBF = sp), then
+;;;      d0..d7 (d0 @ CBF-64), then callee-saved GPR pairs
+;;;      x19/x20 @ -80, x21/x22 @ -96, x23/x24 @ -112, x25/x26 @ -128,
+;;;      x27/x28 @ -144, x29/LR @ -160 ⇒ saved LR at CBF-152.
+;;;
+;;; Loaded by the gate harness after Matt's arch layer (wired by lead).
+
+(in-package "ARM64")
+
+;;; d0..d7 argument-register save block (8 x 8 bytes at CBF-64..CBF-8).
+;;; Referenced: lib/ffi-linuxarm64.lisp:231 (fp-regs-form).
+(defconstant callback-frame.fp-save-offset -64)
+
+;;; The trampoline's saved LR = the C caller's return address (the
+;;; x29/LR pair at CBF-160, LR in the high word).  Referenced:
+;;; lib/ffi-linuxarm64.lisp:247 (generate-callback-bindings' 7th value).
+(defconstant callback-frame.savelr-offset -152)
+
+;;; C caller's stack-passed args, contiguous above the x0..x7 block.
+;;; Not currently referenced by ffi-linuxarm64.lisp BY NAME (its offset
+;;; stream reaches +64 arithmetically), but it is the third member of
+;;; the v2 contract triple — defined so the contract artifact is
+;;; complete.
+(defconstant callback-frame.stack-args-offset 64)

--- a/lisp-kernel/albt.c
+++ b/lisp-kernel/albt.c
@@ -158,6 +158,6 @@ plbt_sp(LispObj currentSP)
 void
 plbt(ExceptionInformation *xp)
 {
-  plbt_sp(xpGPR(xp, Rsp));
+  plbt_sp(xpSP(xp)); /* PROPOSED: sp not in regs[] on arm64 */
 }
     

--- a/lisp-kernel/arm64-asmutils.s
+++ b/lisp-kernel/arm64-asmutils.s
@@ -1,0 +1,242 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "arm64-constants.h"
+#include "arm64-macros.s"   /* pulls arm64-uuo.s @ 115b7aa */
+
+/*
+ * PPC64 LINE-PORT (source: vendor/ccl/lisp-kernel/ppc-asmutils.s)
+ *
+ * The missing arm64-asmutils.o in Matt's linuxarm64/Makefile (ASMOBJ).
+ * Logic from ppc-asmutils.s; AArch64 mechanics from the ARM-family
+ * analog arm-asmutils.s (in Matt's tree) where PPC differs -- such
+ * blocks carry ARM64-DEVIATION tags.  Plain GNU as + cpp, same as the
+ * spentry-* drafts.
+ *
+ * PORT-NOTE / inventory vs the two sources:
+ *  - zero_cache_lines (ppc:24): NOT ported -- its only caller
+ *    (memory.c:492) is inside a PPC-only branch (dcbz page-zeroing).
+ *  - flush_cache_lines: A64 has userspace cache maintenance; the
+ *    canonical dc cvau / ic ivau loop replaces PPC's dcbf/icbi and
+ *    ARM32's __ARM_NR_cacheflush syscall.  Signature kept from PPC
+ *    (base, nlines, line_size) to match xMakeDataExecutable's PPC-shaped
+ *    call (pmcl-kernel.c:2212-2221 needs an ARM64 branch upstream --
+ *    flagged in the gc report, open question 7).
+ *  - set/get/zero_fpscr (ppc:86-116): PPC's one FPSCR splits into
+ *    FPCR (control) + FPSR (status); we export fpcr/fpsr pairs AND
+ *    keep PPC-named wrappers reading the STATUS reg (they're what the
+ *    FP-exception POLLING model reads -- Matt 2026-07-11 mail).
+ *  - save/restore_fp_context, put/get_vector_registers (ppc:118-198,
+ *    280+): ARM32 ships these as no-op stubs (arm-asmutils.s:202-213);
+ *    same here, with the same rationale (the C signal path gets FP
+ *    state from the mcontext, not from these).
+ *  - store_conditional / atomic_swap / atomic_ior / atomic_and
+ *    (ppc:202-258): ldxr/stxr loops, status in w9 (a C-volatile scratch
+ *    -- NOT the Lisp w17 convention; this file runs on the C side).
+ *    atomic_swap_acquire + release_spin_lock added from the ARM32 set
+ *    (arm-asmutils.s:135-158) -- thread_manager.c uses them.
+ *  - pseudo_sigreturn (ppc:270): trivial trap-return marker, ARM32
+ *    shape (arm-asmutils.s:196-199).
+ *  - rt_sigprocmask / call_handler_on_main_stack / __aeabi_uldivmod
+ *    (ARM32-only: android syscall shim, arm-exceptions.c helper, EABI
+ *    division ABI): NOT ported -- no ARM64 caller.
+ *  - dmb/dsb/isb helpers (arm-asmutils.s:255-266): kept.
+ *
+ * AAPCS64: args x0-x7, result x0; x9-x15 volatile scratch.
+ */
+
+        .text
+
+/* Flush the data cache to the point of unification and invalidate the
+ * instruction cache: base = x0, nlines = x1, line_size = x2.
+ * ppc-asmutils.s:37-54 (dcbf/isync/icbi loops collapse into one A64
+ * loop; ARM64-DEVIATION: A64 allows EL0 dc cvau/ic ivau -- no syscall,
+ * unlike ARM32's __ARM_NR_cacheflush (arm-asmutils.s:25-40)). */
+        .globl C(flush_cache_lines)
+C(flush_cache_lines):
+        mul     x1, x1, x2              /* total bytes                  */
+        add     x1, x0, x1              /* end                          */
+        mov     x9, x0
+1:      dc      cvau, x9                /* clean D to PoU               */
+        add     x9, x9, x2
+        cmp     x9, x1
+        b.lo    1b
+        dsb     ish
+        mov     x9, x0
+2:      ic      ivau, x9                /* invalidate I to PoU          */
+        add     x9, x9, x2
+        cmp     x9, x1
+        b.lo    2b
+        dsb     ish
+        isb
+        ret
+
+/* ppc-asmutils.s:58-65 / arm-asmutils.s:42-49: dirty a page (write a
+ * word, write it back to 0), return 1.  The C protection-fault path
+ * compares the faulting PC against [touch_page, touch_page_end). */
+        .globl C(touch_page)
+        .globl C(touch_page_end)
+C(touch_page):
+        str     x0, [x0]
+        mov     x9, #0
+        str     x9, [x0]
+        mov     x0, #1
+C(touch_page_end):
+        ret
+
+/* ppc-asmutils.s:68-70 */
+        .globl C(current_stack_pointer)
+C(current_stack_pointer):
+        mov     x0, sp
+        ret
+
+/* ppc-asmutils.s:73-79 (cntlzw) -> A64 clz.  ARM64-DEVIATION: 64-bit
+ * clz (callers pass natural). */
+        .globl C(count_leading_zeros)
+C(count_leading_zeros):
+        clz     x0, x0
+        ret
+
+/* ppc-asmutils.s:82-83 */
+        .globl C(noop)
+C(noop):
+        ret
+
+/* PPC's one FPSCR splits into FPCR (control) / FPSR (status).
+ * ppc-asmutils.s:86-116; polled-FP model per Matt 2026-07-11. */
+        .globl C(get_fpscr)             /* PPC name: reads STATUS       */
+C(get_fpscr):
+        mrs     x0, fpsr
+        ret
+        .globl C(set_fpscr)             /* PPC name: writes CONTROL     */
+C(set_fpscr):
+        msr     fpcr, x0
+        ret
+        .globl C(zero_fpscr)            /* clear accrued status         */
+C(zero_fpscr):
+        msr     fpsr, xzr
+        ret
+        .globl C(get_fpcr)
+C(get_fpcr):
+        mrs     x0, fpcr
+        ret
+        .globl C(set_fpcr)
+C(set_fpcr):
+        msr     fpcr, x0
+        ret
+        .globl C(get_fpsr)
+C(get_fpsr):
+        mrs     x0, fpsr
+        ret
+        .globl C(set_fpsr)
+C(set_fpsr):
+        msr     fpsr, x0
+        ret
+
+/* ARM32 ships these as stubs (arm-asmutils.s:202-213): the signal path
+ * reads FP state from the mcontext.  Same here. */
+        .globl C(save_fp_context)
+C(save_fp_context):
+        ret
+        .globl C(restore_fp_context)
+C(restore_fp_context):
+        ret
+        .globl C(put_vector_registers)
+C(put_vector_registers):
+        ret
+        .globl C(get_vector_registers)
+C(get_vector_registers):
+        ret
+
+/* Atomically store new (x2) in *x0 if old == expected (x1); return the
+ * actual old value.  ppc-asmutils.s:202-216 (lrarx/strcx) -> ldxr/stxr;
+ * status in w9 (C-side scratch). */
+        .globl C(store_conditional)
+C(store_conditional):
+1:      ldxr    x3, [x0]
+        cmp     x3, x1
+        b.ne    2f
+        stxr    w9, x2, [x0]
+        cbnz    w9, 1b
+        dmb     ish
+        mov     x0, x3
+        ret
+2:      clrex                           /* abandon the reservation      */
+        mov     x0, x3
+        ret
+
+/* Atomically store x1 in *x0; return the old value.
+ * ppc-asmutils.s:219-229. */
+        .globl C(atomic_swap)
+C(atomic_swap):
+1:      ldxr    x3, [x0]
+        stxr    w9, x1, [x0]
+        cbnz    w9, 1b
+        dmb     ish
+        mov     x0, x3
+        ret
+
+/* atomic_swap with acquire semantics + spin-lock release: ARM32 set
+ * (arm-asmutils.s:135-158); thread_manager.c's spin locks use them. */
+        .globl C(atomic_swap_acquire)
+C(atomic_swap_acquire):
+1:      ldaxr   x3, [x0]
+        stxr    w9, x1, [x0]
+        cbnz    w9, 1b
+        mov     x0, x3
+        ret
+        .globl C(release_spin_lock)
+C(release_spin_lock):
+        stlr    xzr, [x0]
+        ret
+
+/* Logically OR x1 into *x0; return the new value.
+ * ppc-asmutils.s:232-244. */
+        .globl C(atomic_ior)
+C(atomic_ior):
+1:      ldxr    x3, [x0]
+        orr     x3, x3, x1
+        stxr    w9, x3, [x0]
+        cbnz    w9, 1b
+        dmb     ish
+        mov     x0, x3
+        ret
+
+/* Logically AND x1 into *x0; return the new value.
+ * ppc-asmutils.s:247-258. */
+        .globl C(atomic_and)
+C(atomic_and):
+1:      ldxr    x3, [x0]
+        and     x3, x3, x1
+        stxr    w9, x3, [x0]
+        cbnz    w9, 1b
+        dmb     ish
+        mov     x0, x3
+        ret
+
+/* FP exceptions are POLLED on arm64 (Matt 2026-07-11); the PPC
+ * prctl-based enable/disable (ppc-asmutils.s:260-267) are no-ops, as on
+ * ARM32 (arm-asmutils.s:186-193).  The C-side pair in
+ * arm64-exceptions.c are the ones actually linked; these asm names are
+ * NOT exported to avoid duplicate symbols. */
+
+/* ppc-asmutils.s:270-277 / arm-asmutils.s:196-199: a recognizable
+ * do-nothing marker the exception path can resume through. */
+        .globl C(pseudo_sigreturn)
+C(pseudo_sigreturn):
+        ret
+
+/* Barrier helpers (ARM32 set, arm-asmutils.s:255-266). */
+        .globl C(dmb)
+C(dmb):
+        dmb     ish
+        ret
+        .globl C(dsb)
+C(dsb):
+        dsb     ish
+        ret
+        .globl C(isb)
+C(isb):
+        isb
+        ret
+
+        .end

--- a/lisp-kernel/arm64-constants.h
+++ b/lisp-kernel/arm64-constants.h
@@ -137,6 +137,9 @@ DEFCONST(fulltag_immheader_0,  0b0100)
 DEFCONST(fulltag_immheader_1,  0b0101)
 DEFCONST(fulltag_nodeheader_0, 0b0110)
 DEFCONST(fulltag_symbol,       0b0111)
+#ifndef __ASSEMBLER__
+#define fulltag_symbol fulltag_symbol /* PROPOSED: gc.h + plsym.c probe this with #ifdef */
+#endif
 DEFCONST(fulltag_odd_fixnum,   0b1000)
 DEFCONST(fulltag_reserved,     0b1001)
 DEFCONST(fulltag_imm_1,        0b1010)

--- a/lisp-kernel/arm64-exceptions.c
+++ b/lisp-kernel/arm64-exceptions.c
@@ -1,21 +1,834 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include "lisp.h"
-#include "lisp-exceptions.h"
-#include "arm64-constants.h"
+/* PPC64 LINE-PORT (source: vendor/ccl/lisp-kernel/ppc-exceptions.c)
+ *
+ * Exception/trap handling for Matt Emerson's upstream ARM64 (low-tag)
+ * design; the missing arm64-exceptions.o in linuxarm64/Makefile.
+ * Tree pin: upstream-arm64-tip @ d71a5ad.
+ *
+ * PORT-NOTE — deviations from the PPC64 source (each tagged inline):
+ *  1. Trap encoding: PPC tw/twi/td/tdi conditional traps + UUO major
+ *     opcodes are replaced by the `udf #imm16' UUO scheme.  Namespace
+ *     source: compiler/ARM64/arm64-asm.lisp:435-450 (Matt's active
+ *     layer; lead ruling 2026-07-10 — arm64-uuo.s's hlt scheme is
+ *     2012-WIP legacy and is NOT decoded here).
+ *     ARM64 trap sites have already BRANCHED (conditional traps become
+ *     b.cond around an unconditional udf), so is_conditional_trap()
+ *     and PPC's TO-field condition re-evaluation have no analog here.
+ *  2. Signal mechanics (sigaltstack, SIGILL routing) follow
+ *     arm-exceptions.c (ARM-family Linux reference) where PPC has no
+ *     analog; such blocks are tagged ARM64-DEVIATION with line cites.
+ *  3. Alloc-sequence emulation: the inline allocator is
+ *     arm64-macros.s:36-69 (Cons/Misc_Alloc/Misc_Alloc_Fixed): a
+ *     multi-instruction sub/cmp/b.hi/udf sequence, so pc_luser_xp uses
+ *     arm-exceptions.c's classify/restart approach (arm-exceptions.c:
+ *     1624-1698) rather than PPC's two-instruction back-decode.
+ *  4. No FE0/FE1 MSR bits, no PR_SET_FPEXC prctl on AArch64:
+ *     enable/disable_fp_exceptions are empty (arm-exceptions.c:55-66).
+ *  5. TCR layout: arm64-constants.h C-side struct (W4-D20: where
+ *     arm64-arch.lisp disagrees, constants.h is followed).
+ *
+ * Register numbers: map authority is compiler/ARM64/arm64-asm.lisp:183-215
+ * (Matt's active layer; lead ruling 2026-07-10): imm5=x5 is DISTINCT from
+ * nargs=x6; all other assignments as in arm64-constants.h's `.req' block
+ * (arg_z=x12, temp0=x13, rnil=x23, tsp=x24, ...).  arm64-constants.h has
+ * exactly one stale line (`imm5 .req x6'); arm64-constants.s's m4 map is
+ * wholly stale (rnil=x6, high-tag residue).  See
+ * drafts/arm64-exceptions-report.md.
+ */
 
-#ifdef DARWIN
-int page_size = 16384;
-int log2_page_size = 14;
-#else
-/* On some systems, the page size is configurable */
-int page_size = 4096;
-int log2_page_size = 2;
+#include "lisp.h"                 /* ppc-exceptions.c:17 */
+#include "lisp-errors.h"          /* error_* trap codes (shared table) */
+#include "lisp-exceptions.h"      /* ppc-exceptions.c:18 */
+#include "lisp_globals.h"         /* ppc-exceptions.c:19 */
+#include <ctype.h>                /* ppc-exceptions.c:20 */
+#include <stdio.h>                /* ppc-exceptions.c:21 */
+#include <stddef.h>               /* ppc-exceptions.c:22 */
+#include <string.h>               /* ppc-exceptions.c:23 */
+#include <stdarg.h>               /* ppc-exceptions.c:24 */
+#include <errno.h>                /* ppc-exceptions.c:25 */
+#include <stdio.h>                /* ppc-exceptions.c:26 */
+#ifdef LINUX                      /* ppc-exceptions.c:27-31 */
+#include <strings.h>
+#include <sys/mman.h>
+#endif
+
+#include "threads.h"              /* ppc-exceptions.c:49 */
+
+/* ------------------------------------------------------------------ */
+/* lisp_globals.h grew a real ARM64 branch @ 93d72a0 (nil-anchored via
+ * the runtime lisp_nil) -- the fixed-address PROPOSED shim that lived
+ * here is retired; lisp_globals.h owns lisp_global/nrs_symbol now. */
+
+/* PROPOSED: canonical NIL/T addresses (spentry-A-alloc-numbers.s:96-101;
+ * derivation: Matt's compiler/ARM64/arm64-arch.lisp canonical-nil-value/
+ * canonical-t-value offsets; absolute base 0x13000 provisional). */
+#ifndef nil_value
+#define nil_value ((LispObj)(0x13000+fulltag_nil+(LOWMEM_BIAS)))
+#endif
+#ifndef t_offset
+#define t_offset ((0x13020+fulltag_symbol)-(0x13000+fulltag_nil))
+#endif
+#ifndef t_value
+#define t_value (nil_value+t_offset)
+#endif
+
+/* ------------------------------------------------------------------ */
+/* C-side register numbers — authority: arm64-constants.h R* numbers
+ * @ pin 115b7aa (map unified upstream at 01d73c3). */
+enum {
+  imm0 = 0,
+  imm1 = 1,
+  imm2 = 2,
+  imm3 = 3,
+  imm4 = 4,
+  imm5 = 5,        /* arm64-asm.lisp: imm5=x5, DISTINCT from nargs */
+  nargs = 6,       /* arm64-asm.lisp: nargs=x6 */
+  fn = 7,          /* fn=x7 */
+  arg_w = 8,       /* renumbered @ upstream 01d73c3 (map unified) */
+  arg_x = 9,
+  arg_y = 10,
+  arg_z = 11,
+  temp0 = 12,
+  temp1 = 13,
+  temp2 = 14, nfn = 14,
+  temp3 = 15, fname = 15,
+  temp4 = 16,
+  temp5 = 17,      /* NEW boxed temp @ 01d73c3 */
+  save0 = 19,
+  save1 = 20,
+  save2 = 21,
+  save3 = 22,
+  rnil = 23,
+  tsp = 24,        /* Matt's design HAS a tsp register */
+  vsp = 25,
+  allocptr = 26,
+  allocbase = 27,
+  rcontext = 28
+  /* Rlr(30)/Rsp(31) are now provided by his arm64-constants.h DEFCONST
+     register table (RECONCILED 556aebe8: our duplicates dropped; our code's
+     Rlr/Rsp references resolve to his, same values).  AArch64 SP is not one
+     of regs[0..30]; Rsp=31 is the selector for stack-register arguments. */
+};
+
+/* ------------------------------------------------------------------ */
+/* PROPOSED C-side struct overlays (ratify with Matt; arm64-constants.h
+ * has no C struct block yet).  lisp_frame moved to
+ * platform-linuxarm64.h (albt.c needs it too).
+ *
+ * catch_frame, laid on the UNTAGGED uvector base (untag(tcr->catch_top);
+ * header @0, first data slot @8: fulltag_misc = 4 + misc_data_offset = 4).
+ * Field order: spentry-C-bind-catch-throw.s:165-177 _structf catch_frame
+ * (PPC64 layout, regs[] sized to this design's nsaveregs = 4). */
+typedef struct catch_frame {
+  LispObj header;
+  LispObj catch_tag;              /* unbound_marker => unwind-protect  */
+  LispObj link;                   /* previous catch frame              */
+  LispObj mvflag;
+  LispObj csp;                    /* saved control-stack lisp_frame    */
+  LispObj db_link;
+  LispObj regs[4];                /* save0..save3                      */
+  LispObj xframe;
+  LispObj nfp;
+} catch_frame;
+
+/* Forward declarations (Matt's arm64-exceptions.h is empty; PPC keeps
+ * these in ppc-exceptions.h). */
+OSStatus handle_error(ExceptionInformation *, unsigned, unsigned,
+                      unsigned, pc);
+Boolean extend_tcr_tlb(TCR *, ExceptionInformation *, unsigned);
+void pc_luser_xp(ExceptionInformation *, TCR *, signed_natural *);
+void adjust_exception_pc(ExceptionInformation *, int);
+OSStatus handle_uuo(ExceptionInformation *, opcode, pc, siginfo_t *);
+void callback_for_trap(LispObj, ExceptionInformation *, pc, natural,
+                       natural, natural);
+void callback_to_lisp(LispObj, ExceptionInformation *, natural, natural,
+                      natural, natural, natural);
+
+/* ------------------------------------------------------------------ */
+/* udf #imm16 UUO decode.  CANON: Matt's lisp-kernel/arm64-uuo.s after
+ * the c9e7ffb renumber (pin 6b6540e) -- misc moved to format 0 (info
+ * must never be all-0 because udf #0 is the code-vector sentinel),
+ * unary infos renumbered and given udf/udf_call, binary fleshed out,
+ * and all type errors moved to a new wrong_type format 3.
+ *
+ * A64 UDF encoding: the permanently-undefined space, instruction word
+ * 0x0000IIII (top 16 bits zero, imm16 in the low 16).  Linux/AArch64
+ * delivers it as SIGILL.
+ *
+ * imm16 low 2 BITS = format:
+ *   0 misc: 14 bits of info in 15:2, NEVER all-0.  His values 1-8
+ *     (1 alloc, 2 gc, 3 debug, 4 interrupt_now, 5 suspend_now,
+ *     6 too_few_args, 7 too_many_args, 8 wrong_number_of_args).
+ *     PROPOSED extension (arm64-globals-proposed.s uuo_interr; ratify):
+ *     info bit 13 set = "interr": bits 12:5 = errors.s errnum,
+ *     bits 4:0 = register.
+ *   1 unary: reg in bits 6:2, 9 bits of info in 15:7 (0 not_callable,
+ *     1 no_throw_tag, 2 unbound, 3 udf, 4 udf_call, 5 tlb_too_small).
+ *   2 binary: ra in 6:2, rb in 11:7, 4 bits of info in 15:12
+ *     (0 vector_bounds, 1 array_bounds, 2 integer_divide_by_zero,
+ *     3 eep_unresolved, 4 fpu_exception, 5 array_rank, 6 array_flags,
+ *     7 two_registers = extra register pair for the preceding uuo).
+ *   3 wrong_type: reg in 6:2, continuable flag in bit 7, expected
+ *     xtype code in 15:8.
+ */
+#define IS_UUO(i)     (((i) & 0xffff0000) == 0)
+#define UUO_IMM16(i)  ((i) & 0xffff)
+
+#define uuo_format_misc       0
+#define uuo_format_unary      1
+#define uuo_format_binary     2
+#define uuo_format_wrong_type 3
+
+#define UUO_FORMAT(imm16)      ((imm16) & 3)
+#define UUO_UNARY_GPR(imm16)   (((imm16) >> 2) & 0x1f)
+#define UUO_UNARY_INFO(imm16)  (((imm16) >> 7) & 0x1ff)
+#define UUO_BINARY_RA(imm16)   (((imm16) >> 2) & 0x1f)
+#define UUO_BINARY_RB(imm16)   (((imm16) >> 7) & 0x1f)
+#define UUO_BINARY_INFO(imm16) (((imm16) >> 12) & 0xf)
+#define UUO_MISC_INFO(imm16)   (((imm16) >> 2) & 0x3fff)
+#define UUO_WT_GPR(imm16)         (((imm16) >> 2) & 0x1f)
+#define UUO_WT_CONTINUABLE(imm16) (((imm16) >> 7) & 1)
+#define UUO_WT_XTYPE(imm16)       (((imm16) >> 8) & 0xff)
+/* PROPOSED interr extension fields (misc info bit 13 set) */
+#define UUO_MISC_IS_INTERR(mi) (((mi) >> 13) & 1)
+#define UUO_INTERR_ERRNUM(mi)  (((mi) >> 5) & 0xff)
+#define UUO_INTERR_GPR(mi)     ((mi) & 0x1f)
+
+/* unary infos (arm64-uuo.s unary_info_*) */
+#define uuo_unary_not_callable  0
+#define uuo_unary_no_throw_tag  1
+#define uuo_unary_unbound       2
+#define uuo_unary_udf           3
+#define uuo_unary_udf_call      4
+#define uuo_unary_tlb_too_small 5
+#define uuo_unary_slot_unbound  6   /* patch 0052 (PROPOSED); three-register
+                                       error -- see doc/porting/arm64.md */
+#define uuo_unary_apply_macro   7   /* patch 0055: funcalled a macro/
+                                       special-operator name; gpr = fname */
+
+/* binary infos (arm64-uuo.s binary_info_*) */
+#define uuo_binary_vector_bounds  0
+#define uuo_binary_array_bounds   1
+#define uuo_binary_int_div_zero   2
+#define uuo_binary_eep_unresolved 3
+#define uuo_binary_fpu_exception  4
+#define uuo_binary_array_rank     5
+#define uuo_binary_array_flags    6
+#define uuo_binary_two_registers  7
+
+/* misc infos (arm64-uuo.s uuo_misc macros; 0 is invalid) */
+#define uuo_misc_alloc          1
+#define uuo_misc_gc_trap        2
+#define uuo_misc_debug_trap     3
+#define uuo_misc_interrupt_now  4
+#define uuo_misc_suspend_now    5
+#define uuo_misc_too_few        6
+#define uuo_misc_too_many       7
+#define uuo_misc_wrong_number   8
+
+/* Whole-instruction forms tested for directly:
+   udf #((info<<2) | uuo_format_misc). */
+#define ALLOC_TRAP_INSTRUCTION         (0x00000004)  /* uuo_alloc = udf #4  */
+#define GC_TRAP_INSTRUCTION            (0x00000008)  /* uuo_gc_trap         */
+#define DEBUG_TRAP_INSTRUCTION         (0x0000000c)  /* uuo_debug_trap      */
+#define DEFERRED_INTERRUPT_INSTRUCTION (0x00000010)  /* uuo_interrupt_now   */
+
+/* ------------------------------------------------------------------ */
+/* Inline-allocator instruction matchers.
+ *
+ * The allocation sequence is arm64-macros.s:36-69 (Cons / Misc_Alloc /
+ * Misc_Alloc_Fixed):
+ *     sub  allocptr, allocptr, {#imm | Xm}
+ *     cmp  allocptr, allocbase
+ *     b.hi 1f
+ *     udf  #3   (uuo_alloc = misc 0; assembler-validated 2026-07-11)
+ * 1:  str  <header|cdr>, [allocptr, #misc_header_offset|#cons.cdr]
+ *    (str  <car>, [allocptr, #cons.car])
+ *     mov  <dest>, allocptr
+ *     bic  allocptr, allocptr, #fulltagmask
+ *
+ * The matchers below hardcode A64 encodings the same way
+ * arm-exceptions.h:79-101 hardcodes ARM32 ones; each carries its
+ * encoding derivation so the lead can verify against an assembler.
+ *
+ * allocptr = x26, allocbase = x27 (arm64-constants.h).
+ */
+
+/* SUB (immediate): sf=1 op=1 S=0 100010 sh imm12 Rn Rd
+   sub x26, x26, #imm12 [, LSL #12]  → 0xd100035a | sh<<22 | imm12<<10 */
+#define IS_SUB_IMM_FROM_ALLOCPTR(i) (((i) & 0xff8003ff) == 0xd100035a)
+#define SUB_IMM_FIELD(i) ((natural)(((i) >> 10) & 0xfff) << ((((i) >> 22) & 1) ? 12 : 0))
+
+/* SUB (shifted register): sf=1 op=1 S=0 01011 00 0 Rm 000000 Rn Rd
+   sub x26, x26, Xm  → 0xcb00035a | Rm<<16 */
+#define IS_SUB_RM_FROM_ALLOCPTR(i) (((i) & 0xffe0ffff) == 0xcb00035a)
+#define RM_field(i) (((i) >> 16) & 0x1f)
+
+/* SUBS xzr (cmp): cmp x26, x27 → 0xeb1b035f */
+#define IS_COMPARE_ALLOCPTR_TO_ALLOCBASE(i) ((i) == 0xeb1b035f)
+
+/* B.cond: 0101 0100 imm19 0 cond; b.hi .+8 → imm19=2, cond=0b1000 */
+#define IS_BRANCH_AROUND_ALLOC_TRAP(i) ((i) == 0x54000048)
+
+#define IS_ALLOC_TRAP(i) ((i) == ALLOC_TRAP_INSTRUCTION)
+
+/* STUR (64-bit): 1111 1000 000 imm9 00 Rn Rt
+   header store: stur Xt, [x26, #misc_header_offset(-4)]
+     imm9 = -4 & 0x1ff = 0x1fc → 0xf8000000|0x1fc<<12|26<<5 = 0xf81fc340 */
+#define IS_SET_ALLOCPTR_HEADER_RD(i) (((i) & 0xffffffe0) == 0xf81fc340)
+/* cons.cdr = -cons_bias = -3 (arm64-constants.h cons struct):
+     stur Xt, [x26, #-3] → imm9 = 0x1fd → 0xf81fd340 */
+#define IS_SET_ALLOCPTR_CDR_RD(i)    (((i) & 0xffffffe0) == 0xf81fd340)
+/* cons.car = -cons_bias + node_size = +5:
+     stur Xt, [x26, #5]  → imm9 = 5 → 0xf8005340 */
+#define IS_SET_ALLOCPTR_CAR_RD(i)    (((i) & 0xffffffe0) == 0xf8005340)
+#define RD_field(i) ((i) & 0x1f)
+
+/* MOV Xd, x26 = ORR Xd, xzr, x26: 0xaa1a03e0 | Rd */
+#define IS_SET_ALLOCPTR_RESULT_RD(i) (((i) & 0xffffffe0) == 0xaa1a03e0)
+
+/* bic allocptr, allocptr, #fulltagmask assembles as
+   AND x26, x26, #0xfffffffffffffff0 (N=1 immr=60 imms=59):
+   0x92000000|1<<22|60<<16|59<<10|26<<5|26 = 0x927cef5a */
+#define IS_CLR_ALLOCPTR_TAG(i)       ((i) == 0x927cef5a)
+
+/* Alloc-sequence classification (ARM64-DEVIATION: arm-exceptions.h:103-111,
+   needed because the ARM-family alloc sequence is multi-instruction). */
+typedef enum {
+  ID_unrecognized_alloc_instruction,
+  ID_adjust_allocptr_instruction,
+  ID_compare_allocptr_to_allocbase_instruction,
+  ID_branch_around_alloc_trap_instruction,
+  ID_alloc_trap_instruction,
+  ID_finish_allocation
+} alloc_instruction_id;
+
+/* ------------------------------------------------------------------ */
+
+#ifndef SA_NODEFER               /* ppc-exceptions.c:35-37 */
+#define SA_NODEFER 0
+#endif
+
+/* ARM64-DEVIATION (arm-exceptions.c:55-66): no FE0/FE1, no PR_SET_FPEXC
+   on AArch64; FP exceptions are untrapped by default (FPCR trap enables
+   are IMPDEF and generally RES0 on shipping cores).  PPC's prctl-based
+   enable/disable_fp_exceptions (ppc-exceptions.c:57-84) reduce to no-ops. */
+void
+enable_fp_exceptions()
+{
+}
+
+void
+disable_fp_exceptions()
+{
+}
+
+/*
+  Handle exceptions.
+*/
+
+extern LispObj lisp_nil;          /* ppc-exceptions.c:91 */
+
+extern natural lisp_heap_gc_threshold;      /* ppc-exceptions.c:93 */
+extern Boolean grow_dynamic_area(natural);  /* ppc-exceptions.c:94 */
+
+int
+page_size = 4096;                 /* ppc-exceptions.c:101-102 */
+
+int
+log2_page_size = 12;              /* ppc-exceptions.c:104-105 */
+
+/*
+  If the PC is pointing to an allocation trap, the previous instruction
+  must have decremented allocptr.  Return the non-zero amount by which
+  allocptr was decremented.
+  (ppc-exceptions.c:111-140; instruction shapes per arm64-macros.s:36-69:
+   the sub is 3 instructions before the udf — sub/cmp/b.hi/udf.)
+*/
+signed_natural
+allocptr_displacement(ExceptionInformation *xp)
+{
+  pc program_counter = xpPC(xp);
+  opcode instr = *program_counter, prev_instr;
+
+  if (IS_ALLOC_TRAP(instr)) {   /* ppc-exceptions.c:122 */
+    prev_instr = program_counter[-3];  /* sub, cmp, b.hi, udf */
+
+    if (IS_SUB_RM_FROM_ALLOCPTR(prev_instr)) {  /* ppc:123-129 (subf) */
+      /* Misc_Alloc: the size register still holds (size - fulltag_misc) */
+      return ((signed_natural) xpGPR(xp, RM_field(prev_instr)));
+    }
+    if (IS_SUB_IMM_FROM_ALLOCPTR(prev_instr)) { /* ppc:130-136 (addi -) */
+      return ((signed_natural) SUB_IMM_FIELD(prev_instr));
+    }
+    Bug(xp, "Can't determine allocation displacement");  /* ppc:137 */
+  }
+  return 0;                      /* ppc-exceptions.c:139 */
+}
+
+
+/*
+  A cons cell's been successfully allocated, but the allocptr's
+  still tagged (as fulltag_cons, of course.)  Emulate any instructions
+  that might follow the allocation (stores to the car or cdr, an
+  assignment to the "result" gpr) that take place while the allocptr's
+  tag is non-zero, advancing over each such instruction.  When we're
+  done, the cons cell will be allocated and initialized, the result
+  register will point to it, the allocptr will be untagged, and
+  the PC will point past the instruction that clears the allocptr's
+  tag.  (ppc-exceptions.c:143-193; ARM64 instruction shapes from
+  arm64-macros.s Cons macro; same structure as arm-exceptions.c:148-172.)
+*/
+void
+finish_allocating_cons(ExceptionInformation *xp)
+{
+  pc program_counter = xpPC(xp);
+  opcode instr;
+  LispObj cur_allocptr = xpGPR(xp, allocptr);
+  cons *c = (cons *)ptr_from_lispobj(untag(cur_allocptr));
+
+  while (1) {
+    instr = *program_counter++;
+
+    if (IS_CLR_ALLOCPTR_TAG(instr)) {       /* ppc:166-170 */
+      xpGPR(xp, allocptr) = untag(cur_allocptr);
+      xpPC(xp) = program_counter;
+      return;
+    } else if (IS_SET_ALLOCPTR_CAR_RD(instr)) {  /* ppc:173-174 */
+      c->car = xpGPR(xp, RD_field(instr));
+    } else if (IS_SET_ALLOCPTR_CDR_RD(instr)) {  /* ppc:176-177 */
+      c->cdr = xpGPR(xp, RD_field(instr));
+    } else if (IS_SET_ALLOCPTR_RESULT_RD(instr)) {  /* ppc:179-190 */
+      xpGPR(xp, RD_field(instr)) = cur_allocptr;
+    } else {
+      Bug(xp, "Unexpected instruction following cons alloc trap at " LISP ":",
+          (LispObj)(program_counter - 1));  /* arm-exceptions.c:203 idiom */
+    }
+  }
+}
+
+/*
+  We were interrupted in the process of allocating a uvector; we
+  survived the allocation trap, and allocptr is tagged as fulltag_misc.
+  Emulate any instructions which store a header into the uvector,
+  assign the value of allocptr to some other register, and clear
+  allocptr's tag.  Don't expect/allow any other instructions in
+  this environment.  (ppc-exceptions.c:195-232.)
+*/
+void
+finish_allocating_uvector(ExceptionInformation *xp)
+{
+  pc program_counter = xpPC(xp);
+  opcode instr;
+  LispObj cur_allocptr = xpGPR(xp, allocptr);
+
+  while (1) {
+    instr = *program_counter++;
+    if (IS_CLR_ALLOCPTR_TAG(instr)) {       /* ppc:213-217 */
+      xpGPR(xp, allocptr) = untag(cur_allocptr);
+      xpPC(xp) = program_counter;
+      return;
+    }
+    if (IS_SET_ALLOCPTR_HEADER_RD(instr)) { /* ppc:218-220 */
+      header_of(cur_allocptr) = xpGPR(xp, RD_field(instr));
+    } else if (IS_SET_ALLOCPTR_RESULT_RD(instr)) { /* ppc:221-230 */
+      xpGPR(xp, RD_field(instr)) = cur_allocptr;
+    } else {
+      Bug(xp, "Unexpected instruction following uvector alloc trap at " LISP ":",
+          (LispObj)(program_counter - 1));
+    }
+  }
+}
+
+
+Boolean
+allocate_object(ExceptionInformation *xp,
+                natural bytes_needed,
+                signed_natural disp_from_allocptr,
+                TCR *tcr)
+{
+  area *a = active_dynamic_area;   /* ppc-exceptions.c:235-282 */
+
+  /* Maybe do an EGC */
+  if (a->older && lisp_global(OLDEST_EPHEMERAL)) {   /* ppc:244 */
+    if (((a->active)-(a->low)) >= a->threshold) {
+      gc_from_xp(xp, 0L);
+    }
+  }
+
+  /* Life is pretty simple if we can simply grab a segment
+     without extending the heap.
+  */
+  if (new_heap_segment(xp, bytes_needed, false, tcr, NULL)) {  /* ppc:253 */
+    xpGPR(xp, allocptr) += disp_from_allocptr;
+    return true;
+  }
+
+  /* It doesn't make sense to try a full GC if the object
+     we're trying to allocate is larger than everything
+     allocated so far.
+  */
+  if ((lisp_global(HEAP_END)-lisp_global(HEAP_START)) > bytes_needed) { /* ppc:266 */
+    untenure_from_area(tenured_area); /* force a full GC */
+    gc_from_xp(xp, 0L);
+  }
+
+  /* Try again, growing the heap if necessary */
+  if (new_heap_segment(xp, bytes_needed, true, tcr, NULL)) {   /* ppc:272 */
+    xpGPR(xp, allocptr) += disp_from_allocptr;
+    return true;
+  }
+
+  return false;
+}
+
+#ifndef XNOMEM                    /* ppc-exceptions.c:284-286 */
+#define XNOMEM 10
 #endif
 
 void
-update_area_active (area **aptr, char *value)
+update_bytes_allocated(TCR* tcr, void *cur_allocptr)
+{                                 /* ppc-exceptions.c:288-298 */
+  BytePtr
+    last = (BytePtr) tcr->last_allocptr,
+    current = (BytePtr) cur_allocptr;
+  if (last && (cur_allocptr != ((void *)VOID_ALLOCPTR))) {
+    tcr->bytes_allocated += last-current;
+  }
+  tcr->last_allocptr = 0;
+}
+
+void
+lisp_allocation_failure(ExceptionInformation *xp, TCR *tcr, natural bytes_needed)
+{                                 /* ppc-exceptions.c:300-309 */
+  /* Couldn't allocate the object.  If it's smaller than some arbitrary
+     size (say 128K bytes), signal a "chronically out-of-memory" condition;
+     else signal a "allocation request failed" condition.
+  */
+  xpGPR(xp,allocptr) = xpGPR(xp,allocbase) = VOID_ALLOCPTR;
+  handle_error(xp, bytes_needed < (128<<10) ? XNOMEM : error_alloc_failed, 0, 0, xpPC(xp));
+}
+
+/*
+  Allocate a large list, where "large" means "large enough to
+  possibly trigger the EGC several times if this was done
+  by individually allocating each CONS."  The number of
+  conses in question is in arg_z; on successful return,
+  the list will be in arg_z.  (ppc-exceptions.c:311-351.)
+*/
+
+Boolean
+allocate_list(ExceptionInformation *xp, TCR *tcr)
 {
+  natural
+    nconses = (unbox_fixnum(xpGPR(xp,arg_z))),
+    bytes_needed = (nconses << dnode_shift);
+  LispObj
+    prev = lisp_nil,
+    current,
+    initial = xpGPR(xp,arg_y);
+
+  if (nconses == 0) {
+    /* Silly case */
+    xpGPR(xp,arg_z) = lisp_nil;
+    xpGPR(xp,allocptr) = lisp_nil;
+    return true;
+  }
+  update_bytes_allocated(tcr, (void *)(void *) tcr->save_allocptr);
+  if (allocate_object(xp,bytes_needed,(-bytes_needed)+fulltag_cons,tcr)) {
+    /* ppc:338-343: after allocate_object, allocptr is tagged fulltag_cons
+       and points (tagged) at the FIRST (lowest-addressed) cons.  Chain
+       upward: deref(current,0) is the CDR (cons.cdr = untag+0 in Matt's
+       layout, arm64-constants.h cons struct — same slot order as PPC64),
+       deref(current,1) the CAR. */
+    for (current = xpGPR(xp,allocptr);
+         nconses;
+         prev = current, current+= dnode_size, nconses--) {
+      deref(current,0) = prev;      /* cdr */
+      deref(current,1) = initial;   /* car */
+    }
+    xpGPR(xp,arg_z) = prev;
+    xpGPR(xp,arg_y) = xpGPR(xp,allocptr);
+    xpGPR(xp,allocptr)-=fulltag_cons;
+  } else {
+    lisp_allocation_failure(xp,tcr,bytes_needed);
+  }
+  return true;
+}
+
+OSStatus
+handle_alloc_trap(ExceptionInformation *xp, TCR *tcr)
+{                                 /* ppc-exceptions.c:353-414 */
+  natural cur_allocptr, bytes_needed = 0;
+  signed_natural disp = 0;
+  unsigned allocptr_tag;
+
+  cur_allocptr = xpGPR(xp,allocptr);
+  allocptr_tag = fulltag_of(cur_allocptr);
+
+  switch (allocptr_tag) {
+  case fulltag_cons:              /* ppc:368-371 */
+    bytes_needed = sizeof(cons);
+    disp = -sizeof(cons) + fulltag_cons;
+    break;
+
+  case fulltag_even_fixnum:       /* ppc:373-375 */
+  case fulltag_odd_fixnum:
+    break;
+
+  case fulltag_misc:              /* ppc:377-395 */
+    /* On PPC this decoded the previous (subf/addi) instruction inline;
+       here the same decode lives in allocptr_displacement() (the sub is
+       3 instructions back per arm64-macros.s Misc_Alloc). */
+    disp = -allocptr_displacement(xp);
+    if (disp) {
+      bytes_needed = (-disp) + fulltag_misc;
+      break;
+    }
+    /* else fall thru */
+  default:                        /* ppc:396-397 */
+    return -1;
+  }
+
+  if (bytes_needed) {             /* ppc:400-412 */
+    update_bytes_allocated(tcr,((BytePtr)(cur_allocptr-disp)));
+    if (allocate_object(xp, bytes_needed, disp, tcr)) {
+      adjust_exception_pc(xp,4);  /* resume at the str after the udf */
+      return 0;
+    }
+    lisp_allocation_failure(xp,tcr,bytes_needed);
+    return -1;
+  }
+  return -1;
+}
+
+natural gc_deferred = 0, full_gc_deferred = 0;  /* ppc-exceptions.c:416 */
+
+signed_natural
+flash_freeze(TCR *tcr, signed_natural param)
+{                                 /* ppc-exceptions.c:418-422 */
+  return 0;
+}
+
+OSStatus
+handle_gc_trap(ExceptionInformation *xp, TCR *tcr)
+{                                 /* ppc-exceptions.c:424-557 */
+  LispObj
+    selector = xpGPR(xp,imm0),
+    arg = xpGPR(xp,imm1);
+  area *a = active_dynamic_area;
+  Boolean egc_was_enabled = (a->older != NULL);
+  natural gc_previously_deferred = gc_deferred;
+
+
+  switch (selector) {
+  case GC_TRAP_FUNCTION_EGC_CONTROL:   /* ppc:436-439 */
+    egc_control(arg != 0, a->active);
+    xpGPR(xp,arg_z) = lisp_nil + (egc_was_enabled ? t_offset : 0);
+    break;
+
+  case GC_TRAP_FUNCTION_CONFIGURE_EGC: /* ppc:441-446 */
+    a->threshold = unbox_fixnum(xpGPR(xp, arg_x));
+    g1_area->threshold = unbox_fixnum(xpGPR(xp, arg_y));
+    g2_area->threshold = unbox_fixnum(xpGPR(xp, arg_z));
+    xpGPR(xp,arg_z) = lisp_nil+t_offset;
+    break;
+
+  case GC_TRAP_FUNCTION_SET_LISP_HEAP_THRESHOLD:  /* ppc:448-455 */
+    if (((signed_natural) arg) > 0) {
+      lisp_heap_gc_threshold =
+        align_to_power_of_2((arg-1) +
+                            (heap_segment_size - 1),
+                            log2_heap_segment_size);
+    }
+    /* fall through */
+  case GC_TRAP_FUNCTION_GET_LISP_HEAP_THRESHOLD:  /* ppc:456-458 */
+    xpGPR(xp, imm0) = lisp_heap_gc_threshold;
+    break;
+
+  case GC_TRAP_FUNCTION_USE_LISP_HEAP_THRESHOLD:  /* ppc:460-471 */
+    /*  Try to put the current threshold in effect.  This may
+        need to disable/reenable the EGC. */
+    untenure_from_area(tenured_area);
+    resize_dynamic_heap(a->active,lisp_heap_gc_threshold);
+    if (egc_was_enabled) {
+      if ((a->high - a->active) >= a->threshold) {
+        tenure_to_area(tenured_area);
+      }
+    }
+    xpGPR(xp, imm0) = lisp_heap_gc_threshold;
+    break;
+
+  case GC_TRAP_FUNCTION_ENSURE_STATIC_CONSES:     /* ppc:473-475 */
+    ensure_static_conses(xp,tcr,32768);
+    break;
+
+  case GC_TRAP_FUNCTION_FLASH_FREEZE:  /* ppc:477-486 */
+    untenure_from_area(tenured_area);
+    gc_like_from_xp(xp,flash_freeze,0);
+    a->active = (BytePtr) align_to_power_of_2(a->active, log2_page_size);
+    tenured_area->static_dnodes = area_dnode(a->active, a->low);
+    if (egc_was_enabled) {
+      tenure_to_area(tenured_area);
+    }
+    xpGPR(xp, imm0) = tenured_area->static_dnodes << dnode_shift;
+    break;
+
+  default:                        /* ppc:488-551 */
+    update_bytes_allocated(tcr, (void *) ptr_from_lispobj(xpGPR(xp, allocptr)));
+
+    if (selector == GC_TRAP_FUNCTION_IMMEDIATE_GC) {
+      if (!full_gc_deferred) {
+        gc_from_xp(xp, 0L);
+        break;
+      }
+      /* Tried to do a full GC when gc was disabled.  That failed,
+         so try full GC now */
+      selector = GC_TRAP_FUNCTION_GC;
+    }
+
+    if (egc_was_enabled) {
+      egc_control(false, (BytePtr) a->active);
+    }
+    gc_from_xp(xp, 0L);
+    if (gc_deferred > gc_previously_deferred) {
+      full_gc_deferred = 1;
+    } else {
+      full_gc_deferred = 0;
+    }
+    if (selector > GC_TRAP_FUNCTION_GC) {
+      if (selector & GC_TRAP_FUNCTION_IMPURIFY) {
+        impurify_from_xp(xp, 0L);
+        lisp_global(OLDSPACE_DNODE_COUNT) = 0;
+        gc_from_xp(xp, 0L);
+      }
+      if (selector & GC_TRAP_FUNCTION_PURIFY) {
+        purify_from_xp(xp, 0L);
+        lisp_global(OLDSPACE_DNODE_COUNT) = 0;
+        gc_from_xp(xp, 0L);
+      }
+      if (selector & GC_TRAP_FUNCTION_SAVE_APPLICATION) {
+        OSErr err;
+        extern OSErr save_application(unsigned, Boolean);
+        TCR *tcr = TCR_FROM_TSD(xpGPR(xp, rcontext));
+        area *vsarea = tcr->vs_area;
+
+        nrs_TOPLFUNC.vcell = *((LispObj *)(vsarea->high)-1);
+        err = save_application(arg, egc_was_enabled);
+        if (err == noErr) {
+          _exit(0);
+        }
+        fatal_oserr(": save_application", err);
+      }
+      switch (selector) {
+
+      case GC_TRAP_FUNCTION_FREEZE:   /* ppc:538-542 */
+        a->active = (BytePtr) align_to_power_of_2(a->active, log2_page_size);
+        tenured_area->static_dnodes = area_dnode(a->active, a->low);
+        xpGPR(xp, imm0) = tenured_area->static_dnodes << dnode_shift;
+        break;
+      default:
+        break;
+      }
+    }
+
+    if (egc_was_enabled) {
+      egc_control(true, NULL);
+    }
+    break;
+
+  }
+
+  adjust_exception_pc(xp,4);      /* ppc:555 */
+  return 0;
+}
+
+
+void
+signal_stack_soft_overflow(ExceptionInformation *xp, unsigned reg)
+{                                 /* ppc-exceptions.c:561-573 */
+  /* The cstack just overflowed.  Force the current thread's
+     control stack to do so until all stacks are well under their overflow
+     limits.
+  */
+  handle_error(xp, error_stack_overflow, reg, 0,  xpPC(xp));
+}
+
+/*
+  Lower (move toward 0) the "end" of the soft protected area associated
+  with a by a page, if we can.
+*/
+
+void
+adjust_soft_protection_limit(area *a)
+{                                 /* ppc-exceptions.c:575-592 */
+  char *proposed_new_soft_limit = a->softlimit - 4096;
+  protected_area_ptr p = a->softprot;
+
+  if (proposed_new_soft_limit >= (p->start+16384)) {
+    p->end = proposed_new_soft_limit;
+    p->protsize = p->end-p->start;
+    a->softlimit = proposed_new_soft_limit;
+  }
+  protect_area(p);
+}
+
+void
+restore_soft_stack_limit(unsigned stkreg)
+{                                 /* ppc-exceptions.c:594-616 */
+  area *a;
+  TCR *tcr = get_tcr(true);
+
+  switch (stkreg) {
+  case Rsp:  /* ARM64-DEVIATION: PPC used sp=r1; AArch64 SP is not a
+                numbered GPR, selector Rsp=31 (see enum above). */
+    a = tcr->cs_area;
+    if ((a->softlimit - 4096) > (a->hardlimit + 16384)) {
+      a->softlimit -= 4096;
+    }
+    tcr->cs_limit = (LispObj)ptr_to_lispobj(a->softlimit);
+    break;
+  case vsp:
+    a = tcr->vs_area;
+    adjust_soft_protection_limit(a);
+    break;
+  case tsp:
+    a = tcr->ts_area;
+    adjust_soft_protection_limit(a);
+  }
+}
+
+/* Maybe this'll work someday.  We may have to do something to
+   make the thread look like it's not handling an exception */
+void
+reset_lisp_process(ExceptionInformation *xp)
+{                                 /* ppc-exceptions.c:618-633 */
+  TCR *tcr = TCR_FROM_TSD(xpGPR(xp,rcontext));
+  catch_frame *last_catch = (catch_frame *) ptr_from_lispobj(untag(tcr->catch_top));
+
+  tcr->save_allocptr = (void *) ptr_from_lispobj(xpGPR(xp, allocptr));
+  tcr->save_allocbase = (void *) ptr_from_lispobj(xpGPR(xp, allocbase));
+
+  tcr->save_vsp = (LispObj *) ptr_from_lispobj(((lisp_frame *)ptr_from_lispobj(last_catch->csp))->savevsp);
+  tcr->save_tsp = (LispObj *) ptr_from_lispobj((LispObj) ptr_to_lispobj(last_catch)) - (2*node_size); /* account for TSP header */
+
+  start_lisp(tcr, 1);
+}
+
+
+void
+platform_new_heap_segment(ExceptionInformation *xp, TCR *tcr, BytePtr low, BytePtr high)
+{                                 /* ppc-exceptions.c:636-642 */
+  tcr->last_allocptr = (void *)high;
+  xpGPR(xp,allocptr) = (LispObj) high;
+  xpGPR(xp,allocbase) = (LispObj) low;
+}
+
+
+void
+update_area_active (area **aptr, BytePtr value)
+{                                 /* ppc-exceptions.c:645-659 */
   area *a = *aptr;
   for (; a; a = a->older) {
     if ((a->low <= value) && (a->high >= value)) break;
@@ -23,204 +836,1579 @@ update_area_active (area **aptr, char *value)
   if (a == NULL) Bug(NULL, "Can't find active area");
   a->active = value;
   *aptr = a;
+
   for (a = a->younger; a; a = a->younger) {
     a->active = a->high;
   }
 }
 
-/* Used when creating variable-length C frames on the control stack */
-#define STP_IMM0_IMM1_SP    0xa90007e0U  /* stp x0, x1, [sp, #0] */
+LispObj *
+tcr_frame_ptr(TCR *tcr)
+{                                 /* ppc-exceptions.c:661-676 */
+  ExceptionInformation *xp;
+  LispObj *bp = NULL;
 
-/* Used when creating lisp frames on the control stack. */
-#define STP_FN_LR_SP        0xa9017be7U  /* stp fn, lr, [sp, #16] */
-
-/*
- * If it looks like we're in the middle of some multi-instruction
- * operation that must be atomic, make it seem as if that operation is
- * either complete, or not yet begun, or otherwise in a safe state.
- */
-void
-pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
-{
-  pc program_counter = xpPC(xp);
-  opcode instr = *program_counter;
-
-  /*
-   * Stack-allocating a variable-length u64-vector
-   *
-   * See, for example, the vinsn allocate-variable-c-frame.
-   *
-   * We are (probably) building a u64-vector on the control stack, and
-   * we don't know what the size of the vector is until run-time.
-   * Ideally, we'd able to write "stp header, savesp, [sp, sizereg]!"
-   * to do this in one instruction.  Unfortunately, that addressing
-   * mode is not available: pre-indexing only works for an immediate
-   * offset.
-   *
-   * Thus, we have to write this
-   *   sub sp, sp, sizereg            // make room on the stack
-   *   stp imm0, imm1, [sp, #0]       // u64-header (plus prevsp in elem 0)
-   *
-   * We wire the header register to imm0 and the prevsp register to
-   * imm1 so that we can read the values back from a known place here.
-   *
-   * The hazard is that if the gc runs between these two instructions
-   * (i.e., if the pc is at the stp instruction), it will probably get
-   * confused by whatever junk is now on top of the stack.  So, we
-   * complete the store from imm0/imm1 and skip over the stp.
-   *
-   * We only look for the stp instruction, so it's possible that we
-   * are not really in the middle of allocating a variable C frame: we
-   * could be in unrelated code.  However, completing the stp here
-   * should be harmless: the code was going to do it anyway.
-   */
-  if (instr == STP_IMM0_IMM1_SP) {
-    LispObj *sp = (LispObj *)ptr_from_lispobj(xpSP(xp));
-    sp[0] = xpGPR(xp, Rimm0);         /* the u64-vector header */
-    sp[1] = xpGPR(xp, Rimm1);         /* saved previous SP (element 0) */
-    xpPC(xp) = program_counter + 1;   /* resume just past the stp */
-    return;
+  if (tcr->pending_exception_context)
+    xp = tcr->pending_exception_context;
+  else {
+    xp = tcr->suspend_context;
   }
-
-  /* TODO(arm64): heap-allocation windows -- port classify_alloc_instruction /
-     finish_allocating_{cons,uvector} / restart_allocation from
-     arm-exceptions.c; this is what fills in *alloc_disp. */
-
-  /*
-   * Bulding a lisp frame
-   *
-   * We are (probably) building a 4-word lisp frame on the control stack.
-   *
-   *   stp  marker, vsp, [sp, #-32]!   // reserve space, write marker & vsp
-   *   stp  fn, lr, [sp, #16]          // save fn, lr
-   *
-   * The hazard is that if the gc runs between these two instructions,
-   * it will probably get confused because the fn and lr slots in the
-   * lisp frame will be random junk instead of gc roots (well, a gc
-   * root and a pc-locative).
-   *
-   * The easiest fix is to zero those slots, which is safe for the gc.
-   *
-   * We could check whether frame->marker == lisp_frame_marker before
-   * zeroing the stack slots (to more narrowly match the "building a
-   * lisp frame" case) but it seems harmless to zero unconditionally,
-   * since the stack slots are about to get overwritten with real
-   * values anyway.
-   */
-  if (instr == STP_FN_LR_SP) {
-    lisp_frame *frame = (lisp_frame *)ptr_from_lispobj(xpSP(xp));
-    frame->savefn = 0;
-    frame->savelr = 0;
-    return;
+  if (xp) {
+    bp = (LispObj *) xpSP(xp);  /* ARM64-DEVIATION: xpGPR(xp,sp) → xpSP */
   }
-
-  /* TODO(arm64): EGC write-barrier windows. */
-}
-
-void
-update_bytes_allocated(TCR *tcr, void *cur_allocptr)
-{
-  char *last = tcr->last_allocptr;
-  char *current = cur_allocptr;
-
-  if (last && (cur_allocptr != (void *)VOID_ALLOCPTR)) {
-    tcr->bytes_allocated += last - current;
-  }
-  tcr->last_allocptr = 0;
+  return bp;
 }
 
 void
 normalize_tcr(ExceptionInformation *xp, TCR *tcr, Boolean is_other_tcr)
-{
-  void *cur_allocptr = 0;
+{                                 /* ppc-exceptions.c:678-733 */
+  void *cur_allocptr = NULL;
   LispObj freeptr = 0;
 
   if (xp) {
     if (is_other_tcr) {
       pc_luser_xp(xp, tcr, NULL);
-      freeptr = xpGPR(xp, Rallocptr);
-      if (fulltag_of(freeptr) == 0) {
-          cur_allocptr = (void *)ptr_from_lispobj(freeptr);
+      freeptr = xpGPR(xp, allocptr);
+      if (fulltag_of(freeptr) == 0){
+        cur_allocptr = (void *) ptr_from_lispobj(freeptr);
       }
     }
-    update_area_active(&tcr->cs_area, (char *)ptr_from_lispobj(xpSP(xp)));
-    update_area_active(&tcr->vs_area, (char* )ptr_from_lispobj(xpGPR(xp,
-                                                                     Rvsp)));
-    update_area_active(&tcr->ts_area, (char *)ptr_from_lispobj(xpGPR(xp,
-                                                                     Rtsp)));
+    update_area_active((area **)&tcr->cs_area, (BytePtr) ptr_from_lispobj(xpSP(xp)));
+    update_area_active((area **)&tcr->vs_area, (BytePtr) ptr_from_lispobj(xpGPR(xp, vsp)));
+    update_area_active((area **)&tcr->ts_area, (BytePtr) ptr_from_lispobj(xpGPR(xp, tsp)));
   } else {
     /* In ff-call. */
-    cur_allocptr = (void *)tcr->save_allocptr;
-    update_area_active(&tcr->cs_area, (char *)tcr->last_lisp_frame);
-    update_area_active(&tcr->vs_area, (char *)tcr->save_vsp);
-    update_area_active(&tcr->ts_area, (char *)tcr->save_tsp);
+    cur_allocptr = (void *) (tcr->save_allocptr);
+    update_area_active((area **)&tcr->vs_area, (BytePtr) tcr->save_vsp);
+    update_area_active((area **)&tcr->ts_area, (BytePtr) tcr->save_tsp);
+    /* ARM64-DEVIATION (16m41): PPC's "No need to update cs_area" comment does
+       NOT carry over.  It is true there because ppc-gc.c:1022 walks a backlink
+       CHAIN, which self-terminates wherever it starts; our walk is linear over
+       [active, high) and asserts it lands on high, so a stale active means it
+       starts in dead stack.  16m40/16m41 observed exactly that: a thread with
+       valence=1 (foreign) and an active left over from an earlier exception,
+       walked into C frames and strode 1.8e16 words off a spilled 0.9d0.
+       tcr.last_lisp_frame is the boundary the ff-call spentries record (see
+       the protocol note in spentry-E-ffi.s); this is where the GC reads it. */
+    update_area_active((area **)&tcr->cs_area, (BytePtr) tcr->last_lisp_frame);
   }
 
-  /* retire current memory segment */
+
   tcr->save_allocptr = tcr->save_allocbase = (void *)VOID_ALLOCPTR;
   if (cur_allocptr) {
     update_bytes_allocated(tcr, cur_allocptr);
     if (freeptr) {
-      xpGPR(xp, Rallocptr) = VOID_ALLOCPTR;
-      xpGPR(xp, Rallocbase) = VOID_ALLOCPTR;
+      xpGPR(xp, allocptr) = VOID_ALLOCPTR;
+      xpGPR(xp, allocbase) = VOID_ALLOCPTR;
     }
-  }                      
-}
-
-LispObj
-code_vector_from_pc(LispObj pcloc)
-{
-  int32_t *pc = (int32_t *)pcloc;
-  /*
-   * There is a udf #0 (which encodes as 0) sentinel instruction at
-   * the beginning of every code-vector.  Scan backwards until we find
-   * it.
-   */
-  while(*pc != 0) {
-    pc--;
   }
-  /*
-   * The header directly precedes the sentinel instruction.
-   */
-  char *code_vector = (char *)(pc - 1) + fulltag_misc;
-  return ptr_to_lispobj(code_vector);
 }
 
-#ifdef DARWIN
-void
-fatal_mach_error(char *format, ...);
+TCR *gc_tcr = NULL;               /* ppc-exceptions.c:735 */
 
-#define MACH_CHECK_ERROR(context, x) if (x != KERN_SUCCESS) {fatal_mach_error("Mach error while %s : %d", context, x);}
+/* Suspend and "normalize" other tcrs, then call a gc-like function
+   in that context.  Resume the other tcrs, then return what the
+   function returned */
 
-void
-associate_tcr_with_exception_port(mach_port_t port, TCR *tcr)
+signed_natural
+gc_like_from_xp(ExceptionInformation *xp,
+                signed_natural(*fun)(TCR *, signed_natural),
+                signed_natural param)
+{                                 /* ppc-exceptions.c:741-800 */
+  TCR *tcr = TCR_FROM_TSD(xpGPR(xp, rcontext)), *other_tcr;
+  int result;
+  signed_natural inhibit;
+
+  suspend_other_threads(true);
+  inhibit = (signed_natural)(lisp_global(GC_INHIBIT_COUNT));
+  if (inhibit != 0) {
+    if (inhibit > 0) {
+      lisp_global(GC_INHIBIT_COUNT) = (LispObj)(-inhibit);
+    }
+    resume_other_threads(true);
+    gc_deferred++;
+    return 0;
+  }
+  gc_deferred = 0;
+
+  gc_tcr = tcr;
+
+  xpGPR(xp, allocptr) = VOID_ALLOCPTR;
+  xpGPR(xp, allocbase) = VOID_ALLOCPTR;
+
+  normalize_tcr(xp, tcr, false);
+
+
+  for (other_tcr = tcr->next; other_tcr != tcr; other_tcr = other_tcr->next) {
+    if (other_tcr->pending_exception_context) {
+      other_tcr->gc_context = other_tcr->pending_exception_context;
+    } else if (other_tcr->valence == TCR_STATE_LISP) {
+      other_tcr->gc_context = other_tcr->suspend_context;
+    } else {
+      /* no pending exception, didn't suspend in lisp state:
+         must have executed a synchronous ff-call.
+      */
+      other_tcr->gc_context = NULL;
+    }
+    normalize_tcr(other_tcr->gc_context, other_tcr, true);
+  }
+
+
+
+  result = fun(tcr, param);
+
+  other_tcr = tcr;
+  do {
+    other_tcr->gc_context = NULL;
+    other_tcr = other_tcr->next;
+  } while (other_tcr != tcr);
+
+  gc_tcr = NULL;
+
+  resume_other_threads(true);
+
+  return result;
+
+}
+
+
+
+/* Returns #bytes freed by invoking GC */
+
+signed_natural
+gc_from_tcr(TCR *tcr, signed_natural param)
+{                                 /* ppc-exceptions.c:804-826 */
+  area *a;
+  BytePtr oldfree, newfree;
+  BytePtr oldend, newend;
+
+  a = active_dynamic_area;
+  oldend = a->high;
+  oldfree = a->active;
+  gc(tcr, param);
+  newfree = a->active;
+  newend = a->high;
+  return ((oldfree-newfree)+(newend-oldend));
+}
+
+signed_natural
+gc_from_xp(ExceptionInformation *xp, signed_natural param)
+{                                 /* ppc-exceptions.c:828-835 */
+  signed_natural status = gc_like_from_xp(xp, gc_from_tcr, param);
+
+  freeGCptrs();
+  return status;
+}
+
+signed_natural
+purify_from_xp(ExceptionInformation *xp, signed_natural param)
+{                                 /* ppc-exceptions.c:837-841 */
+  return gc_like_from_xp(xp, purify, param);
+}
+
+signed_natural
+impurify_from_xp(ExceptionInformation *xp, signed_natural param)
+{                                 /* ppc-exceptions.c:843-847 */
+  return gc_like_from_xp(xp, impurify, param);
+}
+
+
+protection_handler
+ * protection_handlers[] = {      /* ppc-exceptions.c:854-863 */
+   do_spurious_wp_fault,
+   do_soft_stack_overflow,
+   do_soft_stack_overflow,
+   do_soft_stack_overflow,
+   do_hard_stack_overflow,
+   do_hard_stack_overflow,
+   do_hard_stack_overflow
+   };
+
+
+Boolean
+is_write_fault(ExceptionInformation *xp, siginfo_t *info)
+{                                 /* ppc-exceptions.c:866-925 */
+  /* ppc:869-885: use the siginfo.  Linux delivers write-protection
+     faults as SIGSEGV with SEGV_ACCERR in the low bits of si_code.
+     ARM64-DEVIATION: the non-siginfo fallback read PPC's DSISR bit 25 /
+     TRAP=0x300 (ppc:886-895); AArch64's mcontext has no fault-status
+     register (the ESR lives in an optional esr_context extension that
+     older kernels omit), so there is no register fallback — Linux
+     sigaction with SA_SIGINFO always supplies info. */
+  if (info) {
+    return ((info->si_signo == SIGSEGV) &&
+            ((info->si_code & 0xff) == (SEGV_ACCERR & 0xff)));
+  }
+  Bug(xp, "is_write_fault: no siginfo");
+  return false;
+}
+
+static OSStatus pv_cold_load_fatal(ExceptionInformation *xp, BytePtr addr,
+                                   Boolean is_write);
+
+OSStatus
+handle_protection_violation(ExceptionInformation *xp, siginfo_t *info, TCR *tcr, int old_valence)
+{                                 /* ppc-exceptions.c:927-974 */
+  BytePtr addr;
+  protected_area_ptr area;
+  protection_handler *handler;
+  extern Boolean touch_page(void *);
+  extern void touch_page_end(void);
+
+  if (info) {
+    addr = (BytePtr)(info->si_addr);
+  } else {
+    /* ARM64-DEVIATION: PPC read xpDAR (ppc:939); AArch64 mcontext
+       carries the fault address directly. */
+    addr = (BytePtr) ((natural) (xpFaultAddress(xp)));
+  }
+
+  if (addr && (addr == tcr->safe_ref_address)) {  /* ppc:942-947 */
+    adjust_exception_pc(xp,4);
+
+    xpGPR(xp,imm0) = 0;
+    return 0;
+  }
+
+  if (xpPC(xp) == (pc)touch_page) {               /* ppc:949-953 */
+    xpGPR(xp,imm0) = 0;
+    xpPC(xp) = (pc)touch_page_end;
+    return 0;
+  }
+
+
+  if (is_write_fault(xp,info)) {                  /* ppc:956-969 */
+    area = find_protected_area(addr);
+    if (area != NULL) {
+      handler = protection_handlers[area->why];
+      return handler(xp, area, addr);
+    } else {
+      if ((addr >= readonly_area->low) &&
+          (addr < readonly_area->active)) {
+        UnProtectMemory((LogicalAddress)(truncate_to_power_of_2(addr,log2_page_size)),
+                        page_size);
+        return 0;
+      }
+    }
+  }
+  if (old_valence == TCR_STATE_LISP) {            /* ppc:970-972 */
+    LispObj cmain = nrs_CMAIN.vcell;
+    /* Cold-load routing (same test as handle_uuo): calling back into a
+       not-yet-real error system spins forever on its own faults. */
+    if (!((fulltag_of(cmain) == fulltag_misc) &&
+          (header_subtag(header_of(cmain)) == subtag_macptr))) {
+      return pv_cold_load_fatal(xp, addr, is_write_fault(xp,info));
+    }
+    callback_for_trap(cmain, xp, (pc)xpPC(xp), SIGBUS, (natural)addr, is_write_fault(xp,info));
+  }
+  return -1;
+}
+
+
+
+
+
+OSStatus
+do_hard_stack_overflow(ExceptionInformation *xp, protected_area_ptr area, BytePtr addr)
+{                                 /* ppc-exceptions.c:980-988 */
+#ifdef SUPPORT_PRAGMA_UNUSED
+#pragma unused(area,addr)
+#endif
+  reset_lisp_process(xp);
+  return -1;
+}
+
+extern area*
+allocate_vstack(natural useable);       /* This is in "pmcl-kernel.c" */
+
+extern area*
+allocate_tstack(natural useable);       /* This is in "pmcl-kernel.c" */
+
+/* ppc-exceptions.c:996-1009 (catch_frame_p), 1065-1081
+   (find_non_catch_frame_from_xp), 1083-1095 (db_link_chain_in_area_p)
+   are EXTEND_VSTACK-only (not compiled on PPC64 either); not ported. */
+
+/* ppc-exceptions.c:1011-1035 (unwind_protect_cleanup_frame_p,
+   lexpr_entry_frame_p) are PPC-shaped backlink-frame helpers with no
+   callers outside the EXTEND_VSTACK lane (not compiled on PPC64
+   either); ARM32 shipped without them.  Not ported. */
+
+Boolean
+lisp_frame_p(lisp_frame *spPtr)
+{                                 /* arm-exceptions.c:955-958 --
+                                     ARM64-DEVIATION: the ARM-family
+                                     MARKER frame identifies itself; no
+                                     PPC backlink/savefn heuristics
+                                     (ppc:1037-1049). */
+  return (spPtr->marker == lisp_frame_marker);
+}
+
+
+int ffcall_overflow_count = 0;    /* ppc-exceptions.c:1052 */
+
+
+/* Note: CURRENT_VS (CURRENT_TS) is always either the area containing
+  the current value of VSP (TSP) or an older area.  */
+
+OSStatus
+do_vsp_overflow (ExceptionInformation *xp, BytePtr addr)
+{                                 /* ppc-exceptions.c:1103-1112 */
+  TCR* tcr = TCR_FROM_TSD(xpGPR(xp, rcontext));
+  area *a = tcr->vs_area;
+  protected_area_ptr vsp_soft = a->softprot;
+  unprotect_area(vsp_soft);
+  signal_stack_soft_overflow(xp,vsp);
+  return 0;
+}
+
+
+OSStatus
+do_tsp_overflow (ExceptionInformation *xp, BytePtr addr)
+{                                 /* ppc-exceptions.c:1115-1124 */
+  TCR* tcr = TCR_FROM_TSD(xpGPR(xp, rcontext));
+  area *a = tcr->ts_area;
+  protected_area_ptr tsp_soft = a->softprot;
+  unprotect_area(tsp_soft);
+  signal_stack_soft_overflow(xp,tsp);
+  return 0;
+}
+
+OSStatus
+do_soft_stack_overflow(ExceptionInformation *xp, protected_area_ptr prot_area, BytePtr addr)
+{                                 /* ppc-exceptions.c:1126-1141 */
+  /* Trying to write into a guard page on the vstack or tstack.
+     Allocate a new stack segment, emulate stwu and stwux for the TSP, and
+     signal an error_stack_overflow condition.
+      */
+  lisp_protection_kind which = prot_area->why;
+  Boolean on_TSP = (which == kTSPsoftguard);
+
+  if (on_TSP) {
+    return do_tsp_overflow(xp, addr);
+   } else {
+    return do_vsp_overflow(xp, addr);
+   }
+}
+
+OSStatus
+do_spurious_wp_fault(ExceptionInformation *xp, protected_area_ptr area, BytePtr addr)
+{                                 /* ppc-exceptions.c:1143-1150 */
+#ifdef SUPPORT_PRAGMA_UNUSED
+#pragma unused(xp,area,addr)
+#endif
+  return -1;
+}
+
+/* ppc-exceptions.c:1153-1214 (comment block + is_ephemeral_node_store):
+   NOT ported.  is_ephemeral_node_store has no callers in
+   ppc-exceptions.c (dead code), and its body is stw-instruction
+   emulation specific to the PPC ISA. */
+
+OSStatus
+handle_sigfpe(ExceptionInformation *xp, TCR *tcr)
 {
-    kern_return_t kret;
-    
-    kret = mach_port_set_context(mach_task_self(),
-                                 port, (mach_vm_address_t)tcr);
-    MACH_CHECK_ERROR("associating TCR with exception port", kret);
+  /* ppc-exceptions.c:1222-1235 zeroed the FPSCR, re-enabled FP traps
+     via prctl and back-scanned for the offending PPC FPU opcode
+     (handle_fpux_binop).  ARM64-DEVIATION (arm-exceptions.c:1017-1021):
+     AArch64 FP exceptions are untrapped (FPCR trap enables generally
+     RES0 on shipping cores), so a synchronous SIGFPE can only come
+     from integer division; unhandled here (falls through to the
+     debugger path in signal_handler, as on ARM32). */
+  return -1;
+}
+
+OSStatus
+handle_unimplemented_instruction(ExceptionInformation *xp,
+                                 opcode instruction,
+                                 TCR *tcr)
+{
+  /* ppc-exceptions.c:1242-1272 emulated the optional PPC fsqrt/fsqrts
+     instructions.  ARM64-DEVIATION (arm-exceptions.c:1024-1031): no
+     analogous optional instructions to emulate; fsqrt is base A64. */
+  return -1;
+}
+
+OSStatus
+PMCL_exception_handler(int xnum,
+                       ExceptionInformation *xp,
+                       TCR *tcr,
+                       siginfo_t *info,
+                       int old_valence)
+{                                 /* ppc-exceptions.c:1274-1316 */
+  OSStatus status = -1;
+  pc program_counter;
+  opcode instruction = 0;
+
+
+  program_counter = xpPC(xp);
+
+  if ((xnum == SIGILL) | (xnum == SIGTRAP)) {     /* ppc:1288-1290 */
+    instruction = *program_counter;
+  }
+
+  if (((xnum == SIGILL) || (xnum == SIGTRAP)) &&
+      IS_ALLOC_TRAP(instruction)) {               /* ppc:1292-1293 */
+    status = handle_alloc_trap(xp, tcr);
+  } else if ((xnum == SIGSEGV) ||
+             (xnum == SIGBUS)) {                  /* ppc:1294-1296 */
+    status = handle_protection_violation(xp, info, tcr, old_valence);
+  } else if (xnum == SIGFPE) {                    /* ppc:1297-1298 */
+    status = handle_sigfpe(xp, tcr);
+  } else if ((xnum == SIGILL) || (xnum == SIGTRAP)) {  /* ppc:1299-1308 */
+    if (instruction == GC_TRAP_INSTRUCTION) {
+      status = handle_gc_trap(xp, tcr);
+    } else if (IS_UUO(instruction)) {
+      /* All remaining traps are udf UUOs; PPC's separate
+         is_conditional_trap()/handle_trap() path (ppc:1304-1305) folds
+         into handle_uuo because ARM64 trap sites branch around an
+         unconditional udf (see PORT-NOTE 1). */
+      status = handle_uuo(xp, instruction, program_counter, info);
+    } else {
+      status = handle_unimplemented_instruction(xp,instruction,tcr);
+    }
+  } else if (xnum == SIGNAL_FOR_PROCESS_INTERRUPT) {   /* ppc:1309-1313 */
+    tcr->interrupt_pending = 0;
+    /* ARM64-DEVIATION: PPC passed the magic TRI_instruction(TO_GT,nargs,0)
+       word as the "trap" argument so lisp's trap-decode recognizes a
+       process-interrupt (ppc:1311); the ARM64 marker is the
+       take-deferred-interrupt udf. */
+    callback_for_trap(nrs_CMAIN.vcell, xp, 0, DEFERRED_INTERRUPT_INSTRUCTION, 0, 0);
+    status = 0;
+  }
+
+  return status;
 }
 
 void
-disassociate_tcr_from_exception_port(mach_port_t port)
-{
-  kern_return_t kret;
+adjust_exception_pc(ExceptionInformation *xp, int delta)
+{                                 /* ppc-exceptions.c:1318-1322 */
+  xpPC(xp) += (delta >> 2);
+}
 
-  kret = mach_port_set_context(mach_task_self(), port, 0);
-  MACH_CHECK_ERROR("disassociating TCR with exception port", kret);
+/* ppc-exceptions.c:1325-1362 (handle_fpux_binop): NOT ported — it
+   back-scans for PPC FPU major opcodes to classify a trapped FP
+   exception; AArch64 FP exceptions are untrapped (see handle_sigfpe). */
+
+/* Cold-load fatal diagnostic: name the symbol in a trap register and
+   die loudly.  Used when a uuo fires before the lisp error system
+   exists (nrs_CMAIN/nrs_ERRDISP not yet macptrs) -- the alternative is
+   lisp_Debugger, which spins on EOF under a detached boot.
+
+   Layout formulas (OBSERVED in the 16m3 image, cited per doctrine 8):
+   symbol fulltag = fulltag_symbol (7); symbol.pname = [sym + 1]
+   (= tagged - fulltag_symbol + node_size, arm64-arch.lisp symptr:
+   pname is slot 0 after the header).  pname is a misc-tagged string:
+   header at [pname - fulltag_misc], element count = header >> 8
+   (num_subtag_bits), 32-bit code points from [pname - fulltag_misc +
+   node_size]. */
+static void
+uuo_describe_symbol(LispObj sym)
+{
+  if (fulltag_of(sym) == fulltag_symbol) {
+    LispObj pname = *(LispObj *)((sym - fulltag_symbol) + node_size);
+    if (fulltag_of(pname) == fulltag_misc) {
+      natural header = header_of(pname);
+      natural len = header >> num_subtag_bits;
+      unsigned *chars = (unsigned *)((pname - fulltag_misc) + node_size);
+      natural i;
+      fprintf(dbgout, " symbol ");
+      for (i = 0; (i < len) && (i < 256); i++) {
+        unsigned c = chars[i];
+        fputc(((c >= 0x20) && (c < 0x7f)) ? (int)c : '?', dbgout);
+      }
+    } else {
+      fprintf(dbgout, " symbol with unreadable pname (0x%lx)",
+              (unsigned long)pname);
+    }
+  } else {
+    fprintf(dbgout, " non-symbol value 0x%lx", (unsigned long)sym);
+  }
+}
+
+/* Caller context (boot-16m5b): when the named symbol is %ERR-DISP the
+   interesting fact is the ERROR being signalled, not the udf itself —
+   .SPksignalerr jumps through the %err-disp fcell with the errnum in
+   arg_z and the culprit lr.  Dump the call frame so each boot names
+   its own wall (register names per Matt's arm64 map). */
+static void
+cold_load_dump_frame(ExceptionInformation *xp)
+{
+  fprintf(dbgout,
+          "  lr 0x%lx  nargs 0x%lx  vsp 0x%lx  tsp 0x%lx  sp 0x%lx\n"
+          "  imm0-2 0x%lx 0x%lx 0x%lx\n"
+          "  arg_w..z(x8-11) 0x%lx 0x%lx 0x%lx 0x%lx  fn(x7) 0x%lx\n"
+          "  temp0-5(x12-17) 0x%lx 0x%lx 0x%lx 0x%lx 0x%lx 0x%lx\n",
+          (unsigned long)xpGPR(xp, 30), (unsigned long)xpGPR(xp, 6),
+          (unsigned long)xpGPR(xp, 25), (unsigned long)xpGPR(xp, 24),
+          (unsigned long)xpSP(xp),
+          (unsigned long)xpGPR(xp, 0), (unsigned long)xpGPR(xp, 1),
+          (unsigned long)xpGPR(xp, 2),
+          (unsigned long)xpGPR(xp, 8), (unsigned long)xpGPR(xp, 9),
+          (unsigned long)xpGPR(xp, 10), (unsigned long)xpGPR(xp, 11),
+          (unsigned long)xpGPR(xp, 7),
+          (unsigned long)xpGPR(xp, 12), (unsigned long)xpGPR(xp, 13),
+          (unsigned long)xpGPR(xp, 14), (unsigned long)xpGPR(xp, 15),
+          (unsigned long)xpGPR(xp, 16), (unsigned long)xpGPR(xp, 17));
+  fflush(dbgout);
+}
+
+static OSStatus
+uuo_cold_load_fatal(ExceptionInformation *xp, pc where, opcode the_uuo,
+                    const char *what, unsigned gpr)
+{
+  fprintf(dbgout, "\nFATAL (cold load, no lisp error system): %s --", what);
+  uuo_describe_symbol(xpGPR(xp, gpr));
+  fprintf(dbgout, "\n  at pc 0x%lx, uuo 0x%08x, x%u = 0x%lx\n",
+          (unsigned long)(natural)where, the_uuo, gpr,
+          (unsigned long)xpGPR(xp, gpr));
+  cold_load_dump_frame(xp);
+  _exit(157);
+  return -1;                      /* not reached */
+}
+
+/* Protection-violation flavor of the cold-load fatal (16m5o): before this,
+   an unhandled SEGV during cold load called back into a lisp error system
+   that doesn't exist yet, and the callback's own fault made a silent
+   recursive-signal 100%-CPU spin — every such wall cost a gdb session to
+   even NAME.  Same routing rule as handle_uuo: if cmain isn't a real
+   macptr yet, die loudly on dbgout instead of calling back. */
+static OSStatus
+pv_cold_load_fatal(ExceptionInformation *xp, BytePtr addr, Boolean is_write)
+{
+  fprintf(dbgout,
+          "\nFATAL (cold load, no lisp error system): unhandled %s fault\n"
+          "  at pc 0x%lx, fault address 0x%lx\n",
+          is_write ? "write" : "read",
+          (unsigned long)(natural)xpPC(xp), (unsigned long)(natural)addr);
+  cold_load_dump_frame(xp);
+  _exit(157);
+  return -1;                      /* not reached */
+}
+
+/*
+  UUO dispatch.  Combines ppc-exceptions.c's handle_uuo (:1364-1446)
+  and the unconditional-trap semantics of handle_trap (:1552-1673),
+  since every ARM64 trap is a udf UUO (PORT-NOTE 1).
+
+  Callback routing follows PPC:
+   - errnum-style errors → %err-disp (handle_error → nrs_ERRDISP), as
+     PPC handle_uuo's UUO_INTERR default case (ppc:1415-1417).
+   - register/tag/argument-count decode left to lisp → cmain with the
+     raw trap word, as PPC handle_trap's cmain case (ppc:1657-1670).
+  Any path that would call back into lisp before the error system
+  exists routes to uuo_cold_load_fatal instead (named-symbol print +
+  loud exit) -- the boot-bringup diagnosis loop reads dbgout.
+*/
+OSStatus
+handle_uuo(ExceptionInformation *xp, opcode the_uuo, pc where, siginfo_t *info)
+{
+  unsigned imm16 = UUO_IMM16(the_uuo);
+  unsigned format = UUO_FORMAT(imm16);
+  LispObj cmain = nrs_CMAIN.vcell;              /* ppc:1558 */
+  TCR *tcr = TCR_FROM_TSD(xpGPR(xp, rcontext)); /* ppc:1559 */
+  Boolean cmain_is_macptr =
+    ((fulltag_of(cmain) == fulltag_misc) &&
+     (header_subtag(header_of(cmain)) == subtag_macptr)); /* ppc:1657-1658 */
+
+  OSStatus status = -1;
+
+  int bump = 4;                   /* ppc:1377 */
+
+  switch (format) {
+
+  case uuo_format_unary: {
+    unsigned gpr  = UUO_UNARY_GPR(imm16);
+    unsigned uinfo = UUO_UNARY_INFO(imm16);
+
+    switch (uinfo) {
+    case uuo_unary_not_callable:
+      /* funcall target not a function/symbol -> fixed errnum. */
+      status = handle_error(xp, error_cant_call, gpr, 0, where);
+      if (status) {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "called object not callable", gpr);
+      }
+      break;
+
+    case uuo_unary_apply_macro:
+      /* Funcalled a symbol naming a macro/special operator: the fcell's
+         2-element simple-vector was jumped through (slot 0 = %macro-code%,
+         whose single instruction is this UUO).  gpr = fname.  Lisp turns
+         it into $XNOTFUN (call-special-operator-or-macro, a subclass of
+         undefined-function) with the argument list from the frame. */
+      status = handle_error(xp, error_apply_macro_or_special, gpr, 0, where);
+      if (status) {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "funcalled a macro or special-operator "
+                                     "name", gpr);
+      }
+      break;
+
+    case uuo_unary_no_throw_tag:
+      status = handle_error(xp, error_throw_tag_missing, gpr, 0, where);
+      if (status) {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "throw tag missing", gpr);
+      }
+      break;
+
+    case uuo_unary_udf:
+    case uuo_unary_udf_call:
+      /* Undefined function referenced/called; gpr = fname (errors.s:
+         error_udf=1, error_udf_call=2; PPC routes both to %err-disp). */
+      status = handle_error(xp,
+                            (uinfo == uuo_unary_udf) ? error_udf
+                                                     : error_udf_call,
+                            gpr, 0, where);
+      if (status) {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "undefined function", gpr);
+      } else if (uinfo == uuo_unary_udf_call) {
+        /* If lisp's returned from an undefined-function call, it's put
+           a code vector in the xp's PC.  Don't advance the PC
+           (ppc:1424-1429; lisp side = arm64-error-signal.lisp
+           handle-udf-call). */
+        bump = 0;
+      }
+      break;
+
+    case uuo_unary_tlb_too_small:
+      /* ppc:1645-1655: twlle tlb-limit,index -> extend the tcr's tlb.
+         ARM64-DEVIATION: the udf encodes only the INDEX register; the
+         subprim reloads tcr.tlb_limit itself (arm-exceptions.c:
+         1160-1166 does the same). */
+      if (extend_tcr_tlb(tcr, xp, gpr)) {
+        status = 0;
+        break;
+      }
+      status = -1;
+      break;
+
+    case uuo_unary_unbound:
+      /* PPC signalled unbound via a conditional trap on unbound_marker
+         decoded by lisp (cmain path, ppc:1657-1670); gpr = register
+         holding the symbol. */
+      if (cmain_is_macptr) {
+        callback_for_trap(cmain, xp, where, (natural) the_uuo, 0, 0);
+        status = 0;
+      } else {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "unbound variable", gpr);
+      }
+      break;
+
+    case uuo_unary_slot_unbound: {
+      /* Three-register error (doc/porting/arm64.md "Errors that need
+         three registers").  The primary UUO names the SLOT VECTOR; the
+         companion at where[1] is a binary uuo_extra_registers carrying
+         (index, dest).  Lisp needs all three: the slot vector and index
+         to find the slot definition, and dest because CL's SLOT-UNBOUND
+         may RETURN a value that becomes the slot reference's value.  So
+         hand lisp BOTH words and resume past BOTH instructions -- the
+         companion is data and is never executed. */
+      opcode companion = where[1];
+      unsigned cimm16 = UUO_IMM16(companion);
+
+      if ((!IS_UUO(companion)) ||
+          (UUO_FORMAT(cimm16) != uuo_format_binary) ||
+          (UUO_BINARY_INFO(cimm16) != uuo_binary_two_registers)) {
+        /* The emit site must place the companion adjacently; without it
+           index and dest are unrecoverable, so this is never a
+           continuable situation. */
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "slot-unbound uuo with no "
+                                     "uuo_extra_registers companion", gpr);
+        bump = 0;
+        break;
+      }
+      if (cmain_is_macptr) {
+        callback_for_trap(cmain, xp, where, (natural) the_uuo,
+                          (natural) companion, 0);
+        status = 0;
+        bump = 8;               /* primary + companion */
+      } else {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "unbound slot", gpr);
+      }
+      break;
+    }
+
+    default:
+      status = -1;
+      bump = 0;
+      break;
+    }
+    break;
+  }
+
+  case uuo_format_binary:
+    /* ra = one operand reg, rb = the other; lisp decodes reg pair +
+       info from the raw trap word (PPC's twlge index,limit traps,
+       ppc:1657-1670).  All assigned infos are error reports, so the
+       cmain route covers 0-6; 7 (two_registers) extends a PRECEDING
+       uuo and should never fault on its own. */
+    if (UUO_BINARY_INFO(imm16) != uuo_binary_two_registers) {
+      if (cmain_is_macptr) {
+        callback_for_trap(cmain, xp, where, (natural) the_uuo, 0, 0);
+        status = 0;
+      } else {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "binary trap (see uuo bits 15:12)",
+                                     UUO_BINARY_RA(imm16));
+      }
+    } else {
+      status = -1;
+      bump = 0;
+    }
+    break;
+
+  case uuo_format_wrong_type:
+    /* reg in 6:2, continuable bit 7, expected xtype in 15:8; lisp
+       decodes reg + expected type from the raw trap word (PPC's twnei
+       tag traps, ppc:1657-1670). */
+    if (cmain_is_macptr) {
+      callback_for_trap(cmain, xp, where, (natural) the_uuo, 0, 0);
+      status = 0;
+    } else {
+      status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                   "wrong type (expected xtype in uuo bits 15:8)",
+                                   UUO_WT_GPR(imm16));
+    }
+    break;
+
+  case uuo_format_misc: {
+    unsigned mi = UUO_MISC_INFO(imm16);
+
+    if (mi == 0) {
+      /* udf #0 is the code-vector start sentinel (arm64-uuo.s:20-22);
+         executing one is never legitimate.  Loud failure. */
+      status = -1;
+      bump = 0;
+      break;
+    }
+
+    if (UUO_MISC_IS_INTERR(mi)) {
+      /* PROPOSED uuo_interr extension (arm64-globals-proposed.s;
+         ratify): PPC uuo_interr(errnum, reg), ppc:1387-1419. */
+      unsigned errnum = UUO_INTERR_ERRNUM(mi);
+      unsigned gpr = UUO_INTERR_GPR(mi);
+
+      if ((errnum == error_stack_overflow) && (gpr == Rsp)) {
+        /* Failed control-stack overflow check (spentry-C savecontext*
+           emits uuo_interr error_stack_overflow, sp).  PPC
+           handle_trap's "trllt RA==sp" yellow-zone logic,
+           ppc:1564-1629, ported whole. */
+        area
+          *CS_area = tcr->cs_area,
+          *VS_area = tcr->vs_area;
+
+        natural
+          current_SP = xpSP(xp),        /* ppc:1599 xpGPR(sp) */
+          current_VSP = xpGPR(xp,vsp);  /* ppc:1600 */
+
+        if (current_SP  < (natural) (CS_area->hardlimit)) { /* ppc:1602 */
+          /* If we are not in soft overflow mode yet, assume that the
+             user has set the soft overflow size very small and try to
+             continue on another thread before throwing to toplevel */
+          if ((tcr->cs_limit == CS_OVERFLOW_FORCE_LIMIT)) {
+            reset_lisp_process(xp);
+          }
+        } else {
+          if (tcr->cs_limit == CS_OVERFLOW_FORCE_LIMIT) { /* ppc:1610 */
+            /* If the control stack pointer is at least 4K away from its
+               soft limit and the value stack pointer is at least 4K away
+               from its soft limit, stop trapping.  Else keep trapping. */
+            if ((current_SP > (natural) ((CS_area->softlimit)+4096)) &&
+                (current_VSP > (natural) ((VS_area->softlimit)+4096))) {
+              protected_area_ptr vs_soft = VS_area->softprot;
+              if (vs_soft->nprot == 0) {
+                protect_area(vs_soft);
+              }
+              tcr->cs_limit = ptr_to_lispobj(CS_area->softlimit);
+            }
+          } else {
+            tcr->cs_limit = ptr_to_lispobj(CS_area->hardlimit); /* ppc:1623 */
+            signal_stack_soft_overflow(xp, Rsp);
+          }
+        }
+        status = 0;                     /* ppc:1628-1629 */
+        break;
+      }
+
+      {
+        /* Kernel-service + generic errnum dispatch, PPC handle_uuo
+           UUO_INTERR (ppc:1387-1419). */
+        TCR *target = (TCR *)xpGPR(xp,arg_z);  /* ppc:1389 */
+        status = 0;
+        switch (errnum) {
+        case error_propagate_suspend:   /* ppc:1392-1393 */
+          break;
+        case error_interrupt:           /* ppc:1394-1396 */
+          xpGPR(xp,imm0) = (LispObj) raise_thread_interrupt(target);
+          break;
+        case error_suspend:             /* ppc:1397-1399 */
+          xpGPR(xp,imm0) = (LispObj) lisp_suspend_tcr(target);
+          break;
+        case error_suspend_all:         /* ppc:1400-1402 */
+          lisp_suspend_other_threads();
+          break;
+        case error_resume:              /* ppc:1403-1405 */
+          xpGPR(xp,imm0) = (LispObj) lisp_resume_tcr(target);
+          break;
+        case error_resume_all:          /* ppc:1406-1408 */
+          lisp_resume_other_threads();
+          break;
+        case error_kill:                /* ppc:1409-1411 */
+          xpGPR(xp,imm0) = (LispObj)kill_tcr(target);
+          break;
+        case error_allocate_list:       /* ppc:1412-1414 */
+          allocate_list(xp,get_tcr(true));
+          break;
+        default:                        /* ppc:1415-1417 */
+          status = handle_error(xp, errnum, gpr, 0,  where);
+          break;
+        }
+      }
+      break;
+    }
+
+    switch (mi) {
+      /* misc 0 (alloc trap) and misc 1 (GC trap) are dispatched by
+         PMCL_exception_handler before we get here, as on PPC
+         (ppc:1292/1300). */
+
+    case uuo_misc_debug_trap:
+      /* ppc:1640-1644 QUIET_LISP_BREAK_INSTRUCTION; same shape as
+         arm-exceptions.c:1177-1182. */
+      adjust_exception_pc(xp, bump);
+      bump = 0;
+      lisp_Debugger(xp, info, debug_entry_dbg, false, "Lisp Breakpoint");
+      status = 0;
+      break;
+
+    case uuo_misc_interrupt_now:
+      /* ppc:1659-1668: the explicit take-deferred-interrupt trap:
+         reset interrupt level/pending, then tell cmain. */
+      if (cmain_is_macptr) {
+        TCR_INTERRUPT_LEVEL(tcr) = 0;
+        tcr->interrupt_pending = 0;
+        callback_for_trap(cmain, xp, where, (natural) the_uuo, 0, 0);
+        status = 0;
+      }
+      break;
+
+    case uuo_misc_suspend_now:
+      /* ppc:1391-1393 (error_propagate_suspend does nothing but
+         resume). */
+      status = 0;
+      break;
+
+    case uuo_misc_too_few:
+    case uuo_misc_too_many:
+    case uuo_misc_wrong_number:
+      /* nargs checks: lisp decodes the trap word via cmain, as with
+         PPC conditional nargs traps (ppc:1657-1670). */
+      if (cmain_is_macptr) {
+        callback_for_trap(cmain, xp, where, (natural) the_uuo, 0, 0);
+        status = 0;
+      } else {
+        status = uuo_cold_load_fatal(xp, where, the_uuo,
+                                     "wrong argument count", nargs);
+      }
+      break;
+
+    default:
+      status = -1;
+      bump = 0;
+      break;
+    }
+    break;
+  }
+  }
+
+  if ((!status) && bump) {        /* ppc:1442-1444 */
+    adjust_exception_pc(xp, bump);
+  }
+  return status;
+}
+
+natural
+register_codevector_contains_pc (natural lisp_function, pc where)
+{                                 /* ppc-exceptions.c:1448-1463 */
+  natural code_vector, size;
+
+  /* A function is an ordinary miscobj (fulltag_misc + subtag_function;
+     fulltag_function removed, patch 0055); codevector is slot 0
+     (deref(fn,1)) as on PPC64. */
+  if ((fulltag_of(lisp_function) == fulltag_misc) &&
+      (header_subtag(header_of(lisp_function)) == subtag_function)) {
+    code_vector = deref(lisp_function, 1);
+    size = header_element_count(header_of(code_vector)) << 2;
+    if ((untag(code_vector) < (natural)where) &&
+        ((natural)where < (code_vector + size)))
+      return(code_vector);
+  }
+
+  return(0);
+}
+
+/* Callback to lisp to handle a trap. Need to translate the
+   PC (where) into one of two forms of pairs:
+
+   1. If PC is in fn or nfn's code vector, use the register number
+      of fn or nfn and the index into that function's code vector.
+   2. Otherwise use 0 and the pc itself
+   (ppc-exceptions.c:1465-1489)
+*/
+void
+callback_for_trap (LispObj callback_macptr, ExceptionInformation *xp, pc where,
+                   natural arg1, natural arg2, natural arg3)
+{
+  natural code_vector = register_codevector_contains_pc(xpGPR(xp, fn), where);
+  unsigned register_number = fn;
+  natural index = (natural)where;
+
+  if (code_vector == 0) {
+    register_number = nfn;
+    code_vector = register_codevector_contains_pc(xpGPR(xp, nfn), where);
+  }
+  if (code_vector == 0)
+    register_number = 0;
+  else
+    /* misc_data_offset = -4 relative to the tagged code vector in
+       Matt's layout (arm64-constants.h:143-144: fulltag_misc 12,
+       data = header + node_size). */
+    index = ((natural)where - (code_vector + misc_data_offset)) >> 2;
+  callback_to_lisp(callback_macptr, xp, register_number, index, arg1, arg2, arg3);
 }
 
 void
-fatal_mach_error(char *format, ...)
-{
-  va_list args;
-  char s[512];
+callback_to_lisp (LispObj callback_macptr, ExceptionInformation *xp,
+                  natural arg1, natural arg2, natural arg3, natural arg4, natural arg5)
+{                                 /* ppc-exceptions.c:1491-1535 */
+  natural  callback_ptr;
+  area *a;
 
-  va_start(args, format);
-  vsnprintf(s, sizeof(s),format, args);
-  va_end(args);
+  TCR *tcr = TCR_FROM_TSD(xpGPR(xp, rcontext));
 
-  Fatal("Mach error", s);
+  /* Put the active stack pointer where .SPcallback expects it */
+  a = tcr->cs_area;
+  a->active = (BytePtr) ptr_from_lispobj(xpSP(xp)); /* ppc:1502 xpGPR(sp) */
+
+  /* Copy globals from the exception frame to tcr */
+  tcr->save_allocptr = (void *)ptr_from_lispobj(xpGPR(xp, allocptr));
+  tcr->save_allocbase = (void *)ptr_from_lispobj(xpGPR(xp, allocbase));
+  tcr->save_vsp = (LispObj*) ptr_from_lispobj(xpGPR(xp, vsp));
+  tcr->save_tsp = (LispObj*) ptr_from_lispobj(xpGPR(xp, tsp));
+
+
+
+  /* Call back.
+     Lisp will handle trampolining through some code that
+     will push lr/fn & pc/nfn stack frames for backtrace.
+  */
+  callback_ptr = ((macptr *)ptr_from_lispobj(untag(callback_macptr)))->address;
+  UNLOCK(lisp_global(EXCEPTION_LOCK), tcr);
+  ((void (*)())callback_ptr) (xp, arg1, arg2, arg3, arg4, arg5);
+  LOCK(lisp_global(EXCEPTION_LOCK), tcr);
+
+
+
+  /* Copy GC registers back into exception frame */
+  xpGPR(xp, allocbase) = (LispObj) ptr_to_lispobj(tcr->save_allocbase);
+  xpGPR(xp, allocptr) = (LispObj) ptr_to_lispobj(tcr->save_allocptr);
 }
-#endif /* DARWIN */
+
+area *
+allocate_no_stack (natural size)
+{                                 /* ppc-exceptions.c:1537-1545 */
+#ifdef SUPPORT_PRAGMA_UNUSED
+#pragma unused(size)
+#endif
+
+  return (area *) NULL;
+}
+
+
+/* ppc-exceptions.c:1552-1673 (handle_trap): folded into handle_uuo
+   above — the conditional-trap decode (:1591-1655) has no ARM64 analog
+   (trap sites branch around an unconditional udf), the cstack
+   yellow-zone logic lives in handle_uuo's error_stack_overflow case,
+   the tlb case in uuo_unary_tlb_too_small, the LISP_BREAK cases in
+   uuo_misc_debug_trap, and the cmain fallback in the raw-uuo
+   callback branches.
+   ppc-exceptions.c:1676-1692 (scan_for_instr) and :1701-1734
+   (is_conditional_trap): PPC-ISA-specific helpers with no callers
+   here; not ported. */
+
+
+void non_fatal_error( char *msg )
+{                                 /* ppc-exceptions.c:1695-1699 */
+  fprintf( dbgout, "Non-fatal error: %s.\n", msg );
+  fflush( dbgout );
+}
+
+OSStatus
+handle_error(ExceptionInformation *xp, unsigned errnum, unsigned rb, unsigned continuable, pc where)
+{                                 /* ppc-exceptions.c:1736-1749 */
+  LispObj   errdisp = nrs_ERRDISP.vcell;
+
+  if ((fulltag_of(errdisp) == fulltag_misc) &&
+      (header_subtag(header_of(errdisp)) == subtag_macptr)) {
+    /* errdisp is a macptr, we can call back to lisp */
+    callback_for_trap(errdisp, xp, where, errnum, rb, continuable);
+    return(0);
+    }
+
+  return(-1);
+}
+
+
+/* ===========================================================================
+ * Exception-lock plumbing, signal handlers, pc_luser_xp, installation.
+ * ppc-exceptions.c:1758-2333 (fns 56-70 of the inventory), completed by the
+ * lead after the drafting agent's session ended at fn 55.
+ * ===========================================================================
+ */
+
+int
+prepare_to_wait_for_exception_lock(TCR *tcr, ExceptionInformation *context)
+{                                 /* ppc-exceptions.c:1758-1769, verbatim */
+  int old_valence = tcr->valence;
+
+  tcr->pending_exception_context = context;
+  tcr->valence = TCR_STATE_EXCEPTION_WAIT;
+
+  ALLOW_EXCEPTIONS(context);      /* lisp-exceptions.h:100-108 */
+  return old_valence;
+}
+
+void
+wait_for_exception_lock_in_handler(TCR *tcr,
+                                   ExceptionInformation *context,
+                                   xframe_list *xf)
+{                                 /* ppc-exceptions.c:1771-1786, verbatim */
+  LOCK(lisp_global(EXCEPTION_LOCK), tcr);
+  xf->curr = context;
+  xf->prev = tcr->xframe;
+  tcr->xframe = xf;
+  tcr->pending_exception_context = NULL;
+  tcr->valence = TCR_STATE_FOREIGN;
+}
+
+void
+unlock_exception_lock_in_handler(TCR *tcr)
+{                                 /* ppc-exceptions.c:1788-1797, verbatim */
+  tcr->pending_exception_context = tcr->xframe->curr;
+  tcr->xframe = tcr->xframe->prev;
+  tcr->valence = TCR_STATE_EXCEPTION_RETURN;
+  UNLOCK(lisp_global(EXCEPTION_LOCK), tcr);
+}
+
+/* If an interrupt is pending on exception exit, try to ensure that the
+   thread sees it as soon as it's able to run. */
+void
+raise_pending_interrupt(TCR *tcr)
+{                                 /* ppc-exceptions.c:1803-1809, verbatim */
+  if (TCR_INTERRUPT_LEVEL(tcr) > 0) {
+    pthread_kill((pthread_t)ptr_from_lispobj(tcr->osid),
+                 SIGNAL_FOR_PROCESS_INTERRUPT);
+  }
+}
+
+void
+exit_signal_handler(TCR *tcr, int old_valence, natural old_last_lisp_frame)
+{                                 /* ppc-exceptions.c:1811-1820 + the boundary */
+  sigset_t mask;
+  sigfillset(&mask);
+
+  pthread_sigmask(SIG_SETMASK, &mask, NULL);
+  tcr->valence = old_valence;
+  tcr->pending_exception_context = NULL;
+  /* ARM64-DEVIATION (16m41): restore the lisp<->foreign cstack boundary the
+     handler moved.  PPC has no such field because its cstack walk is a
+     backlink chain (see normalize_tcr); on a marker/linear walk the boundary
+     is the only thing that keeps a foreign-valence thread's walk out of C
+     frames.  Same shape as the ARM-family handler exit. */
+  tcr->last_lisp_frame = old_last_lisp_frame;
+}
+
+void
+signal_handler(int signum, siginfo_t *info, ExceptionInformation *context)
+{                                 /* ppc-exceptions.c:1823-1866 */
+  TCR *tcr;
+  int old_valence;
+  natural old_last_lisp_frame;
+  xframe_list xframe_link;
+
+  tcr = (TCR *) get_interrupt_tcr(false);
+
+  /* The signal handler's entered with all signals (notably the
+     thread_suspend signal) blocked.  Don't allow any other signals
+     (notably the thread_suspend signal) to preempt us until we've
+     set the TCR's xframe slot to include the current exception
+     context.  (ppc:1832-1838.)
+
+     16m41 CORRECTION: the note here said ARM32's tcr->last_lisp_frame save
+     "does NOT port -- Matt's tcr has no last_lisp_frame field".  That was
+     false at this pin (arm64-constants.h:470 asm / :531 C), and dropping the
+     save left the field permanently 0, which is what normalize_tcr's ff-call
+     branch then had nothing to read.  While this handler runs, the thread's
+     lisp-owned cstack ends at the faulting SP, so that is the boundary; the
+     old value is restored in exit_signal_handler. */
+  old_last_lisp_frame = tcr->last_lisp_frame;
+  tcr->last_lisp_frame = (natural)ptr_to_lispobj(xpSP(context));
+
+  old_valence = prepare_to_wait_for_exception_lock(tcr, context);
+
+  if (tcr->flags & (1 << TCR_FLAG_BIT_PENDING_SUSPEND)) {
+    CLR_TCR_FLAG(tcr, TCR_FLAG_BIT_PENDING_SUSPEND);
+    pthread_kill(pthread_self(), thread_suspend_signal);
+  }
+
+  wait_for_exception_lock_in_handler(tcr, context, &xframe_link);
+  if ((noErr != PMCL_exception_handler(signum, context, tcr, info,
+                                       old_valence))) {
+    char msg[512];
+    /* 16m40: NAME THE INSTRUCTION, not just its address.
+       "Unhandled exception 5 at <pc>" is a SIGILL/SIGTRAP whose word this
+       handler already looked at and could not decode -- so the one fact
+       that identifies the bug is the word itself, and it was the one fact
+       the message omitted.  16m39/16m40 each spent a boot recovering it by
+       hand.  That trick only works while the pc is in the IMAGE, which is
+       mapped at a fixed address; for code the RESIDENT compiler generated
+       the pc is in the dynamic heap and differs every run, so there is no
+       second boot that can read it.  Hence: print it here.
+       Decoded per arm64-uuo.s: a udf is `#imm16' with the top 16 bits
+       zero, format in imm16 1:0; a brk is 0xd42xxxx0 and is NOT a uuo on
+       this architecture (arm64-uuo.s:11) -- seeing one means a placeholder
+       trap reached the kernel. */
+    opcode faulting = 0;
+    char insn_desc[160];
+    insn_desc[0] = 0;
+    if ((signum == SIGILL) || (signum == SIGTRAP)) {
+      faulting = *(xpPC(context));
+      if (IS_UUO(faulting)) {
+        unsigned imm16 = UUO_IMM16(faulting);
+        snprintf(insn_desc, sizeof(insn_desc),
+                 ", insn 0x%08x = udf #0x%x (uuo format %d, UNDECODED)",
+                 faulting, imm16, UUO_FORMAT(imm16));
+      } else if ((faulting & 0xffe0001f) == 0xd4200000) {
+        snprintf(insn_desc, sizeof(insn_desc),
+                 ", insn 0x%08x = brk #0x%x -- NOT a uuo on arm64; this is a "
+                 "PLACEHOLDER trap that should be a udf",
+                 faulting, (faulting >> 5) & 0xffff);
+      } else {
+        snprintf(insn_desc, sizeof(insn_desc),
+                 ", insn 0x%08x (neither udf nor brk)", faulting);
+      }
+    }
+    snprintf(msg, sizeof(msg),
+             "Unhandled exception %d at 0x%lx%s, context->regs at #x%lx",
+             signum, (natural)xpPC(context), insn_desc,
+             (natural)xpGPRvector(context));
+    if (lisp_Debugger(context, info, signum, false, msg)) {
+      SET_TCR_FLAG(tcr, TCR_FLAG_BIT_PROPAGATE_EXCEPTION);
+    }
+  }
+
+  unlock_exception_lock_in_handler(tcr);
+
+  /* This thread now looks like a thread that was suspended while
+     executing lisp code.  If some other thread gets the exception
+     lock and GCs, the context (this thread's suspend_context) will
+     be updated.  (ppc:1858-1863) */
+  exit_signal_handler(tcr, old_valence, old_last_lisp_frame);
+  raise_pending_interrupt(tcr);
+}
+
+/*
+  If it looks like we're in the middle of an atomic operation, make
+  it seem as if that operation is either complete or hasn't started
+  yet.  (ppc-exceptions.c:1868-1897 comment; cases (a)/(b)/(c)/(e)
+  below.  PPC case (d) -- stmw to the vsp -- is PPC32-only and does
+  not port.)
+*/
+
+extern opcode
+  egc_rplaca, egc_rplaca_did_store,          /* spentry-D (window half 1) */
+  egc_rplacd, egc_rplacd_did_store, egc_rplacd_end,
+  egc_gvset, egc_gvset_did_store,            /* spentry-B (window half 2) */
+  egc_set_hash_key, egc_set_hash_key_did_store,
+  egc_store_node_conditional, egc_store_node_conditional_test,
+  egc_set_hash_key_conditional, egc_set_hash_key_conditional_test,
+  egc_write_barrier_end;
+
+/* The tsp-frame "raw" mark: `str tsp, [tsp, #tsp_frame.type]' (type == 8;
+   spentry-A tsp_frame equates / arm64-macros.s TSP frame discipline).
+   STR (unsigned offset, 64-bit): 0xF9000000 | (8>>3)<<10 | tsp<<5 | tsp,
+   tsp = x24 (arm64-asm.lisp:215). */
+#define MARK_TSP_FRAME_INSTRUCTION 0xF9000718
+
+/* Marker lisp-frame creation + slot stores (the drafts' canonical build
+   order: sub sp,sp,#32; str marker@0; str vsp@8; str fn@16; str lr@24 --
+   spentry-A misc_alloc_init:661-666 et al.).
+   SUB sp,sp,#32: 0xD1000000 | (32<<10) | (31<<5) | 31 = 0xD10083FF.
+   STR Xt,[sp,#imm]: 0xF9000000 | (imm>>3)<<10 | (31<<5) | Rt. */
+#define CREATE_LISP_FRAME_INSTRUCTION 0xD10083FF
+#define IS_STR_TO_SP(i) (((i) & 0xFFC003E0) == 0xF90003E0)
+#define STR_TO_SP_DISP(i) ((((i) >> 10) & 0xfff) << 3)
+
+void
+pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
+{                                 /* ppc-exceptions.c:1900-2130 */
+  pc program_counter = xpPC(xp);
+  opcode instr = *program_counter;
+  lisp_frame *frame = (lisp_frame *)ptr_from_lispobj(xpSP(xp));
+  LispObj cur_allocptr = xpGPR(xp, allocptr);
+  int allocptr_tag = fulltag_of(cur_allocptr);
+
+  /* (e) EGC write-barrier subprims.  ARM64-DEVIATION (window shape only):
+     PPC brackets ALL barrier subprims in one contiguous
+     [egc_write_barrier_start, egc_write_barrier_end) region; here the
+     family is split across spentry-D (rplaca/rplacd) and spentry-B
+     (gvset/set-hash-key/conditionals), so we test the two per-file
+     windows.  Case logic and memoization are ppc:1911-1979 verbatim.
+     Conditional-store "did it store?" test: PPC reads CR0.EQ
+     (xpCCR & 0x20000000); the drafts' ll/sc loops leave the stxr status
+     in w17 (= temp5 after the 01d73c3 renumber; the uniform status register):
+     status != 0 means not-stored/will-retry. */
+  if (((program_counter >= &egc_rplaca) &&
+       (program_counter < &egc_rplacd_end)) ||
+      ((program_counter >= &egc_gvset) &&
+       (program_counter < &egc_write_barrier_end))) {
+    LispObj *ea = 0, val = 0, root = 0;
+    bitvector refbits = (bitvector)(lisp_global(REFBITS));
+    Boolean need_check_memo = true, need_memoize_root = false;
+
+    if (program_counter >= &egc_set_hash_key_conditional) {
+      if ((program_counter < &egc_set_hash_key_conditional_test) ||
+          ((program_counter == &egc_set_hash_key_conditional_test) &&
+           ((xpGPR(xp, temp5) & 0xffffffff) != 0))) {
+        return;
+      }
+      root = xpGPR(xp, arg_x);
+      ea = (LispObj *)(root + unbox_fixnum(xpGPR(xp, temp0)));
+      need_memoize_root = true;
+    } else if (program_counter >= &egc_store_node_conditional) {
+      if ((program_counter < &egc_store_node_conditional_test) ||
+          ((program_counter == &egc_store_node_conditional_test) &&
+           ((xpGPR(xp, temp5) & 0xffffffff) != 0))) {
+        /* The conditional store either hasn't been attempted yet, or
+           has failed.  No need to adjust the PC, or do memoization. */
+        return;
+      }
+      ea = (LispObj *)(xpGPR(xp, arg_x) + unbox_fixnum(xpGPR(xp, temp0)));
+      xpGPR(xp, arg_z) = t_value;
+    } else if (program_counter >= &egc_set_hash_key) {
+      if (program_counter < &egc_set_hash_key_did_store) {
+        return;
+      }
+      root = xpGPR(xp, arg_x);
+      val = xpGPR(xp, arg_z);
+      ea = (LispObj *)(root + xpGPR(xp, arg_y) + misc_data_offset);
+      need_memoize_root = true;
+    } else if (program_counter >= &egc_gvset) {
+      if (program_counter < &egc_gvset_did_store) {
+        return;
+      }
+      ea = (LispObj *)(xpGPR(xp, arg_x) + xpGPR(xp, arg_y) + misc_data_offset);
+      val = xpGPR(xp, arg_z);
+    } else if (program_counter >= &egc_rplacd) {
+      if (program_counter < &egc_rplacd_did_store) {
+        return;
+      }
+      ea = (LispObj *)untag(xpGPR(xp, arg_y));       /* cdr @ untag+0 */
+      val = xpGPR(xp, arg_z);
+    } else {                      /* egc_rplaca */
+      if (program_counter < &egc_rplaca_did_store) {
+        return;
+      }
+      ea = ((LispObj *)untag(xpGPR(xp, arg_y))) + 1; /* car @ untag+8 */
+      val = xpGPR(xp, arg_z);
+    }
+    if (need_check_memo) {        /* ppc:1964-1976 verbatim */
+      natural bitnumber = area_dnode(ea, lisp_global(REF_BASE));
+      if ((bitnumber < lisp_global(OLDSPACE_DNODE_COUNT)) &&
+          ((LispObj)ea < val)) {
+        atomic_set_bit(refbits, bitnumber);
+        atomic_set_bit(global_refidx, bitnumber >> 8);
+        if (need_memoize_root) {
+          bitnumber = area_dnode(root, lisp_global(REF_BASE));
+          atomic_set_bit(refbits, bitnumber);
+          atomic_set_bit(global_refidx, bitnumber >> 8);
+        }
+      }
+    }
+    /* Barrier subprims are leaves: returning to LR skips the remaining
+       asm barrier (the memoization just happened here).  ppc:1977 */
+    set_xpPC(xp, xpLR(xp));
+    return;
+  }
+
+  /* (b) marking a newly-allocated TSP frame as containing "raw" data.
+     ppc:1983-1990 */
+  if (instr == MARK_TSP_FRAME_INSTRUCTION) {
+    LispObj tsp_val = xpGPR(xp, tsp);
+
+    ((LispObj *)ptr_from_lispobj(tsp_val))[1] = tsp_val;
+    adjust_exception_pc(xp, 4);
+    return;
+  }
+
+  /* (a) storing into a newly-allocated lisp frame on the stack.
+     ppc:1992-2032, re-derived for the marker frame: PPC detects a std
+     to sp with a CREATE_LISP_FRAME (stdu) 1-3 instructions back and
+     zeroes the not-yet-stored slots so the GC never sees garbage in a
+     fresh frame.  The ARM64 marker frame is built sub sp,sp,#32 then
+     marker@0 / savevsp@8 / savefn@16 / savelr@24 in that order
+     (drafts' canonical sequence).  PROPOSED: compiler-emitted frame
+     builds must keep this store order (flagged in the report; ARM32
+     never had this window because its stmdb build was atomic). */
+  if (IS_STR_TO_SP(instr) &&
+      ((program_counter[-1] == CREATE_LISP_FRAME_INSTRUCTION) ||
+       (program_counter[-2] == CREATE_LISP_FRAME_INSTRUCTION) ||
+       (program_counter[-3] == CREATE_LISP_FRAME_INSTRUCTION))) {
+    natural disp = STR_TO_SP_DISP(instr);
+
+    if (disp < lisp_frame_size) {
+      /* Slots at and above `disp' haven't been stored yet: zero them
+         (the interrupted store re-executes on resume).  If even the
+         marker hasn't landed, plant it so the frame is walkable. */
+      if (disp == 0) {
+        frame->marker = lisp_frame_marker;
+      }
+      if (disp <= 8) {
+        frame->savevsp = 0;
+      }
+      if (disp <= 16) {
+        frame->savefn = 0;
+      }
+      frame->savelr = 0;          /* disp <= 24 always true here */
+      return;
+    }
+  }
+
+  /* (c) consing / uvector allocation.  ppc:2034-2094 verbatim (the
+     alloc-sequence decode lives in allocptr_displacement /
+     finish_allocating_* above). */
+  if (allocptr_tag != tag_fixnum) {
+    signed_natural disp = allocptr_displacement(xp);
+
+    if (disp) {
+      /* Being architecturally "at" the alloc trap doesn't tell us
+         whether the thread has committed to taking the trap.  Make the
+         allocptr valid; the interrupt handler undoes this (interrupt
+         case) or the trap is re-taken (GC case).  ppc:2036-2076 */
+      if (alloc_disp) {
+        *alloc_disp = disp;
+        xpGPR(xp, allocptr) += disp;
+      } else {
+        update_bytes_allocated(tcr,
+                               (void *)ptr_from_lispobj(cur_allocptr + disp));
+        xpGPR(xp, allocbase) = VOID_ALLOCPTR;
+        xpGPR(xp, allocptr) = VOID_ALLOCPTR - disp;
+      }
+    } else {
+      /* Already past the alloc trap: finish allocating the object. */
+      if (allocptr_tag == fulltag_cons) {
+        finish_allocating_cons(xp);
+      } else {
+        if (allocptr_tag == fulltag_misc) {
+          finish_allocating_uvector(xp);
+        } else {
+          Bug(xp, "what's being allocated here ?");
+        }
+      }
+      xpGPR(xp, allocptr) = xpGPR(xp, allocbase) = VOID_ALLOCPTR;
+    }
+    return;
+  }
+
+  /* PPC's INIT_CATCH_FRAME partial-init back-out (ppc:2096-2110) is NOT
+     ported yet: the ARM64 catch-frame build sequence (spentry-C
+     build_catch_lisp_frame + catch push) has no settled single
+     detection instruction, and the compiler side doesn't emit catch
+     frames yet.  Risk window = interrupting a thread mid-catch-push;
+     revisit when Matt's vinsns build catch frames (report item).
+     PPC's stmw case (ppc:2112-2123) is PPC32-only; not ported. */
+}
+
+void
+interrupt_handler(int signum, siginfo_t *info, ExceptionInformation *context)
+{                                 /* ppc-exceptions.c:2132-2181 */
+  TCR *tcr = get_interrupt_tcr(false);
+  if (tcr) {
+    if (TCR_INTERRUPT_LEVEL(tcr) < 0) {
+      tcr->interrupt_pending = 1 << fixnumshift;
+    } else {
+      LispObj cmain = nrs_CMAIN.vcell;
+
+      if ((fulltag_of(cmain) == fulltag_misc) &&
+          (header_subtag(header_of(cmain)) == subtag_macptr)) {
+        /* This thread can (allegedly) take an interrupt now.  It's
+           tricky to do that if we're executing foreign code.  If we're
+           unwinding the stack, we also want to defer the interrupt.
+           ppc:2144-2151 */
+        if ((tcr->valence != TCR_STATE_LISP) ||
+            (tcr->unwinding != 0)) {
+          TCR_INTERRUPT_LEVEL(tcr) = (1 << fixnumshift);
+        } else {
+          xframe_list xframe_link;
+          int old_valence;
+          signed_natural disp = 0;
+          /* 16m41: same boundary save/restore as signal_handler. */
+          natural old_last_lisp_frame = tcr->last_lisp_frame;
+
+          tcr->last_lisp_frame = (natural)ptr_to_lispobj(xpSP(context));
+          pc_luser_xp(context, tcr, &disp);
+          old_valence = prepare_to_wait_for_exception_lock(tcr, context);
+          wait_for_exception_lock_in_handler(tcr, context, &xframe_link);
+          PMCL_exception_handler(signum, context, tcr, info, old_valence);
+          if (disp) {
+            xpGPR(context, allocptr) -= disp;
+          }
+          unlock_exception_lock_in_handler(tcr);
+          exit_signal_handler(tcr, old_valence, old_last_lisp_frame);
+        }
+      }
+    }
+  }
+}
+
+void
+install_signal_handler(int signo, void *handler, unsigned flags)
+{                                 /* ppc-exceptions.c:2186-2207, verbatim */
+  struct sigaction sa;
+  int err;
+
+  sa.sa_sigaction = (void *)handler;
+  sigfillset(&sa.sa_mask);
+  sa.sa_flags = SA_SIGINFO;
+
+  if (flags & RESTART_SYSCALLS)
+    sa.sa_flags |= SA_RESTART;
+  if (flags & RESERVE_FOR_LISP) {
+    extern sigset_t user_signals_reserved;
+    sigaddset(&user_signals_reserved, signo);
+  }
+
+  err = sigaction(signo, &sa, NULL);
+  if (err) {
+    perror("sigaction");
+    exit(1);
+  }
+}
+
+void
+install_pmcl_exception_handlers()
+{                                 /* ppc-exceptions.c:2210-2226 */
+  extern int no_sigtrap;
+  /* udf raises SIGILL on aarch64-linux; brk (the drafts' remaining
+     placeholders + the debugger entry) raises SIGTRAP. */
+  install_signal_handler(SIGILL, (void *)signal_handler, RESERVE_FOR_LISP);
+  if (no_sigtrap != 1) {
+    install_signal_handler(SIGTRAP, (void *)signal_handler, RESERVE_FOR_LISP);
+  }
+  install_signal_handler(SIGBUS, (void *)signal_handler, RESERVE_FOR_LISP);
+  install_signal_handler(SIGSEGV, (void *)signal_handler, RESERVE_FOR_LISP);
+  install_signal_handler(SIGFPE, (void *)signal_handler, RESERVE_FOR_LISP);
+
+  install_signal_handler(SIGNAL_FOR_PROCESS_INTERRUPT,
+                         (void *)interrupt_handler, RESERVE_FOR_LISP);
+  signal(SIGPIPE, SIG_IGN);
+}
+
+void
+thread_kill_handler(int signum, siginfo_t *info, ExceptionInformation *xp)
+{                                 /* ppc-exceptions.c:2229-2255, verbatim */
+  TCR *tcr = get_tcr(false);
+  area *a;
+  sigset_t mask;
+
+  sigemptyset(&mask);
+
+  if (tcr) {
+    tcr->valence = TCR_STATE_FOREIGN;
+    a = tcr->vs_area;
+    if (a) {
+      a->active = a->high;
+    }
+    a = tcr->ts_area;
+    if (a) {
+      a->active = a->high;
+    }
+    a = tcr->cs_area;
+    if (a) {
+      a->active = a->high;
+    }
+  }
+
+  pthread_sigmask(SIG_SETMASK, &mask, NULL);
+  pthread_exit(NULL);
+}
+
+void
+thread_signal_setup()
+{                                 /* ppc-exceptions.c:2258-2268, verbatim */
+  thread_suspend_signal = SIG_SUSPEND_THREAD;
+  thread_kill_signal = SIG_KILL_THREAD;
+
+  install_signal_handler(thread_suspend_signal,
+                         (void *)suspend_resume_handler,
+                         RESERVE_FOR_LISP | RESTART_SYSCALLS);
+  install_signal_handler(thread_kill_signal, (void *)thread_kill_handler,
+                         RESERVE_FOR_LISP);
+}
+
+void
+unprotect_all_areas()
+{                                 /* ppc-exceptions.c:2272-2280, verbatim */
+  protected_area_ptr p;
+
+  for (p = AllProtectedAreas, AllProtectedAreas = NULL; p; p = p->next) {
+    unprotect_area(p);
+  }
+}
+
+/*
+  The tlb-too-small trap (udf unary-misc sub 2) carries the INDEX
+  register; extend the tcr's tlb so the index is in bounds, filling new
+  pages with no_thread_local_binding_marker.  ppc-exceptions.c:2282-2321,
+  3-arg signature per ARM32 (arm-exceptions.c:2014 -- the drafts' binding
+  subprims reload tcr.tlb_limit from the tcr each time, so there is no
+  live limit REGISTER to update, unlike PPC's twlle shape).
+*/
+Boolean
+extend_tcr_tlb(TCR *tcr, ExceptionInformation *xp, unsigned idx_regno)
+{
+  unsigned
+    index = (unsigned)(xpGPR(xp, idx_regno)),
+    old_limit = tcr->tlb_limit,
+    new_limit = align_to_power_of_2(index + 1, 12),
+    new_bytes = new_limit - old_limit;
+  LispObj
+    *old_tlb = tcr->tlb_pointer,
+    *new_tlb = realloc(old_tlb, new_limit),
+    *work;
+
+  if (new_tlb == NULL) {
+    return false;
+  }
+
+  work = (LispObj *)((BytePtr)new_tlb + old_limit);
+
+  while (new_bytes) {
+    *work++ = no_thread_local_binding_marker;
+    new_bytes -= sizeof(LispObj);
+  }
+  tcr->tlb_pointer = new_tlb;
+  tcr->tlb_limit = new_limit;
+  return true;
+}
+
+void
+exception_init()
+{                                 /* ppc-exceptions.c:2327-2331, verbatim */
+  install_pmcl_exception_handlers();
+}

--- a/lisp-kernel/arm64-gc.c
+++ b/lisp-kernel/arm64-gc.c
@@ -1,28 +1,1079 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+﻿/* SPDX-License-Identifier: Apache-2.0 */
 
-#include "lisp.h"
-#include "lisp_globals.h"
-#include "bits.h"
-#include "gc.h"
-#include "area.h"
-#include "lisp-exceptions.h"
-#include "threads.h"
-#include <stddef.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/time.h>
+/* PPC64 LINE-PORT (source: vendor/ccl/lisp-kernel/ppc-gc.c)
+ *
+ * Arch-dependent GC for Matt Emerson's upstream ARM64 (low-tag) design;
+ * the missing arm64-gc.o in linuxarm64/Makefile:57 (compiles alongside
+ * the arch-independent gc-common.c).  Tree pin: upstream-arm64-tip @
+ * 115b7aa.  Companion report (contract, decisions, open items):
+ * drafts/arm64-gc-report.md.
+ *
+ * PORT-NOTE â€” deviations from the PPC64 source (each tagged inline):
+ *  1. Tag scheme: Matt's arm64 fulltags mirror X8664's *shape* (symbols
+ *     and functions have their OWN pointer tags; cons=3, nil=11,
+ *     RMARK_PREV_CAR = fulltag_cons + node_size = fulltag_nil exactly as
+ *     on X8664).  Where PPC64 logic is tag-scheme-specific (rmark's
+ *     link-inversion FSM, is_node_fulltag, mark_ephemeral_root), the
+ *     X8664 rendering of the same logic is the analog and is cited as
+ *     x86-gc.c:NNN.
+ *  2. pc locatives: PPC64's backward grovel for the 32-bit 'CODE' prefix
+ *     becomes a grovel for 0x00000000 = the `udf #0' sentinel that starts
+ *     every arm64 code vector (arm64-uuo.s format 0).  No CTR, no loc_pc
+ *     register on ARM64: pc roots are xpPC/xpLR only.
+ *  3. cstack: ARM64 uses MARKER lisp_frames {marker,savevsp,savefn,savelr}
+ *     (arm64-constants.h:359-364), not PPC backlink frames; the four
+ *     cstack walkers follow arm-gc.c's marker walk, with the case ORDER
+ *     corrected for arm64 header fulltags (see mark_cstack_area).
+ *  4. tstack: Matt's design HAS a tsp/tstack (unlike ARM32) â€” the tstack
+ *     walkers port from PPC verbatim.
+ *  5. Function objects are {header, entrypoint, codevector, ...}
+ *     (arm64-constants.h:300-304).  Every site that must treat the
+ *     entrypoint slot as a locative is tagged OPEN-ENTRYPOINT: the
+ *     call-side convention is unsettled upstream; the ARM32 convention
+ *     (entrypoint = untag(codevector)+fulltag_odd_fixnum) is assumed,
+ *     under which the plain node walkers skip it as a fixnum.
+ *  6. VENDOR BUG FIXED (see report Â§5): ppc-gc.c:1795-1798 (PPC64 branch
+ *     of purify_locref) forgets to include the header word in the
+ *     displacement when groveling (the PPC32 branch, which finds the
+ *     header itself rather than the prefix, is correct).  Our grovel adds
+ *     the missing node_size.
+ *
+ * Register-number authority: arm64-exceptions.c enum (map unified
+ * upstream @ 01d73c3): imm0-5=x0-5, nargs=x6, fn=x7, arg_w-z=x8-11,
+ * temp0-5=x12-17, save0-3=x19-22, rnil=x23, tsp=x24, vsp=x25,
+ * allocptr=x26, allocbase=x27, rcontext=x28.
+ *
+ * PROPOSED register SET marked by mark_xp/forward_xp/purify_xp/
+ * impurify_xp (ratify with Matt): the BOXED node registers
+ * fn(7)..rnil(23) EXCEPT x18 (platform register).  Excluded: imm0-5 and
+ * nargs (unboxed/fixnum), tsp/vsp/rcontext/fp (raw pointers),
+ * allocptr/allocbase (mid-allocation state is normalized by
+ * pc_luser_xp on the exception side before gc runs, as on ARM32).
+ * pc locatives: xpPC, xpLR.
+ */
+
+#include "lisp.h"                 /* ppc-gc.c:17 */
+#include "lisp_globals.h"         /* ppc-gc.c:18 */
+#include "bits.h"                 /* ppc-gc.c:19 */
+#include "gc.h"                   /* ppc-gc.c:20 */
+#include "area.h"                 /* ppc-gc.c:21 */
+#include "threads.h"              /* ppc-gc.c:22 */
+#include <stddef.h>               /* ppc-gc.c:23 */
+#include <stdlib.h>               /* ppc-gc.c:24 */
+#include <string.h>               /* ppc-gc.c:25 */
+#include <sys/time.h>             /* ppc-gc.c:26 */
+#include <sys/mman.h>             /* for munmap in impurify (ppc-gc.c:2283
+                                     calls munmap; PPC got the prototype
+                                     transitively) */
+
+/* ------------------------------------------------------------------ */
+/* Guarded shims for headers that lack an ARM64 branch at the pin.
+ * (linuxarm64/Makefile:27 defines -DARM64 only â€” NOT -DARM â€” so the
+ * PPC/X86/ARM ladders in gc.h/macros.h/lisp_globals.h all fall through.)
+ * Each is #ifndef-guarded so the real upstream branch supersedes it.   */
+
+/* lisp_globals.h grew a real ARM64 branch @ 93d72a0 (nil-anchored via
+ * the runtime lisp_nil) -- the fixed-address shim retired. */
+
+/* PROPOSED upstream gc.h ARM64 branch: node fulltags are cons, misc,
+ * symbol (fulltag_function removed, patch 0055: a function is an ordinary
+ * miscobj).  No x86 tra tags: arm64 return addresses are RAW
+ * 4-byte-aligned locatives, not node-tagged.
+ * fulltag_nil excluded: only NIL carries it and NIL is static
+ * (x8632/x8664 precedent). */
+#ifndef is_node_fulltag
+#define is_node_fulltag(f)  ((1<<(f))&((1<<fulltag_cons)     | \
+                                       (1<<fulltag_misc)     | \
+                                       (1<<fulltag_symbol)))
+#endif
+
+/* PROPOSED upstream macros.h ARM64 branch (macros.h:53-83 ladder has no
+ * ARM64 case).  arm64 nodeheader fulltags = {6,14}, immheader = {5,12,13}
+ * (arm64-constants.h:120-135); X8664-mask style (macros.h:64-73). */
+#ifndef nodeheader_tag_p
+#define NODEHEADER_MASK ((1<<fulltag_nodeheader_0) | \
+                         (1<<fulltag_nodeheader_1))
+#define nodeheader_tag_p(tag) ((1<<(tag)) & NODEHEADER_MASK)
+#define IMMHEADER_MASK ((1<<fulltag_immheader_0) | \
+                        (1<<fulltag_immheader_1) | \
+                        (1<<fulltag_immheader_2))
+#define immheader_tag_p(tag) ((1<<(tag)) & IMMHEADER_MASK)
+#endif
+
+/* 16m10: a corrupt/garbage uvector header decodes to an absurd element
+ * count and the suffix set_n_bits memsets far past the markbits buffer
+ * (observed: a pointer misread as a header claimed a 51GB object; the
+ * ~400MB memset ran off the mapping and the SEGV handler looped at
+ * 100% CPU).  Any claimed extent beyond the GC area is proof of a
+ * corrupt header - die loudly at the object, not in the storm. */
+static void
+check_marked_extent(LispObj n, natural dnode, natural suffix_dnodes)
+{
+  if ((dnode + 1 + suffix_dnodes) > GCndnodes_in_area) {
+    Bug(NULL, "GC: object 0x%lx (dnode 0x%lx) claims 0x%lx suffix dnodes"
+        " but the area has only 0x%lx - corrupt uvector header?",
+        (unsigned long)n, (unsigned long)dnode,
+        (unsigned long)suffix_dnodes, (unsigned long)GCndnodes_in_area);
+  }
+}
+
+/* forward_marker: gc.h:106-114 falls through to `fulltag_nil' (11) under
+ * -DARM64.  Usable as-is: 0xB as a raw slot word would be a fulltag_nil
+ * "pointer" to address 0 â€” never a legal object, header, or 4-aligned
+ * locative.  (Had -DARM been defined we'd have inherited ARM32's udf
+ * encoding, which would be wrong here.)  No local definition needed.   */
+
+/* The udf #0 sentinel word that STARTS every arm64 code vector
+ * (arm64-uuo.s:25-27 format 0: "udf #0 is the sentinel at the start of
+ * every code vector"; A64 UDF encodes as 0x0000imm16 â†’ udf #0 is
+ * 0x00000000).  Replaces PPC64_CODE_VECTOR_PREFIX ('CODE', gc.h:30) in
+ * the pc-locative â†’ header grovel.  Alignment: code-vector headers are
+ * dnode(16)-aligned, so the sentinel (element 0) sits at header+8, an
+ * 8-aligned address that the 8-byte-stepped grovel always lands on.
+ * ASSUMPTION (report OPEN #8): no other 0x00000000 word at an 8-aligned
+ * offset inside the instruction stream (no inline literal pools).      */
+#define ARM64_CODE_VECTOR_SENTINEL 0
+
+/* PROPOSED (ratify with Matt): arm64-constants.h defines
+ * subtag_lisp_frame_marker = SUBTAG(fulltag_imm_1,5) but no
+ * stack_alloc_marker yet (it exists only in the STALE high-tag
+ * arm64-constants.s:112).  ARM32 keeps the two adjacent
+ * (arm-constants.h:245-246); propose the next imm_1 slot.              */
+#ifndef stack_alloc_marker
+#define stack_alloc_marker SUBTAG(fulltag_imm_1, 6)
+#endif
+
+/* The marker lisp_frame C overlay lives in platform-linuxarm64.h
+ * (albt.c and arm64-exceptions.c consume it too). */
+
+/* ===== cstack walk trail: make a walk failure name its own cause ==========
+ *
+ * KEEP (16m41).  The bare Bug() this replaced named the function and NOTHING
+ * else -- not which of the walk's five strides overshot, not the word it strode
+ * on, not whether the region leading in was a frame, an nfp ivector or a
+ * stack-consed vector -- and that cost two sessions.  With the trail, ONE run
+ * named the cause: three marker frames, then an x29 hop and four zero words
+ * (i.e. C frames), then a spilled 0.9d0 read as an ivector header.  That is the
+ * whole diagnosis of the missing lisp<->foreign boundary protocol (see
+ * spentry-E-ffi.s), and it cost a single stage-11 cycle instead of a build per
+ * question.  The cost on the healthy path is a few stores per stride over a
+ * walk that is hundreds of steps long: keep it.
+ *
+ * Reports, then Bug()s -- the walk has no way to continue correctly, and the
+ * clamp-and-continue used during the 16m41 diagnosis leaves marking INCOMPLETE
+ * (it exists only so a diagnostic run can show the pattern across GCs; set
+ * CSTACK_MAX_REPORTS > 1 to get it back).                                    */
+enum {
+  CB_FRAME = 0,                 /* lisp_frame_marker: stride sizeof(lisp_frame) */
+  CB_MARKER0,                   /* stack_alloc_marker or 0: stride 2 */
+  CB_NODE,                      /* nodeheader: stride 1+elements (+pad) */
+  CB_IMM,                       /* immheader: skip_over_ivector (nfp frames) */
+  CB_BACKLINK,                  /* (word & fixnummask)==0: current = word */
+  CB_NBRANCH
+};
+
+static const char *cstack_branch_name[CB_NBRANCH] = {
+  "lisp_frame", "marker/zero", "nodeheader", "immheader", "backlink"
+};
+
+typedef struct {
+  LispObj at, word, next;
+  int br;
+} cstack_step;
+
+#define CSTACK_TRAIL 12
+#define CSTACK_MAX_REPORTS 1    /* >1 = diagnostic mode: clamp and keep going */
+
+static natural cstack_walk_reports = 0;
+
+#define CSTACK_TRAIL_DECL \
+  cstack_step _ctrail[CSTACK_TRAIL]; \
+  natural _cnsteps = 0, _chisto[CB_NBRANCH] = {0, 0, 0, 0, 0}; \
+  LispObj *_cfrom = NULL
+
+/* The parameter is _br, not br: a macro parameter is substituted after `->'
+   too, so naming it `br' turns `_s->br' into `_s->CB_FRAME'. */
+#define CSTACK_TRAIL_STEP(_br)                                  \
+  do {                                                          \
+    cstack_step *_s = _ctrail + (_cnsteps % CSTACK_TRAIL);       \
+    _s->at = (LispObj)_cfrom;                                   \
+    _s->word = header;                                          \
+    _s->next = (LispObj)current;                                \
+    _s->br = (_br);                                             \
+    _cnsteps++;                                                 \
+    _chisto[_br]++;                                             \
+  } while (0)
+
+/* Returns 1 if the caller may clamp and keep walking, 0 if it must Bug out. */
+static int
+cstack_walk_report(const char *who, const char *why, area *a,
+                   LispObj *current, LispObj *limit,
+                   cstack_step *trail, natural nsteps, natural *histo)
+{
+  natural i, first = (nsteps > CSTACK_TRAIL) ? nsteps - CSTACK_TRAIL : 0;
+  LispObj *p;
+
+  fprintf(dbgout, "\n*** %s: %s (report %lu of %d)\n",
+          who, why, (unsigned long)cstack_walk_reports + 1, CSTACK_MAX_REPORTS);
+  fprintf(dbgout, "  area    low=0x%lx active=0x%lx high=0x%lx  (walked range = %ld words)\n",
+          (unsigned long)a->low, (unsigned long)a->active, (unsigned long)a->high,
+          (long)(((LispObj *)a->high) - ((LispObj *)a->active)));
+  fprintf(dbgout, "  walk    current=0x%lx limit=0x%lx  past-limit=%ld words  steps=%lu\n",
+          (unsigned long)current, (unsigned long)limit,
+          (long)(current - limit), (unsigned long)nsteps);
+  /* Owner state.  nfp says whether an nfp ivector frame was live at the
+     safepoint (compare it against the step bases below), last_lisp_frame and an
+     odd valence say whether this thread was in foreign code -- which is the
+     other way a->active can name a word the walk cannot classify. */
+  if (a->owner) {
+    TCR *tcr = a->owner;
+    fprintf(dbgout, "  owner   tcr=0x%lx valence=%ld%s nfp=0x%lx last_lisp_frame=0x%lx\n"
+                    "          save_vsp=0x%lx save_tsp=0x%lx cs_limit=0x%lx\n",
+            (unsigned long)tcr, (long)tcr->valence,
+            (tcr->valence & 1) ? " (ODD = in foreign code)" : "",
+            (unsigned long)tcr->nfp, (unsigned long)tcr->last_lisp_frame,
+            (unsigned long)tcr->save_vsp, (unsigned long)tcr->save_tsp,
+            (unsigned long)tcr->cs_limit);
+  }
+  fprintf(dbgout, "  strides taken:");
+  for (i = 0; i < CB_NBRANCH; i++) {
+    fprintf(dbgout, " %s=%lu", cstack_branch_name[i], (unsigned long)histo[i]);
+  }
+  fprintf(dbgout, "\n");
+
+  if (nsteps == 0) {
+    fprintf(dbgout, "  NO steps taken -- the FIRST word at a->active failed; a->active is the suspect\n");
+  } else {
+    fprintf(dbgout, "  last %lu steps (oldest first):\n", (unsigned long)(nsteps - first));
+    for (i = first; i < nsteps; i++) {
+      cstack_step *s = trail + (i % CSTACK_TRAIL);
+      fprintf(dbgout, "    at 0x%lx word 0x%-18lx %-12s -> 0x%lx (%+ld words)\n",
+              (unsigned long)s->at, (unsigned long)s->word,
+              cstack_branch_name[s->br], (unsigned long)s->next,
+              (long)(((LispObj *)s->next) - ((LispObj *)s->at)));
+    }
+    /* The region the overshooting stride flew over, read raw. */
+    p = (LispObj *)(trail[(nsteps - 1) % CSTACK_TRAIL].at);
+    fprintf(dbgout, "  raw words from the last step's base:\n");
+    for (i = 0; i < 10 && (p + i) < limit; i++) {
+      fprintf(dbgout, "    [0x%lx] = 0x%lx\n",
+              (unsigned long)(p + i), (unsigned long)p[i]);
+    }
+  }
+  fprintf(dbgout, "  raw words at the top of the area:\n");
+  for (p = limit - 6; p < limit; p++) {
+    if (p >= (LispObj *)a->low) {
+      fprintf(dbgout, "    [0x%lx] = 0x%lx%s\n", (unsigned long)p,
+              (unsigned long)*p,
+              (*p == lisp_frame_marker) ? "   <- lisp_frame_marker" : "");
+    }
+  }
+  fflush(dbgout);
+  return (++cstack_walk_reports < CSTACK_MAX_REPORTS);
+}
+/* ===== end 16m41 TEMPORARY DIAG ========================================== */
+
+/* Heap sanity checking. */
+
+void
+check_node(LispObj n)                                /* ppc-gc.c:30-115 */
+{
+  int tag = fulltag_of(n), header_tag;
+  area *a;
+  LispObj header;
+
+  switch (tag) {
+  case fulltag_even_fixnum:                          /* ppc-gc.c:38-39 */
+  case fulltag_odd_fixnum:
+  /* arm64 immediate fulltags (ppc-gc.c:43-46 lists PPC64's four imm
+     tags; arm64's are single_float, imm_0, imm_1) */
+  case fulltag_single_float:
+  case fulltag_imm_0:
+  case fulltag_imm_1:
+    return;
+
+  case fulltag_nil:                                  /* ppc-gc.c:55-59 (PPC32
+       branch; PPC64 has no fulltag_nil, arm64 does â€” x86-gc.c precedent) */
+    if (n != lisp_nil) {
+      Bug(NULL,"Object tagged as nil, not nil : " LISP, n);
+    }
+    return;
+
+  case fulltag_nodeheader_0:                         /* ppc-gc.c:64-78 */
+  case fulltag_nodeheader_1:
+  case fulltag_immheader_0:
+  case fulltag_immheader_1:
+  case fulltag_immheader_2:
+    Bug(NULL, "Header not expected : 0x" LISP, n);
+    return;
+
+  case fulltag_reserved:      /* ARM64-DEVIATION: arm64-constants.h:129
+       reserves fulltag 9; nothing may carry it */
+    Bug(NULL, "Reserved tag not expected : 0x" LISP, n);
+    return;
+
+  case fulltag_misc:                                 /* ppc-gc.c:81-97 */
+  case fulltag_cons:
+  case fulltag_symbol:      /* ARM64-DEVIATION: own-tag pointers are heap
+       nodes too (x86-gc.c:153-154 precedent).  fulltag_function removed
+       (patch 0055): functions arrive here as fulltag_misc. */
+    a = heap_area_containing((BytePtr)ptr_from_lispobj(n));
+
+    if (a == NULL) {
+      /* Can't do as much sanity checking as we'd like to
+         if object is a defunct stack-consed object.
+         If a dangling reference to the heap, that's
+         bad .. */
+      a = active_dynamic_area;
+      if ((n > (ptr_to_lispobj(a->active))) &&
+          (n < (ptr_to_lispobj(a->high)))) {
+        Bug(NULL, "Node points to heap free space: 0x" LISP, n);
+      }
+      return;
+    }
+    break;
+  }
+  /* Node points to heap area, so check header/lack thereof. */
+  header = header_of(n);                             /* ppc-gc.c:99-114 */
+  header_tag = fulltag_of(header);
+  if (tag == fulltag_cons) {
+    if ((nodeheader_tag_p(header_tag)) ||
+        (immheader_tag_p(header_tag))) {
+      Bug(NULL, "Cons cell at 0x" LISP " has bogus header : 0x" LISP, n, header);
+    }
+    return;
+  }
+
+  if ((!nodeheader_tag_p(header_tag)) &&
+      (!immheader_tag_p(header_tag))) {
+    Bug(NULL,"Vector at 0x" LISP " has bogus header : 0x" LISP, n, header);
+  }
+  return;
+}
+
+
+void
+check_range(LispObj *start, LispObj *end, Boolean header_allowed)
+{                                                    /* ppc-gc.c:120-154 */
+  LispObj node, *current = start, *prev = NULL;
+  int tag, subtag;
+  natural elements;
+
+  while (current < end) {
+    prev = current;
+    node = *current++;
+    tag = fulltag_of(node);
+    if (immheader_tag_p(tag)) {
+      if (! header_allowed) {
+        Bug(NULL, "Header not expected at 0x" LISP "\n", prev);
+      }
+      current = (LispObj *)skip_over_ivector((natural)prev, node);
+    } else if (nodeheader_tag_p(tag)) {
+      if (! header_allowed) {
+        Bug(NULL, "Header not expected at 0x" LISP "\n", prev);
+      }
+      /* OPEN-ENTRYPOINT (arm-gc.c:121-129, ARM64-DEVIATION): consistency
+         check for the function entrypoint/codevector pair; only fires
+         under the ARM32-style odd_fixnum entrypoint convention. */
+      subtag = header_subtag(node);
+      if (subtag == subtag_function) {
+        if (fulltag_of(current[0]) == fulltag_odd_fixnum) {
+          if (untag(current[0]) != untag(current[1])) {
+            Bug(NULL, "In function at 0x" LISP ", entrypoint (0x" LISP ") and codevector (0x" LISP ") don't match\n", (LispObj)prev, current[0], current[1]);
+          }
+        }
+      }
+
+      elements = header_element_count(node) | 1;
+      while (elements--) {
+        check_node(*current++);
+      }
+    } else {
+      check_node(node);
+      check_node(*current++);
+    }
+  }
+
+  if (current != end) {
+    Bug(NULL, "Overran end of memory range: start = 0x" LISP ", end = 0x" LISP ", prev = 0x" LISP ", current = 0x" LISP,
+        start, end, prev, current);
+  }
+}
+
+void
+check_all_areas(TCR *tcr)                            /* ppc-gc.c:156-204 */
+{
+  area *a = active_dynamic_area;
+  area_code code = a->code;
+
+  while (code != AREA_VOID) {
+    switch (code) {
+    case AREA_DYNAMIC:
+    case AREA_STATIC:
+    case AREA_MANAGED_STATIC:
+      check_range((LispObj *)a->low, (LispObj *)a->active, true);
+      break;
+
+    case AREA_VSTACK:
+      {
+        LispObj* low = (LispObj *)a->active;
+        LispObj* high = (LispObj *)a->high;
+
+        if (((natural)low) & node_size) {
+          check_node(*low++);
+        }
+        check_range(low, high, false);
+      }
+      break;
+
+    case AREA_TSTACK:                                /* ppc-gc.c:182-198 */
+      {
+        LispObj *current, *next,
+                *start = (LispObj *) a->active,
+                *end = start,
+                *limit = (LispObj *) a->high;
+
+        for (current = start;
+             end != limit;
+             current = next) {
+          next = ptr_from_lispobj(*current);
+          end = ((next >= start) && (next < limit)) ? next : limit;
+          if (current[1] == 0) {
+            check_range(current+2, end, true);
+          }
+        }
+      }
+      break;
+    }
+    a = a->succ;
+    code = (a->code);
+  }
+}
+
+/* Sooner or later, this probably wants to be in assembler */
+void
+mark_root(LispObj n)                                 /* ppc-gc.c:216-334 */
+{
+  int tag_n = fulltag_of(n);
+  natural dnode, bits, *bitsp, mask;
+
+  if (!is_node_fulltag(tag_n)) {
+    return;
+  }
+
+  dnode = gc_area_dnode(n);
+  if (dnode >= GCndnodes_in_area) {
+    return;
+  }
+  set_bits_vars(GCmarkbits,dnode,bitsp,bits,mask);
+  if (bits & mask) {
+    return;
+  }
+  *bitsp = (bits | mask);
+
+  if (tag_n == fulltag_cons) {
+    cons *c = (cons *) ptr_from_lispobj(untag(n));
+    rmark(c->car);
+    rmark(c->cdr);
+    return;
+  }
+  {
+    LispObj *base = (LispObj *) ptr_from_lispobj(untag(n));
+    natural
+      header = *((natural *) base),
+      subtag = header_subtag(header),
+      element_count = header_element_count(header),
+      total_size_in_bytes,      /* including 8-byte header */
+      suffix_dnodes;
+    tag_n = fulltag_of(header);
+
+    /* ppc-gc.c:253-268 (PPC64 ivector classes), re-keyed to arm64's
+       three classes (arm64-constants.h:149-151): there is NO
+       ivector_class_8_bit on arm64 â€” 8-bit subtags live in other_bit
+       (x86-gc.c:526-546 same shape).
+       16m41: the note here said subtag_complex_double_float_vector and
+       subtag_s16_vector COLLIDE at SUBTAG(other_bit,9), so no cdf branch
+       was possible (report OPEN #2).  STALE â€” Matt fixed it upstream
+       (s16 moved to index 10); at this pin arm64-constants.h:176/178 are
+       9 and 10, distinct, and cdf is min_cl_ivector_subtag.  So the cdf
+       leg below is now both possible and REQUIRED: cdf is index 9, i.e.
+       BELOW subtag_s8_vector, so it used to fall into the 16-bit leg and
+       every complex-double-float vector mis-sized the heap walk.
+       Element = 2 doubles = 16 bytes, data immediately after the header
+       (see the layout note in skip_over_ivector). */
+    if ((nodeheader_tag_p(tag_n)) ||
+        (tag_n == ivector_class_64_bit)) {
+      /* includes complex_single_float_vector (index 11): 2 singles = 8
+         bytes per element, so the generic 8n is already correct. */
+      total_size_in_bytes = 8 + (element_count<<3);
+    } else if (tag_n == ivector_class_32_bit) {
+      total_size_in_bytes = 8 + (element_count<<2);
+    } else {
+      /* ivector_class_other_bit: complex-double, 8/16-bit arrays, bitvector */
+      if (subtag == subtag_bit_vector) {
+        total_size_in_bytes = 8 + ((element_count+7)>>3);
+      } else if (subtag >= subtag_s8_vector) { /* s8/u8;
+              bit_vector already handled */
+        total_size_in_bytes = 8 + element_count;
+      } else if (subtag == subtag_complex_double_float_vector) {
+        total_size_in_bytes = 8 + (element_count<<4);
+      } else {                  /* s16, u16 */
+        total_size_in_bytes = 8 + (element_count<<1);
+      }
+    }
+
+    suffix_dnodes = ((total_size_in_bytes+(dnode_size-1))>>dnode_shift) -1;
+
+    if (suffix_dnodes) {
+      check_marked_extent(n, dnode, suffix_dnodes);
+      set_n_bits(GCmarkbits, dnode+1, suffix_dnodes);
+    }
+
+    if (nodeheader_tag_p(tag_n)) {                   /* ppc-gc.c:294-332 */
+      if (subtag == subtag_hash_vector) {
+        /* Don't invalidate the cache here.  It should get
+           invalidated on the lisp side, if/when we know
+           that rehashing is necessary. */
+        LispObj flags = ((hash_table_vector_header *) base)->flags;
+
+        if (flags & nhash_weak_mask) {
+          ((hash_table_vector_header *) base)->cache_key = undefined;
+          ((hash_table_vector_header *) base)->cache_value = lisp_nil;
+          mark_weak_htabv(n);
+          return;
+        }
+      }
+
+      if (subtag == subtag_pool) {
+        deref(n, 1) = lisp_nil;
+      }
+
+      if (subtag == subtag_weak) {
+        natural weak_type = (natural) base[2];
+        if (weak_type >> population_termination_bit) {
+          element_count -= 2;
+        } else {
+          element_count -= 1;
+        }
+      }
+
+      /* OPEN-ENTRYPOINT: for subtag_function (pseudofunction removed upstream @ a6314ba) gvectors,
+         slot 1 (entrypoint) is visited by this loop; under the assumed
+         ARM32 convention it is fixnum-tagged so rmark ignores it.  If
+         the settled convention makes it a node-tagged or 4-aligned-raw
+         value, functions need a prefix-skip here (x86-gc.c:603-618
+         shape). */
+      base += (1+element_count);
+
+      while(element_count--) {
+        rmark(*--base);
+      }
+      if (subtag == subtag_weak) {
+        deref(n, 1) = GCweakvll;
+        GCweakvll = untag(n);
+      }
+    }
+  }
+}
+
 
 /*
- *  Return the address just past an ivector whose header word is HEADER
- *  and whose header sits at START.
- */
-LispObj *
-skip_over_ivector(natural start, LispObj header)
-{
-  natural element_count = header_element_count(header);
-  natural subtag = header_subtag(header);
-  natural nbytes;
+  This marks the node if it needs to; it returns true if the node
+  is either a hash table vector header or a cons/misc-tagged pointer
+  to ephemeral space.
+  Note that it  might be a pointer to ephemeral space even if it's
+  not pointing to the current generation.
+*/
 
+Boolean
+mark_ephemeral_root(LispObj n)                       /* ppc-gc.c:345-364 */
+{
+  int tag_n = fulltag_of(n);
+  natural eph_dnode;
+
+  if (nodeheader_tag_p(tag_n)) {
+    return (header_subtag(n) == subtag_hash_vector);
+  }
+
+  /* ARM64-DEVIATION (x86-gc.c:650): is_node_fulltag, not cons|misc â€”
+     symbol/function-tagged ephemeral references count too. */
+  if (is_node_fulltag(tag_n)) {
+    eph_dnode = area_dnode(n, GCephemeral_low);
+    if (eph_dnode < GCn_ephemeral_dnodes) {
+      mark_root(n);             /* May or may not mark it */
+      return true;              /* but return true 'cause it's an ephemeral node */
+    }
+  }
+  return false;                 /* Not a heap pointer or not ephemeral */
+}
+
+
+/* ppc-gc.c:367-378 (PPC64 comment, adapted): any register or stack
+   location that we're calling this on should have its low 2 bits clear;
+   the pc/lr should never point to a tagged object or contain a fixnum
+   with the low bits set.
+
+   If the "pc" appears to be pointing into a heap-allocated code vector
+   that's not yet marked, back up until we find the code vector's
+   sentinel (the 32-bit word 0x00000000 = `udf #0' which is the vector's
+   first element) and mark the entire code vector. */
+void
+mark_pc_root(LispObj xpc)                            /* ppc-gc.c:379-411 */
+{
+  if ((xpc & 3) != 0) {
+    Bug(NULL, "Bad PC locative!");
+  } else {
+    natural dnode = gc_area_dnode(xpc);
+    if ((dnode < GCndnodes_in_area) &&
+        !ref_bit(GCmarkbits,dnode)) {
+      LispObj
+        *headerP,
+        header;
+      opcode *program_counter;
+
+      for(program_counter=(opcode *)ptr_from_lispobj(xpc & ~7);
+          (LispObj)program_counter >= GCarealow;
+          program_counter-=2) {
+        if (*program_counter == ARM64_CODE_VECTOR_SENTINEL) {
+          headerP = ((LispObj *)program_counter)-1;
+          header = *headerP;
+          dnode = gc_area_dnode(headerP);
+          /* code vectors are 32-bit ivectors on arm64 too
+             (subtag_code_vector âˆˆ ivector_class_32_bit,
+             arm64-constants.h:181) â€” same size formula. */
+          {
+            natural code_dnodes =
+              (8+(header_element_count(header)<<2)+(dnode_size-1))>>dnode_shift;
+            if (code_dnodes) {
+              check_marked_extent((LispObj)headerP, dnode, code_dnodes - 1);
+            }
+            set_n_bits(GCmarkbits, dnode, code_dnodes);
+          }
+          return;
+        }
+      }
+      /*
+        Expected to have found a header by now, but didn't.
+        That's a bug.
+        */
+      Bug(NULL, "code_vector header not found!");
+    }
+  }
+}
+
+/* C-side register numbers used by the xp walkers â€” subset of the
+ * authority enum in arm64-exceptions.c:86-120 (arm64-constants.h R*
+ * numbers @ pin, map unified upstream @ 01d73c3). */
+enum {
+  fn = 7,          /* first BOXED node register */
+  arg_w = 8, arg_x = 9, arg_y = 10, arg_z = 11,
+  temp0 = 12, temp1 = 13, temp2 = 14, temp3 = 15, temp4 = 16, temp5 = 17,
+  /* x18: platform register â€” NEVER a lisp register */
+  save0 = 19, save1 = 20, save2 = 21, save3 = 22,
+  rnil = 23        /* last BOXED node register */
+};
+
+/* FSM state tags for the link-inverting marker.
+   ARM64-DEVIATION (x86-gc.c:664-665 â€” same tag layout: cons=3, nil=11,
+   imm_1=10): RMARK_PREV_ROOT is the fulltag of the `undefined' value
+   (SUBTAG(fulltag_imm_1,1), arm64-constants.h:205-207); RMARK_PREV_CAR =
+   fulltag_cons + node_size = fulltag_nil ("Coincidence?  I think not.")
+   PPC64 used fulltag_imm_3/fulltag_misc (ppc-gc.c:459-461) â€” different
+   tag space. */
+#define RMARK_PREV_ROOT fulltag_imm_1
+#define RMARK_PREV_CAR fulltag_nil
+
+/*
+  This wants to be in assembler even more than "mark_root" does.
+  For now, it does link-inversion: hard as that is to express in C,
+  reliable stack-overflow detection may be even harder ...
+*/
+void
+rmark(LispObj n)                                     /* ppc-gc.c:476-787 */
+{
+  int tag_n = fulltag_of(n);
+  bitvector markbits = GCmarkbits;
+  natural dnode, bits, *bitsp, mask;
+
+  if (!is_node_fulltag(tag_n)) {
+    return;
+  }
+
+  dnode = gc_area_dnode(n);
+  if (dnode >= GCndnodes_in_area) {
+    return;
+  }
+  set_bits_vars(markbits,dnode,bitsp,bits,mask);
+  if (bits & mask) {
+    return;
+  }
+  *bitsp = (bits | mask);
+
+  if (current_stack_pointer() > GCstack_limit) {     /* ppc-gc.c:497 */
+    if (tag_n == fulltag_cons) {
+      rmark(deref(n,1));
+      rmark(deref(n,0));
+    } else {
+      LispObj *base = (LispObj *) ptr_from_lispobj(untag(n));
+      natural
+        header = *((natural *) base),
+        subtag = header_subtag(header),
+        element_count = header_element_count(header),
+        total_size_in_bytes,
+        suffix_dnodes;
+      tag_n = fulltag_of(header);
+      /* ppc-gc.c:510-525 sizing, arm64 classes (see mark_root) */
+      if ((nodeheader_tag_p(tag_n)) ||
+          (tag_n == ivector_class_64_bit)) {
+        total_size_in_bytes = 8 + (element_count<<3);
+      } else if (tag_n == ivector_class_32_bit) {
+        total_size_in_bytes = 8 + (element_count<<2);
+      } else {
+        if (subtag == subtag_bit_vector) {
+          total_size_in_bytes = 8 + ((element_count+7)>>3);
+        } else if (subtag >= subtag_s8_vector) {
+          total_size_in_bytes = 8 + element_count;
+        } else if (subtag == subtag_complex_double_float_vector) {
+          total_size_in_bytes = 8 + (element_count<<4); /* 16m41; see mark_root */
+        } else {                /* 16-bit: s16, u16 */
+          total_size_in_bytes = 8 + (element_count<<1);
+        }
+      }
+
+      suffix_dnodes = ((total_size_in_bytes+(dnode_size-1))>>dnode_shift)-1;
+
+      if (suffix_dnodes) {
+        check_marked_extent(n, dnode, suffix_dnodes);
+        set_n_bits(GCmarkbits, dnode+1, suffix_dnodes);
+      }
+
+      if (!nodeheader_tag_p(tag_n)) return;
+
+      if (subtag == subtag_hash_vector) {            /* ppc-gc.c:552-569 */
+        /* Splice onto weakvll, then return */
+        /* In general, there's no reason to invalidate the cached
+           key/value pair here.  However, if the hash table's weak,
+           we don't want to retain an otherwise unreferenced key
+           or value simply because they're referenced from the
+           cache.  Clear the cached entries iff the hash table's
+           weak in some sense.
+        */
+        LispObj flags = ((hash_table_vector_header *) base)->flags;
+
+        if (flags & nhash_weak_mask) {
+          ((hash_table_vector_header *) base)->cache_key = undefined;
+          ((hash_table_vector_header *) base)->cache_value = lisp_nil;
+          mark_weak_htabv(n);
+          return;
+        }
+      }
+
+      if (subtag == subtag_pool) {
+        deref(n, 1) = lisp_nil;
+      }
+
+      if (subtag == subtag_weak) {
+        natural weak_type = (natural) base[2];
+        if (weak_type >> population_termination_bit)
+          element_count -= 2;
+        else
+          element_count -= 1;
+      }
+      while (element_count) {
+        rmark(deref(n,element_count));
+        element_count--;
+      }
+
+      if (subtag == subtag_weak) {
+        deref(n, 1) = GCweakvll;
+        GCweakvll = untag(n);
+      }
+
+    }
+  } else {
+    /* Link-inversion FSM (ppc-gc.c:593-786 structure; tag mechanics from
+       x86-gc.c:975-1189 â€” the same own-tag-symbol/function layout):
+
+       - marking a CONS: `this' is fulltag_cons (3) while its cdr is
+         being marked, fulltag_nil (11 = cons+node_size) while its car is.
+       - marking a gvector: `this' = base + tag_of(orig) + element
+         offset; steps of node_size keep the 3-bit tag: tag 4 for
+         fulltag_misc references (fulltags alternate 4/12), tag 7 for
+         fulltag_symbol references (fulltags alternate 7/15; 15 is just
+         the bit-3 flip of a symbol climb -- fulltag_function removed,
+         patch 0055).  When the header is reached, the original fulltag
+         is restored: tag 4 â†’ fulltag_misc, tag 7 â†’ fulltag_symbol (a
+         misc-tagged reference to a symbol -- or to a function, which is
+         an ordinary miscobj now -- keeps tag 4 and is restored to
+         fulltag_misc, exactly what it was).
+       - prev = `undefined' (fulltag_imm_1) marks the FSM root.
+
+       ARM64-DEVIATION vs x86: no function_boundary_marker / in-object
+       code â€” arm64 function gvectors are {header, entrypoint,
+       codevector, constants...}; the back-scan visits the entrypoint
+       slot like any other (OPEN-ENTRYPOINT: skipped as a fixnum under
+       the assumed ARM32 convention). */
+    LispObj prev = undefined;
+    LispObj this = n, next;
+    /*
+      This is an FSM.  The basic states are:
+      (0) Just marked the cdr of a cons; mark the car next;
+      (1) Just marked the car of a cons; back up.
+      (2) Hit a gvector header.  Back up.
+      (3) Marked a gvector element; mark the preceding one.
+      (4) Backed all the way up to the object that got us here.
+
+      This is all encoded in the fulltag of the "prev" pointer.
+    */
+
+    if (tag_n == fulltag_cons) goto MarkCons;
+    goto MarkVector;
+
+  ClimbCdr:                                          /* ppc-gc.c:610-612 */
+    prev = deref(this,0);
+    deref(this,0) = next;
+
+  Climb:                                             /* ppc-gc.c:614-633 */
+    next = this;
+    this = prev;
+    tag_n = fulltag_of(prev);
+    switch(tag_n) {
+    /* Vector states.  Climbing a gvector walks BACKWARD one slot at a time,
+       and node_size is 8 while fulltagmask is 15, so each step FLIPS BIT 3 of
+       the pointer's fulltag: a vector reference is seen under BOTH members of
+       a {t, t+8} pair, and both must be cased.  x86-gc.c:925-935 spells this
+       as `case tag_misc: case fulltag_misc:' (5/13), `case tag_symbol: case
+       fulltag_symbol:' (6/14), `case tag_function: case fulltag_function:'
+       (7/15) -- always the 3-bit tag AND its fulltag.
+         arm64 (arm64-constants.h:123-147): fulltag_misc=12 pairs with
+       tag_4=4; fulltag_symbol=7 pairs with 15 = fulltag_symbol+node_size,
+       the bit-3 flip alias of the SAME symbol climb (15 stopped being a
+       pointer tag when fulltag_function was removed, patch 0055).
+         This case used to read fulltag_immheader_1, which is 5 on arm64, not
+       4 -- so the misc pair was {12,5}, the real tag-4 half of every
+       misc-vector climb fell to `default:', and rmark abort()ed.  16m42
+       OBSERVED exactly that: "unexpected prev fulltag 4" after ~4194 ANSI
+       tests.  The comment above this switch always said {4,12}; only the
+       constant was wrong.  Spelled tag_4 rather than fulltag_immheader_0
+       (numerically identical) because this state is a MISC POINTER minus a
+       slot, not a header -- the same reason x86 writes tag_misc there. */
+    case fulltag_misc:
+    case tag_4:
+    case fulltag_symbol:
+    case fulltag_symbol + node_size:    /* 15: symbol climb, bit-3 flip */
+      goto ClimbVector;
+
+    case RMARK_PREV_ROOT:
+      return;
+
+    case fulltag_cons:
+      goto ClimbCdr;
+
+    case RMARK_PREV_CAR:
+      goto ClimbCar;
+
+    default:
+      /* KEEP (16m42), same reason as the sizing Bug() above: this used to be a
+         bare abort(), which died as SIGABRT with NO output whatsoever -- not
+         the fulltag, not a pointer, not even the function name.  Stage 11
+         reaches it after ~4194 ANSI tests and a gdb boot could only report
+         "stopped in lisp code", because the suite fires thousands of benign
+         UUO SIGTRAPs before the real death and there was no C symbol worth
+         breaking on.  An unreachable-state assert must say which state it saw.
+
+         The FSM's state IS prev's fulltag, so landing here means either a
+         link-inversion state we never encode, or a `prev' corrupted while
+         inverted.  Encoded states (RMARK_PREV_* above + arm64-constants.h:
+         123-147): vector refs tag_4(4)/fulltag_misc(12) and
+         fulltag_symbol(7)/its bit-3 flip(15); RMARK_PREV_ROOT =
+         fulltag_imm_1(10); fulltag_cons(3); RMARK_PREV_CAR = fulltag_nil(11).
+
+         Print the whole FSM triple, not just the tag: `this' and `next' say
+         where in the object graph the walk was, prev's FULL word says what it
+         tried to climb into, and the root `n' says which mark_root call owns
+         the walk. */
+      Bug(NULL, "rmark FSM: unexpected prev fulltag %d (not one of "
+                "cons/3 tag_4/4 symbol/7 imm_1/10 nil/11 misc/12 "
+                "symbol-flip/15)\n"
+                "  prev = 0x" LISP "\n  this = 0x" LISP "\n  next = 0x" LISP
+                "\n  root = 0x" LISP "\n",
+          tag_n, prev, this, next, n);
+      /* Bug() is NOT noreturn -- it returns if lisp_Debugger does, and falling
+         out of this switch would drop into DescendCons with a corrupt FSM.
+         Keep the original abort() so only the DIAGNOSTIC is new. */
+      abort();
+    }
+
+  DescendCons:                                       /* ppc-gc.c:635-637 */
+    prev = this;
+    this = next;
+
+  MarkCons:                                          /* ppc-gc.c:639-651 */
+    next = deref(this,1);
+    this += node_size;          /* fulltag_cons â†’ fulltag_nil (RMARK_PREV_CAR) */
+    tag_n = fulltag_of(next);
+    if (!is_node_fulltag(tag_n)) goto MarkCdr;
+    dnode = gc_area_dnode(next);
+    if (dnode >= GCndnodes_in_area) goto MarkCdr;
+    set_bits_vars(markbits,dnode,bitsp,bits,mask);
+    if (bits & mask) goto MarkCdr;
+    *bitsp = (bits | mask);
+    deref(this,1) = prev;
+    if (tag_n == fulltag_cons) goto DescendCons;
+    goto DescendVector;
+
+  ClimbCar:                                          /* ppc-gc.c:653-655 */
+    prev = deref(this,1);
+    deref(this,1) = next;
+
+  MarkCdr:                                           /* ppc-gc.c:657-669 */
+    next = deref(this, 0);
+    this -= node_size;          /* fulltag_nil â†’ fulltag_cons */
+    tag_n = fulltag_of(next);
+    if (!is_node_fulltag(tag_n)) goto Climb;
+    dnode = gc_area_dnode(next);
+    if (dnode >= GCndnodes_in_area) goto Climb;
+    set_bits_vars(markbits,dnode,bitsp,bits,mask);
+    if (bits & mask) goto Climb;
+    *bitsp = (bits | mask);
+    deref(this, 0) = prev;
+    if (tag_n == fulltag_cons) goto DescendCons;
+    /* goto DescendVector; */
+
+  DescendVector:                                     /* ppc-gc.c:671-673 */
+    prev = this;
+    this = next;
+
+  MarkVector:                                        /* ppc-gc.c:675-755 */
+    {
+      LispObj *base = (LispObj *) ptr_from_lispobj(untag(this));
+      natural
+        header = *((natural *) base),
+        subtag = header_subtag(header),
+        element_count = header_element_count(header),
+        total_size_in_bytes,
+        suffix_dnodes;
+
+      tag_n = fulltag_of(header);
+
+      /* ppc-gc.c:687-702 sizing, arm64 classes (see mark_root) */
+      if ((nodeheader_tag_p(tag_n)) ||
+          (tag_n == ivector_class_64_bit)) {
+        total_size_in_bytes = 8 + (element_count<<3);
+      } else if (tag_n == ivector_class_32_bit) {
+        total_size_in_bytes = 8 + (element_count<<2);
+      } else {
+        if (subtag == subtag_bit_vector) {
+          total_size_in_bytes = 8 + ((element_count+7)>>3);
+        } else if (subtag >= subtag_s8_vector) {
+          total_size_in_bytes = 8 + element_count;
+        } else if (subtag == subtag_complex_double_float_vector) {
+          total_size_in_bytes = 8 + (element_count<<4); /* 16m41; see mark_root */
+        } else {                /* 16-bit: s16, u16 */
+          total_size_in_bytes = 8 + (element_count<<1);
+        }
+      }
+
+      suffix_dnodes = ((total_size_in_bytes+(dnode_size-1))>>dnode_shift)-1;
+
+      if (suffix_dnodes) {
+        check_marked_extent(this, dnode, suffix_dnodes);
+        set_n_bits(GCmarkbits, dnode+1, suffix_dnodes);
+      }
+
+      if (!nodeheader_tag_p(tag_n)) goto Climb;
+
+      if (subtag == subtag_hash_vector) {            /* ppc-gc.c:729-739 */
+        /* Splice onto weakvll, then climb */
+        LispObj flags = ((hash_table_vector_header *) base)->flags;
+
+        if (flags & nhash_weak_mask) {
+          ((hash_table_vector_header *) base)->cache_key = undefined;
+          ((hash_table_vector_header *) base)->cache_value = lisp_nil;
+          dws_mark_weak_htabv(this);
+          element_count = hash_table_vector_header_count;
+        }
+      }
+
+      if (subtag == subtag_pool) {
+        deref(this, 1) = lisp_nil;
+      }
+
+      if (subtag == subtag_weak) {
+        natural weak_type = (natural) base[2];
+        if (weak_type >> population_termination_bit)
+          element_count -= 2;
+        else
+          element_count -= 1;
+      }
+
+      /* ARM64-DEVIATION (x86-gc.c:1128): keep the reference's 3-bit tag
+         in the scan pointer (PPC64 used a raw untagged pointer,
+         ppc-gc.c:753 â€” its tag space differs). */
+      this = (LispObj)(base) + (tag_of(this)) + ((element_count+1) << node_shift);
+      goto MarkVectorLoop;
+    }
+
+  ClimbVector:                                       /* ppc-gc.c:757-759 */
+    prev = indirect_node(this);
+    indirect_node(this) = next;
+
+  MarkVectorLoop:                                    /* ppc-gc.c:761-774 */
+    this -= node_size;
+    next = indirect_node(this);
+    tag_n = fulltag_of(next);
+    if (nodeheader_tag_p(tag_n)) goto MarkVectorDone;
+    if (!is_node_fulltag(tag_n)) goto MarkVectorLoop;
+    dnode = gc_area_dnode(next);
+    if (dnode >= GCndnodes_in_area) goto MarkVectorLoop;
+    set_bits_vars(markbits,dnode,bitsp,bits,mask);
+    if (bits & mask) goto MarkVectorLoop;
+    *bitsp = (bits | mask);
+    indirect_node(this) = prev;
+    if (tag_n == fulltag_cons) goto DescendCons;
+    goto DescendVector;
+
+  MarkVectorDone:                                    /* ppc-gc.c:776-785 */
+    /* "next" is the vector header; "this" = header address + the 3-bit tag of
+       the original reference (indirect_node masks ~tagmask, so the loop stops
+       at the residue that node-aligns onto the header: 4 for a misc climb, 7
+       for a symbol climb).  Restore the original fulltag.
+
+       fulltag_function removed (patch 0055): tag residue 7 can ONLY be a
+       symbol reference now, so the old header-subtag disambiguation (7 ->
+       function iff subtag_function -- needed when fulltag_symbol(7) and
+       fulltag_function(15) shared one {t, t+8} pair) collapses to an
+       unconditional fulltag_symbol.  Function references are misc-tagged
+       and take the tag_4 arm like every other misc climb.
+
+       The MISC arm history (16m42): it tested `tag_of(this) == fulltag_misc',
+       and tag_of() masks with tagmask=7 while fulltag_misc is 12 -- a 3-bit
+       value compared against 12 is NEVER equal, so the branch was dead and
+       every misc vector was restored as fulltag_symbol(7).  Spelled tag_4
+       since then. */
+    if (tag_of(this) == tag_4) {
+      this = node_aligned(this) + fulltag_misc;
+    } else {
+      this = node_aligned(this) + fulltag_symbol;
+    }
+
+    if (header_subtag(next) == subtag_weak) {
+      deref(this, 1) = GCweakvll;
+      GCweakvll = untag(this);
+    }
+    goto Climb;
+  }
+}
+
+LispObj *
+skip_over_ivector(natural start, LispObj header)     /* ppc-gc.c:789-836 */
+{
+  natural
+    element_count = header_element_count(header),
+    subtag = header_subtag(header),
+    nbytes;
+
+  /* ppc-gc.c:798-818 (PPC64 switch), arm64 classes (see mark_root) */
   switch (fulltag_of(header)) {
   case ivector_class_64_bit:
     nbytes = element_count << 3;
@@ -33,74 +1084,1745 @@ skip_over_ivector(natural start, LispObj header)
   case ivector_class_other_bit:
   default:
     if (subtag == subtag_bit_vector) {
-      nbytes = (element_count + 7) >> 3;
-    } else if (subtag == subtag_complex_double_float_vector) {
-      nbytes = element_count << 4;
+      nbytes = (element_count+7)>>3;
     } else if (subtag >= subtag_s8_vector) {
-      nbytes = element_count;           /* 8-bit elements */
-    } else {
-      nbytes = element_count << 1;      /* 16-bit elements */
+      nbytes = element_count;
+    } else if (subtag == subtag_complex_double_float_vector) {
+      /* 16m41: 2 doubles = 16 bytes per element.  LAYOUT NOTE (this is the
+         authority the other four sizing sites and the allocators agree with):
+         data starts immediately after the header, NOT after an 8-byte pad as
+         on x8664 (l0-array.lisp:862-865).  ARM64-DEVIATION, deliberate: both
+         our allocators compute 16n with no pad (spentry-A misc_alloc label 3
+         and stack_misc_alloc label 6, `add imm1,arg_y,arg_y'), subtag-bytes
+         (patch 0015) says (ash n 4), and aarch64 needs only 8-byte alignment
+         for LDP d/LDR q on normal memory, so x8664's pad buys nothing here.
+         The dnode round-up below puts the slack at the END instead, so the
+         total object size matches x8664's 16n+16 either way.  UPSTREAM ITEM:
+         confirm with Matt that arm64 wants no pad. */
+      nbytes = element_count << 4;
+    } else {                    /* 16-bit: s16, u16 */
+      nbytes = element_count << 1;
     }
   }
-  /* one node for the header, then the elements, rounded up to a dnode. */
-  return ptr_from_lispobj(start + ((nbytes + node_size + (dnode_size - 1))
-                                   & ~(dnode_size - 1)));
+  return ptr_from_lispobj(start+(~15 & (nbytes + 8 + 15)));
+}
+
+
+void
+check_refmap_consistency(LispObj *start, LispObj *end, bitvector refbits, bitvector refidx)
+{                                                    /* ppc-gc.c:839-905 */
+  LispObj x1, *base = start, *prev = start;
+  int tag;
+  natural ref_dnode, node_dnode;
+  Boolean intergen_ref, lenient_next_dnode = false, lenient_this_dnode = false;
+
+  while (start < end) {
+    x1 = *start;
+    tag = fulltag_of(x1);
+    if (immheader_tag_p(tag)) {
+      prev = start;
+      start = skip_over_ivector(ptr_to_lispobj(start), x1);
+    } else {
+      if (nodeheader_tag_p(tag)) {
+        prev = start;
+      }
+      intergen_ref = false;
+      if (header_subtag(x1) == subtag_weak) {
+        lenient_next_dnode = true;
+      }
+      if (is_node_fulltag(tag)) {
+        node_dnode = gc_area_dnode(x1);
+        if (node_dnode < GCndnodes_in_area) {
+          intergen_ref = true;
+        }
+      }
+      if (lenient_this_dnode) {
+        lenient_this_dnode = false;
+      } else {
+        if (intergen_ref == false) {
+          x1 = start[1];
+          tag = fulltag_of(x1);
+          if (is_node_fulltag(tag)) {
+            node_dnode = gc_area_dnode(x1);
+            if (node_dnode < GCndnodes_in_area) {
+              intergen_ref = true;
+            }
+          }
+        }
+      }
+      if (intergen_ref) {
+        /* Consumer side of the spentry-B/D write-barrier memoization:
+           dnode math on the doubleword address, bitnumber>>8 into the
+           refidx (same producer protocol). */
+        ref_dnode = area_dnode(start, base);
+        if (!ref_bit(refbits, ref_dnode)) {
+          Bug(NULL, "Missing memoization in doublenode at 0x" LISP "\n", start);
+          set_bit(refbits, ref_dnode);
+          if (refidx) {
+            set_bit(refidx,ref_dnode>>8);
+          }
+        } else {
+          if (refidx) {
+            if (!ref_bit(refidx, ref_dnode>>8)) {
+              Bug(NULL, "Memoization for doublenode at 0x" LISP " not indexed\n", start);
+              set_bit(refidx,ref_dnode>>8);
+            }
+          }
+        }
+      }
+      start += 2;
+      if (lenient_next_dnode) {
+        lenient_this_dnode = true;
+      }
+      lenient_next_dnode = false;
+    }
+  }
+}
+
+
+void
+mark_simple_area_range(LispObj *start, LispObj *end) /* ppc-gc.c:912-963 */
+{
+  LispObj x1, *base;
+  int tag;
+
+  while (start < end) {
+    x1 = *start;
+    tag = fulltag_of(x1);
+    if (immheader_tag_p(tag)) {
+      start = (LispObj *)ptr_from_lispobj(skip_over_ivector(ptr_to_lispobj(start), x1));
+    } else if (!nodeheader_tag_p(tag)) {
+      ++start;
+      mark_root(x1);
+      mark_root(*start++);
+    } else {
+      int subtag = header_subtag(x1);
+      natural element_count = header_element_count(x1);
+      natural size = (element_count+1 + 1) & ~1;
+
+      if (subtag == subtag_hash_vector) {
+        LispObj flags = ((hash_table_vector_header *) start)->flags;
+
+        if (flags & nhash_weak_mask) {
+          ((hash_table_vector_header *) start)->cache_key = undefined;
+          ((hash_table_vector_header *) start)->cache_value = lisp_nil;
+          mark_weak_htabv((LispObj)start);
+          element_count = 0;
+        }
+      }
+      if (subtag == subtag_pool) {
+        start[1] = lisp_nil;
+      }
+
+      if (subtag == subtag_weak) {
+        natural weak_type = (natural) start[2];
+        if (weak_type >> population_termination_bit)
+          element_count -= 2;
+        else
+          element_count -= 1;
+        start[1] = GCweakvll;
+        GCweakvll = ptr_to_lispobj(start);
+      }
+
+      /* OPEN-ENTRYPOINT: function gvectors' entrypoint slot is visited
+         here; a fixnum-tagged locative (assumed convention) no-ops. */
+      base = start + element_count + 1;
+      while(element_count--) {
+        mark_root(*--base);
+      }
+      start += size;
+    }
+  }
+}
+
+
+/* Mark a tstack area */
+void
+mark_tstack_area(area *a)                            /* ppc-gc.c:967-986 */
+{
+  /* Matt's arm64 HAS a tsp/tstack (tsp=x24; tcr.save_tsp/next_tsp/
+     ts_area) â€” PPC-shaped {backlink, type, data...} frames; the walk
+     ports verbatim (ARM32's empty stub, arm-gc.c:851, does NOT apply). */
+  LispObj
+    *current,
+    *next,
+    *start = (LispObj *) (a->active),
+    *end = start,
+    *limit = (LispObj *) (a->high);
+
+  for (current = start;
+       end != limit;
+       current = next) {
+    next = (LispObj *) ptr_from_lispobj(*current);
+    end = ((next >= start) && (next < limit)) ? next : limit;
+    if (current[1] == 0) {
+      mark_simple_area_range(current+2, end);
+    }
+  }
 }
 
 /*
-  Mark Lisp roots on the control stack, from a->active up to a->high.
+  It's really important that headers never wind up in tagged registers.
+  Those registers would (possibly) get pushed on the vstack and confuse
+  the hell out of this routine.
 
-  When the thread has Lisp valence, a->active is its live SP.  When it
-  was suspended in foreign code, the suspend path has already saved
-  a->active to tcr->last_lisp_frame so the raw C frames below the
-  boundary frame are simply not in range here.
+  vstacks are just treated as a "simple area range", possibly with
+  an extra word at the top (where the area's active pointer points.)
+  */
 
-  Every word this loop lands on is a frame-leading word, and on arm64 that is
-  exactly one of two things:
-
-    a lisp_frame_marker: a {marker,savevsp,savefn,savelr} Lisp frame,
-        built by the save-lisp-context vinsns.  It contains two roots,
-        namely savefn and savelr.
-
-    an immheader: a u64-vector that encapsulates or covers an unboxed region.
-        Two producers make these on the control stack:
-        
-        1. A C frame, whose element could is ultimately shrunk to expose
-           a boundary lisp frame at its high end.
-        2. In the callback case, a u64-vector set up to cover an entire
-           lisp->C->...->C stretch.
-
-        Either way, skip_over_ivector steps over the whole covered
-        region in one hop and lands us on the next real frame.
-
-  Unlike on other ports, a fixnum-tagged, zero, or otherwise unrecognized
-  word is a bug (not a backlink or anything else).  Stack-consed objects
-  live on the temp stack, never here, so there's no node-header case, and
-  no stack_alloc_marker case either.
-*/
 void
-mark_cstack_area(area *a)
+mark_vstack_area(area *a)                            /* ppc-gc.c:997-1013 */
 {
-  LispObj *current = (LispObj *)(a->active),
-          *limit = (LispObj *)(a->high),
-          header;
+  LispObj
+    *start = (LispObj *) a->active,
+    *end = (LispObj *) a->high;
 
-  while (current < limit) {
+#if 0
+  fprintf(dbgout, "mark VSP range: 0x%lx:0x%lx\n", start, end);
+#endif
+  if (((natural)start) & (sizeof(natural))) {
+    /* Odd number of words.  Mark the first (can't be a header) */
+    mark_root(*start);
+    ++start;
+  }
+  mark_simple_area_range(start, end);
+}
+
+
+/*
+  Mark lisp frames on the control stack.
+
+  ARM64-DEVIATION (whole function; ppc-gc.c:1021-1049 walks PPC backlink
+  frames): arm64 uses MARKER frames â€” the walk is arm-gc.c:889-928, with
+  one correction: the nodeheader/immheader tests are moved BEFORE the
+  `(header & fixnummask) == 0' raw-pointer test.  ARM32's order is unsafe
+  here because arm64 immheader_1(12) â‰¡ 0 (mod 4): a stack-consed ivector
+  header (e.g. simple_base_string, header fulltag 12) would be misread as
+  a raw backlink.  Raw stack addresses are 16-aligned (fulltag 0 =
+  even_fixnum), so they can never be mistaken for headers by the moved
+  tests.
+*/
+
+void
+mark_cstack_area(area *a)                            /* arm-gc.c:889-928 */
+{
+  LispObj *current = (LispObj *)(a->active)
+    , *limit = (LispObj*)(a->high), header;
+  lisp_frame *frame;
+  CSTACK_TRAIL_DECL;                                 /* 16m41 DIAG */
+
+  while(current < limit) {
     header = *current;
+    _cfrom = current;                                /* 16m41 DIAG */
 
     if (header == lisp_frame_marker) {
-      lisp_frame *frame = (lisp_frame *)current;
-      mark_root(frame->savefn);         /* the running function */
-      mark_pc_root(frame->savelr);      /* return address -> code vector */
-      current += sizeof(lisp_frame) / sizeof(LispObj);  /* 4 nodes */
-    } else if (immheader_tag_p(fulltag_of(header))) {
-      current = skip_over_ivector((natural)current, header);
+      frame = (lisp_frame *)current;
+
+      mark_root(frame->savevsp); /* likely a fixnum */
+      mark_root(frame->savefn);
+      mark_pc_root(frame->savelr);
+      current += sizeof(lisp_frame)/sizeof(LispObj);
+      CSTACK_TRAIL_STEP(CB_FRAME);                   /* 16m41 DIAG */
+    } else if ((header == stack_alloc_marker) || (header == 0)) {
+      current += 2;
+      CSTACK_TRAIL_STEP(CB_MARKER0);                 /* 16m41 DIAG */
+    } else if (nodeheader_tag_p(fulltag_of(header))) { /* REORDERED, see above */
+      natural elements = header_element_count(header);
+
+      current++;
+      while(elements--) {
+        mark_root(*current++);
+      }
+      if (((natural)current) & sizeof(natural)) {
+        current++;
+      }
+      CSTACK_TRAIL_STEP(CB_NODE);                    /* 16m41 DIAG */
+    } else if (immheader_tag_p(fulltag_of(header))) {  /* REORDERED, see above */
+      current=(LispObj *)skip_over_ivector((natural)current,header);
+      CSTACK_TRAIL_STEP(CB_IMM);                     /* 16m41 DIAG */
+    } else if ((header & fixnummask) == 0) {
+      /* 16m40: the note here claimed fixnummask=3 was "suspected ARM32
+         copy-pasta, report OPEN #3", justified as a 4-aligned test.  STALE:
+         at this pin arm64-constants.h:32 is DEFCONST(fixnummask, 7), correct
+         for fixnumshift=3, so this is an 8-aligned test and OPEN #3 is moot.
+         Do NOT re-open it.
+         What IS true, and is the live hazard: this branch cannot tell a boxed
+         FIXNUM from a raw backlink -- with fixnumshift=3 both have the low 3
+         bits clear -- so a fixnum on the cstack is followed as a pointer.
+         That is a property of this linear-scan shape, not of the mask.  See
+         comms/ARM64-CSTACK-WALK-DECISION.md before touching it. */
+      current = (LispObj *)header;
+      CSTACK_TRAIL_STEP(CB_BACKLINK);                /* 16m41 DIAG */
     } else {
-      Bug(NULL, "Unrecognized control stack word 0x" LISP " at 0x" LISP "\n",
-          header, (natural)current);
+      /* 16m41 DIAG: dump the trail before dying -- the shape leading in says
+         more about an unclassifiable word than the word itself does. */
+      cstack_walk_report("mark_cstack_area", "UNKNOWN STACK WORD", a,
+                         current, limit, _ctrail, _cnsteps, _chisto);
+      Bug(NULL, "Unknown stack word at 0x" LISP ":\n", current);
+    }
+    /* 16m41 DIAG: report AT the overshooting step, not after the loop. */
+    if (current > limit) {
+      if (!cstack_walk_report("mark_cstack_area", "RAN OFF THE END of cstack area",
+                              a, current, limit, _ctrail, _cnsteps, _chisto)) {
+        Bug(NULL, "Ran off the end of cstack area\n");
+      }
+      current = limit;                  /* clamp: marking is now INCOMPLETE */
     }
   }
   if (current != limit) {
-    Bug(NULL, "Ran off the end of the control stack area\n");
+    Bug(NULL, "Ran off the end of cstack area\n");
   }
+}
+
+
+
+/* Mark the lisp objects in an exception frame */
+void
+mark_xp(ExceptionInformation *xp)                    /* ppc-gc.c:1054-1083 */
+{
+  natural *regs = (natural *) xpGPRvector(xp);
+  int r;
+  /* PPC marks regs[fn..31] as node roots and PC/LR/CTR/loc_pc as pc
+     locatives (ppc-gc.c:1071-1080).  The arm64 BOXED-node-register SET
+     (PROPOSED â€” see file header): fn(x7)..rnil(x23), skipping x18 (the
+     platform register).  pc locatives: PC and LR only (no CTR/loc_pc on
+     ARM64 â€” ARM64-DEVIATION, arm-gc.c:956-957).
+
+     In general, marking a locative is more expensive than marking
+     a node is, since it may be neccessary to back up and find the
+     containing object's header.  Since exception frames contain
+     many locatives, it'd be wise to mark them *after* marking the
+     stacks, nilreg-relative globals, etc.
+     */
+
+  for (r = fn; r <= rnil; r++) {
+    if (r != 18) {
+      mark_root((regs[r]));
+    }
+  }
+
+  mark_pc_root(ptr_to_lispobj(xpPC(xp)));
+  mark_pc_root(ptr_to_lispobj(xpLR(xp)));
+}
+
+/* A "pagelet" contains 32 doublewords.  The relocation table contains
+   a word for each pagelet which defines the lowest address to which
+   dnodes on that pagelet will be relocated.
+
+   The relocation address of a given pagelet is the sum of the relocation
+   address for the preceding pagelet and the number of bytes occupied by
+   marked objects on the preceding pagelet.
+
+   (On 64-bit platforms a markbits word covers 64 dnodes =
+   nbits_in_word; "32" above is the 32-bit heritage of the comment â€”
+   the code below is the PPC64/WORD_SIZE-64 version: qnode = unsigned
+   short, 4 qnodes per markbits word.)
+*/
+
+LispObj
+calculate_relocation()                               /* ppc-gc.c:1094-1128 */
+{
+  LispObj *relocptr = GCrelocptr;
+  LispObj current = GCareadynamiclow;
+  bitvector
+    markbits = GCdynamic_markbits;
+  qnode *q = (qnode *) markbits;
+  natural npagelets = ((GCndynamic_dnodes_in_area+(nbits_in_word-1))>>bitmap_shift);
+  natural thesebits;
+  LispObj first = 0;
+
+  /* Endianness note: summing one_bits over all four qnodes of a word is
+     order-independent, and `thesebits'/BIT0_MASK work on the whole
+     natural â€” no little-endian fix needed here (unlike
+     dnode_forwarding_address below). */
+  do {
+    *relocptr++ = current;
+    thesebits = *markbits++;
+    if (thesebits == ALL_ONES) {
+      current += nbits_in_word*dnode_size;
+      q += 4; /* sic */
+    } else {
+      if (!first) {
+        first = current;
+        while (thesebits & BIT0_MASK) {
+          first += dnode_size;
+          thesebits += thesebits;
+        }
+      }
+      current += one_bits(*q++);
+      current += one_bits(*q++);
+      current += one_bits(*q++);
+      current += one_bits(*q++);
+    }
+  } while(--npagelets);
+  *relocptr++ = current;
+  return first ? first : current;
+}
+
+/* 16m38: WHICH ROOT held the reference?  dnode_forwarding_address knows the
+   object but not the referrer, and the referrer is the whole question: an
+   "unmarked object being forwarded" means the forwarding pass reached a
+   reference the MARK pass never followed, so naming the area or register that
+   held it names the gap.  Set on entry to each forward_* walker; costs one
+   store per area (not per slot) and is read only inside the GCDebug branch. */
+const char *GCforward_context = "(none yet)";
+int GCforward_reg = -1;
+/* 16m39: WHICH SLOT, and does the MARK side agree?  The 16m38 Bug() named the
+   area (cstack) but not the referring slot, and it read only the FORWARD side's
+   view of the markbits (GCdynamic_markbits, dynamiclow-relative).  mark_root
+   writes GCmarkbits at a GCarealow-relative dnode; those views coincide only if
+   the static_dnodes prefix arithmetic is exact, so the Bug below now evaluates
+   BOTH views of the failing node.  Slot/branch are set only in the cold cstack
+   and xp walkers (per-slot stores there are a handful of frames, not the heap
+   sweep), so the hot forward_range path still pays one store per area. */
+LispObj *GCforward_slot = NULL;
+const char *GCforward_branch = "(unset)";
+
+LispObj
+dnode_forwarding_address(natural dnode, int tag_n)   /* ppc-gc.c:1131-1174 (PPC64) */
+{
+  natural pagelet, nbits;
+  unsigned int near_bits;
+  LispObj new;
+
+  if (GCDebug) {
+    if (! ref_bit(GCdynamic_markbits, dnode)) {
+      /* 16m38: the bare assert (ppc-gc.c:1140) says WHAT went wrong and nothing
+         about WHICH object, and one boot buys one Bug() -- so spend it.
+         dnode here is relative to GCareadynamiclow, because every caller reaches
+         this through gc_dynamic_area_dnode (gc.h:111 -- area_dnode(w,low) is
+         ((w - low) >> dnode_shift), gc.h:109), so the object's first word sits at
+         GCareadynamiclow + (dnode << dnode_shift).
+         The NEIGHBOURING mark bits are the discriminating fact: if dnode-1 is
+         marked then this reference points INTO a live object -- an interior or
+         off-by-one pointer, whose cause is a tag/offset error at the referring
+         site -- whereas an unmarked run either side means the mark phase never
+         reached the object at all, i.e. a root-set or subtag-dispatch gap. Those
+         two want opposite investigations, and guessing between them is what this
+         line exists to avoid. */
+      LispObj addr = GCareadynamiclow + (((natural)dnode) << dnode_shift);
+      LispObj w0 = 0, w1 = 0;
+      int readable = ((addr >= GCareadynamiclow) &&
+                      ((addr + node_size) <
+                       ptr_to_lispobj(active_dynamic_area->high)));
+      /* 16m39: the MARK side's view of this same node.  mark_root computes
+         gc_area_dnode (GCarealow-relative) and tests/sets GCmarkbits; the
+         check above read GCdynamic_markbits at a GCareadynamiclow-relative
+         dnode.  node reconstructs the tagged ref exactly: dnode came from
+         (node - GCareadynamiclow) >> dnode_shift, and tag_n restores the
+         low bits that shift discarded. */
+      LispObj node = addr + tag_n;
+      natural mdnode = gc_area_dnode(node);
+      int m_in_bounds = (mdnode < GCndnodes_in_area);
+      int m_bit = m_in_bounds ? (ref_bit(GCmarkbits, mdnode) ? 1 : 0) : -1;
+      LispObj s0 = 0, s1 = 0, s2 = 0, s3 = 0;
+
+      if (readable) {
+        w0 = *(LispObj *)ptr_from_lispobj(addr);
+        w1 = *(LispObj *)ptr_from_lispobj(addr + node_size);
+      }
+      if (GCforward_slot != NULL) {
+        s0 = GCforward_slot[-1];
+        s1 = GCforward_slot[0];
+        s2 = GCforward_slot[1];
+        s3 = GCforward_slot[2];
+      }
+      Bug(NULL, "unmarked object being forwarded!\n"
+          "  dnode 0x" LISP "  tag_n %d  addr 0x" LISP "  readable %d\n"
+          "  w0 0x" LISP "  w1 0x" LISP "  (w0 as header: subtag 0x%02x)\n"
+          "  markbits prev/self/next = %d/%d/%d\n"
+          "  forwarding context: %s  reg %d\n"
+          "  referring slot 0x" LISP "  branch %s  slot[-1..2] 0x" LISP
+          " 0x" LISP " 0x" LISP " 0x" LISP "\n"
+          "  mark-side view: mdnode 0x" LISP "  in-bounds %d  GCmarkbits bit %d\n"
+          "  GCmarkbits %p  GCdynamic_markbits %p  static-prefix bytes 0x" LISP "\n"
+          "  GCfirstunmarked 0x" LISP "  GCephemeral_low 0x" LISP
+          "  GCn_ephemeral_dnodes 0x" LISP "\n"
+          "  GCareadynamiclow 0x" LISP "  GCarealow 0x" LISP
+          "  dynamic active 0x" LISP " high 0x" LISP "\n",
+          (LispObj)dnode, tag_n, addr, readable,
+          w0, w1, (unsigned)(header_subtag(w0) & 0xff),
+          (dnode ? (ref_bit(GCdynamic_markbits, dnode - 1) ? 1 : 0) : -1),
+          (ref_bit(GCdynamic_markbits, dnode) ? 1 : 0),
+          (ref_bit(GCdynamic_markbits, dnode + 1) ? 1 : 0),
+          GCforward_context, GCforward_reg,
+          (LispObj)(natural)GCforward_slot, GCforward_branch, s0, s1, s2, s3,
+          (LispObj)mdnode, m_in_bounds, m_bit,
+          (void *)GCmarkbits, (void *)GCdynamic_markbits,
+          (LispObj)(GCareadynamiclow - GCarealow),
+          GCfirstunmarked, GCephemeral_low, (LispObj)GCn_ephemeral_dnodes,
+          GCareadynamiclow, GCarealow,
+          ptr_to_lispobj(active_dynamic_area->active),
+          ptr_to_lispobj(active_dynamic_area->high));
+    }
+  }
+
+  pagelet = dnode >> bitmap_shift;
+  nbits = dnode & bitmap_shift_count_mask;
+  /* ARM64-DEVIATION (arm-gc.c:1021-1023 idiom, widened to uint32):
+     markbits words are 64-bit naturals with MSB-first bit numbering
+     (BIT0_MASK = 1<<63, bits.h:28), so dnodes 0-31 of a word live in
+     its HIGH uint32.  PPC64 (big-endian) indexes uint32s with
+     dnode>>(dnode_shift+1) directly (ppc-gc.c:1146); on little-endian
+     AArch64 the uint32 index must be XORed with 1. */
+  near_bits = ((unsigned int *)GCdynamic_markbits)[(dnode>>(dnode_shift+1))^1];
+
+  if (nbits < 32) {
+    new = GCrelocptr[pagelet] + tag_n;
+    /* Increment "new" by the count of 1 bits which precede the dnode */
+    if (near_bits == 0xffffffff) {
+      return (new + (nbits << 4));
+    } else {
+      near_bits &= (0xffffffff00000000 >> nbits);
+      if (nbits > 15) {
+        new += one_bits(near_bits & 0xffff);
+      }
+      return (new + (one_bits(near_bits >> 16)));
+    }
+  } else {
+    new = GCrelocptr[pagelet+1] + tag_n;
+    nbits = 64-nbits;
+
+    if (near_bits == 0xffffffff) {
+      return (new - (nbits << 4));
+    } else {
+      /* VENDOR-UB FIXED: ppc-gc.c:1167 computes (1<<nbits)-1 with int
+         arithmetic; nbits can be 32 here (dnode â‰¡ 32 mod 64), and
+         1<<32 is UB / wrong on AArch64.  (natural)1 gives the intended
+         all-ones 32-bit mask. */
+      near_bits &= ((natural)1<<nbits)-1;
+      if (nbits > 15) {
+        new -= one_bits(near_bits >> 16);
+      }
+      return (new -  one_bits(near_bits & 0xffff));
+    }
+  }
+}
+
+
+LispObj
+locative_forwarding_address(LispObj obj)             /* ppc-gc.c:1223-1257 */
+{
+  int tag_n = fulltag_of(obj);
+  natural dnode;
+
+  /* Locatives can be tagged as misc objects, as fixnums, or be raw
+     4-byte-aligned instruction addresses (residues 0/4/8/12 mod 16 =
+     fulltags even_fixnum/misc/odd_fixnum/immheader_1).  Immediates,
+     node headers at other residues, and nil shouldn't be "forwarded".
+     ARM64-DEVIATION: `(obj & 3) == 0' is the arm64 rendering of PPC64's
+     `(tag_n & lowtag_mask) == lowtag_primary' (ppc-gc.c:1236) â€” on
+     PPC64 the four 4-aligned residues were exactly its four primary
+     tags; here they are the four tags listed above.  fulltag_cons(3) is
+     NOT accepted: arm64 conses are never pc locatives, and
+     update_locref is only applied to known locative slots. */
+  if ((obj & 3) != 0) {
+    return obj;
+  }
+
+  dnode = gc_dynamic_area_dnode(obj);
+
+  if ((dnode >= GCndynamic_dnodes_in_area) ||
+      (obj < GCfirstunmarked)) {
+    return obj;
+  }
+
+  return dnode_forwarding_address(dnode, tag_n);
+}
+
+
+
+
+void
+forward_range(LispObj *range_start, LispObj *range_end)
+{                                                    /* ppc-gc.c:1262-1320 */
+  LispObj *p = range_start, node, new;
+  int tag_n, subtag;
+  natural nwords;
+  hash_table_vector_header *hashp;
+
+  GCforward_context = "range (dynamic/static sweep)"; GCforward_reg = -1;
+  GCforward_slot = NULL; GCforward_branch = "(range)";
+
+  while (p < range_end) {
+    node = *p;
+    tag_n = fulltag_of(node);
+    if (immheader_tag_p(tag_n)) {
+      p = (LispObj *) skip_over_ivector((natural) p, node);
+    } else if (nodeheader_tag_p(tag_n)) {
+      nwords = header_element_count(node);
+      nwords += (1 - (nwords&1));
+      if ((header_subtag(node) == subtag_hash_vector) &&
+          ((((hash_table_vector_header *)p)->flags) & nhash_track_keys_mask)) {
+        natural skip = (sizeof(hash_table_vector_header)/sizeof(LispObj))-1;
+        hashp = (hash_table_vector_header *) p;
+        p++;
+        nwords -= skip;
+        while(skip--) {
+          update_noderef(p);
+          p++;
+        }
+        /* "nwords" is odd at this point: there are (floor nwords 2)
+           key/value pairs to look at, and then an extra word for
+           alignment.  Process them two at a time, then bump "p"
+           past the alignment word. */
+        nwords >>= 1;
+        while(nwords--) {
+          if (update_noderef(p) && hashp) {
+            hashp->flags |= nhash_key_moved_mask;
+            hashp = NULL;
+          }
+          p++;
+          update_noderef(p);
+          p++;
+        }
+        *p++ = 0;
+      } else {
+        p++;
+        /* OPEN-ENTRYPOINT (ARM64-DEVIATION, arm-gc.c:1129-1135): the
+           first slot of a function (pseudofunction removed upstream @ a6314ba) is the entrypoint â€”
+           a locative into its code vector, not a node. */
+        subtag = header_subtag(node);
+        if (subtag == subtag_function) {
+          update_locref(p);
+          p++;
+          nwords--;
+        }
+        while(nwords--) {
+          update_noderef(p);
+          p++;
+        }
+      }
+    } else {
+      new = node_forwarding_address(node);
+      if (new != node) {
+        *p = new;
+      }
+      p++;
+      update_noderef(p);
+      p++;
+    }
+  }
+}
+
+
+
+
+/* Forward a tstack area */
+void
+forward_tstack_area(area *a)                         /* ppc-gc.c:1326-1345 */
+{
+  LispObj
+    *current,
+    *next,
+    *start = (LispObj *) a->active,
+    *end = start,
+    *limit = (LispObj *) (a->high);
+
+  GCforward_context = "tstack"; GCforward_reg = -1;
+  GCforward_slot = NULL; GCforward_branch = "(tstack)";
+
+  for (current = start;
+       end != limit;
+       current = next) {
+    next = ptr_from_lispobj(*current);
+    end = ((next >= start) && (next < limit)) ? next : limit;
+    if (current[1] == 0) {
+      forward_range(current+2, end);
+    }
+  }
+}
+
+/* Forward a vstack area */
+void
+forward_vstack_area(area *a)                         /* ppc-gc.c:1348-1363 */
+{
+  LispObj
+    *p = (LispObj *) a->active,
+    *q = (LispObj *) a->high;
+
+  GCforward_context = "vstack"; GCforward_reg = -1;
+  GCforward_slot = NULL; GCforward_branch = "(vstack)";
+
+#ifdef DEBUG
+  fprintf(dbgout,"Forward range 0x%x/0x%x (owner 0x%x)\n",p,q,a->owner);
+#endif
+  if (((natural)p) & sizeof(natural)) {
+    update_noderef(p);
+    p++;
+  }
+  forward_range(p, q);
+}
+
+void
+forward_cstack_area(area *a)                         /* arm-gc.c:1179-1223 */
+{
+  /* ARM64-DEVIATION (whole function; ppc-gc.c:1365-1384 walks backlink
+     frames): marker-frame walk, case order corrected as in
+     mark_cstack_area. */
+  LispObj *current = (LispObj *)(a->active)
+    , *limit = (LispObj*)(a->high), header;
+  lisp_frame *frame;
+  unsigned subtag;
+  CSTACK_TRAIL_DECL;                                 /* 16m41 DIAG */
+
+  GCforward_context = "cstack"; GCforward_reg = -1;
+  GCforward_slot = NULL; GCforward_branch = "(cstack, pre-slot)";
+
+  while (current < limit) {
+    header = *current;
+    _cfrom = current;                                /* 16m41 DIAG */
+
+    if (header == lisp_frame_marker) {
+      frame = (lisp_frame *)current;
+
+      GCforward_slot = &(frame->savefn);
+      GCforward_branch = "lisp_frame.savefn";
+      update_noderef(&(frame->savefn));
+      GCforward_slot = &(frame->savelr);
+      GCforward_branch = "lisp_frame.savelr";
+      update_locref(&(frame->savelr));
+      current += sizeof(lisp_frame)/sizeof(LispObj);
+      CSTACK_TRAIL_STEP(CB_FRAME);                   /* 16m41 DIAG */
+    } else if ((header == stack_alloc_marker) || (header == 0)) {
+      current += 2;
+      CSTACK_TRAIL_STEP(CB_MARKER0);                 /* 16m41 DIAG */
+    } else if (nodeheader_tag_p(fulltag_of(header))) { /* REORDERED, see mark_cstack_area */
+      natural elements = header_element_count(header);
+
+      current++;
+      /* OPEN-ENTRYPOINT (arm-gc.c:1203-1209) */
+      subtag = header_subtag(header);
+      if (subtag == subtag_function) {
+        GCforward_slot = current;
+        GCforward_branch = "stack gvector fn entrypoint";
+        update_locref(current);
+        current++;
+        elements--;
+      }
+      GCforward_branch = "stack gvector slot";
+      while(elements--) {
+        GCforward_slot = current;
+        update_noderef(current);
+        current++;
+      }
+      if (((natural)current) & sizeof(natural)) {
+        current++;
+      }
+      CSTACK_TRAIL_STEP(CB_NODE);                    /* 16m41 DIAG */
+    } else if (immheader_tag_p(fulltag_of(header))) {  /* REORDERED */
+      current=(LispObj *)skip_over_ivector((natural)current,header);
+      CSTACK_TRAIL_STEP(CB_IMM);                     /* 16m41 DIAG */
+    } else if ((header & fixnummask) == 0) {
+      current = (LispObj *)header;
+      CSTACK_TRAIL_STEP(CB_BACKLINK);                /* 16m41 DIAG */
+    } else {
+      cstack_walk_report("forward_cstack_area", "UNKNOWN STACK WORD", a,
+                         current, limit, _ctrail, _cnsteps, _chisto);
+      Bug(NULL, "Unknown stack word at 0x" LISP ":\n", current);
+    }
+    /* ARM64-DEVIATION (16m41): the reference walk has no end-of-area assertion
+       here (asymmetric with mark_cstack_area), so an overshoot in the FORWARD
+       pass was silent -- and a forward pass that skips a region leaves stale
+       pointers into freed space, i.e. silent corruption instead of a crash we
+       can read.  Report and die: loud failure beats a corrupted heap. */
+    if (current > limit) {
+      cstack_walk_report("forward_cstack_area", "RAN OFF THE END of cstack area",
+                         a, current, limit, _ctrail, _cnsteps, _chisto);
+      Bug(NULL, "Ran off the end of cstack area (forward)\n");
+    }
+  }
+}
+
+
+
+void
+forward_xp(ExceptionInformation *xp)                 /* ppc-gc.c:1388-1409 */
+{
+  natural *regs = (natural *) xpGPRvector(xp);
+
+  int r;
+
+  /* Same register SET as mark_xp (see file header); PC and LR are
+     treated as "locatives" (no CTR/loc_pc on ARM64 â€” ARM64-DEVIATION,
+     arm-gc.c:1243-1244). */
+
+  GCforward_context = "xp GPR";
+  GCforward_branch = "(xp)";
+  for (r = fn; r <= rnil; r++) {
+    if (r != 18) {
+      GCforward_reg = r;
+      GCforward_slot = (LispObj *) (&(regs[r]));
+      update_noderef((LispObj*) (&(regs[r])));
+    }
+  }
+  GCforward_reg = -1; GCforward_slot = NULL;
+
+  GCforward_context = "xp PC";
+  update_locref((LispObj*) (&(xpPC(xp))));
+  GCforward_context = "xp LR";
+  update_locref((LispObj*) (&(xpLR(xp))));
+}
+
+
+void
+forward_tcr_xframes(TCR *tcr)                        /* ppc-gc.c:1412-1428 */
+{
+  xframe_list *xframes;
+  ExceptionInformation *xp;
+
+  xp = tcr->gc_context;
+  if (xp) {
+    forward_xp(xp);
+  }
+  for (xframes = tcr->xframe; xframes; xframes = xframes->prev) {
+    if (xframes->curr == xp) {
+      Bug(NULL, "forward xframe twice ???");
+    }
+    forward_xp(xframes->curr);
+  }
+}
+
+/*
+  Compact the dynamic heap (from GCfirstunmarked through its end.)
+  Return the doublenode address of the new freeptr.
+  */
+
+LispObj
+compact_dynamic_heap()                               /* ppc-gc.c:1437-1607 */
+{
+  LispObj *src = ptr_from_lispobj(GCfirstunmarked), *dest = src, node, new;
+  natural
+    elements,
+    dnode = gc_area_dnode(GCfirstunmarked),
+    node_dnodes = 0,
+    imm_dnodes = 0,
+    bitidx,
+    *bitsp,
+    bits,
+    nextbit,
+    diff;
+  int tag, subtag;
+  bitvector markbits = GCmarkbits;
+
+  /* 16m39: self-attribute.  This function Bug()ed while GCforward_context
+     still said "cstack" (the walkers' residue), and the 16m38 handoff
+     chased a stack-walker gap for it.  An unmarked ref found HERE means a
+     MARKED object's slot references an unmarked object: mark-closure gap
+     or a dead entry a weak/GCTWA pass failed to scrub -- a different
+     investigation from a root-set gap.  NB the gc-common.c sites between
+     the area loop and here (forward_memoized_area) and after (
+     forward_weakvll_links) still can't self-attribute; a Bug tagged with a
+     walker name that the slot value contradicts is one of THOSE. */
+  GCforward_context = "compact (slot of a MARKED object)";
+  GCforward_slot = NULL; GCforward_branch = "(compact)";
+    /* keep track of whether or not we saw any
+       code_vector headers, and only flush cache if so. */
+  Boolean GCrelocated_code_vector = false;
+
+  if (dnode < GCndnodes_in_area) {
+    lisp_global(FWDNUM) += (1<<fixnum_shift);
+
+    set_bitidx_vars(markbits,dnode,bitsp,bits,bitidx);
+    while (dnode < GCndnodes_in_area) {
+      if (bits == 0) {
+        int remain = nbits_in_word - bitidx;
+        dnode += remain;
+        src += (remain+remain);
+        bits = *++bitsp;
+        bitidx = 0;
+      } else {
+        /* Have a non-zero markbits word; all bits more significant
+           than "bitidx" are 0.  Count leading zeros in "bits"
+           (there'll be at least "bitidx" of them.)  If there are more
+           than "bitidx" leading zeros, bump "dnode", "bitidx", and
+           "src" by the difference. */
+        nextbit = count_leading_zeros(bits);
+        if ((diff = (nextbit - bitidx)) != 0) {
+          dnode += diff;
+          bitidx = nextbit;
+          src += (diff+diff);
+        }
+
+        if (GCDebug) {
+          if (dest != ptr_from_lispobj(locative_forwarding_address(ptr_to_lispobj(src)))) {
+            Bug(NULL, "Out of synch in heap compaction.  Forwarding from 0x%lx to 0x%lx,\n expected to go to 0x%lx\n",
+                src, dest, locative_forwarding_address(ptr_to_lispobj(src)));
+          }
+        }
+
+        node = *src++;
+        tag = fulltag_of(node);
+        if (nodeheader_tag_p(tag)) {                 /* ppc-gc.c:1490-1533 */
+          elements = header_element_count(node);
+          node_dnodes = (elements+2)>>1;
+          dnode += node_dnodes;
+          if ((header_subtag(node) == subtag_hash_vector) &&
+              (((hash_table_vector_header *) (src-1))->flags & nhash_track_keys_mask)) {
+            hash_table_vector_header *hashp = (hash_table_vector_header *) dest;
+            int skip = (sizeof(hash_table_vector_header)/sizeof(LispObj))-1;
+
+            *dest++ = node;
+            elements -= skip;
+            while(skip--) {
+              *dest++ = node_forwarding_address(*src++);
+            }
+            /* There should be an even number of (key/value) pairs in elements;
+               an extra alignment word follows. */
+            elements >>= 1;
+            while (elements--) {
+              if (hashp) {
+                node = *src++;
+                new = node_forwarding_address(node);
+                if (new != node) {
+                  hashp->flags |= nhash_key_moved_mask;
+                  hashp = NULL;
+                  *dest++ = new;
+                } else {
+                  *dest++ = node;
+                }
+              } else {
+                *dest++ = node_forwarding_address(*src++);
+              }
+              *dest++ = node_forwarding_address(*src++);
+            }
+            *dest++ = 0;
+            src++;
+          } else {
+            *dest++ = node;
+            /* OPEN-ENTRYPOINT (ARM64-DEVIATION, arm-gc.c:1391-1398):
+               the first slot of a function (pseudofunction removed upstream @ a6314ba) is its
+               entrypoint locative. */
+            subtag = header_subtag(node);
+            if (subtag == subtag_function) {
+              *dest++ = locative_forwarding_address(*src++);
+            } else {
+              *dest++ = node_forwarding_address(*src++);
+            }
+            while(--node_dnodes) {
+              *dest++ = node_forwarding_address(*src++);
+              *dest++ = node_forwarding_address(*src++);
+            }
+          }
+          set_bitidx_vars(markbits,dnode,bitsp,bits,bitidx);
+        } else if (immheader_tag_p(tag)) {           /* ppc-gc.c:1534-1587 */
+          *dest++ = node;
+          *dest++ = *src++;
+          elements = header_element_count(node);
+          tag = header_subtag(node);
+
+          /* ppc-gc.c:1541-1561 (PPC64 class switch) re-keyed to arm64
+             classes; a subtag's low 4 bits ARE its immheader class.
+             PPC64's ivector_class_8_bit case folds into other_bit. */
+          switch(fulltag_of(tag)) {
+          case ivector_class_64_bit:
+            imm_dnodes = ((elements+1)+1)>>1;
+            break;
+          case ivector_class_32_bit:
+            if (tag == subtag_code_vector) {
+              GCrelocated_code_vector = true;
+            }
+            imm_dnodes = (((elements+2)+3)>>2);
+            break;
+          case ivector_class_other_bit:
+          default:
+            if (tag == subtag_bit_vector) {
+              imm_dnodes = (((elements+64)+127)>>7);
+            } else if (tag >= subtag_s8_vector) {
+              imm_dnodes = (((elements+8)+15)>>4);
+            } else if (tag == subtag_complex_double_float_vector) {
+              /* 16m41: 16 bytes/element + the 8-byte header, rounded up =
+                 ceil((16n+8)/16) = n+1.  This site COPIES imm_dnodes, so a
+                 wrong count here corrupts the heap during compaction rather
+                 than merely mis-striding a walk. */
+              imm_dnodes = elements + 1;
+            } else {            /* 16-bit: s16, u16 */
+              imm_dnodes = (((elements+4)+7)>>3);
+            }
+          }
+
+          dnode += imm_dnodes;
+          while (--imm_dnodes) {
+            *dest++ = *src++;
+            *dest++ = *src++;
+          }
+          set_bitidx_vars(markbits,dnode,bitsp,bits,bitidx);
+        } else {                                     /* ppc-gc.c:1588-1594 */
+          *dest++ = node_forwarding_address(node);
+          *dest++ = node_forwarding_address(*src++);
+          bits &= ~(BIT0_MASK >> bitidx);
+          dnode++;
+          bitidx++;
+        }
+      }
+
+    }
+
+    {
+      natural nbytes = (natural)ptr_to_lispobj(dest) - (natural)GCfirstunmarked;
+      if ((nbytes != 0) && GCrelocated_code_vector) {
+        /* PPC form (ppc-gc.c:1599-1604).  OPEN (report #7): verify that
+           pmcl-kernel.c's xMakeDataExecutable actually flushes the
+           I-cache on AArch64 (no arm64-asmutils.s at the pin, so ARM32's
+           flush_cache_lines alternative doesn't exist). */
+        xMakeDataExecutable((BytePtr)ptr_from_lispobj(GCfirstunmarked), nbytes);
+      }
+    }
+  }
+  return ptr_to_lispobj(dest);
+}
+
+
+
+
+/*
+  Total the (physical) byte sizes of all ivectors in the indicated memory range
+*/
+
+natural
+unboxed_bytes_in_range(LispObj *start, LispObj *end) /* ppc-gc.c:1618-1682 */
+{
+  natural total=0, elements, tag, subtag, bytes;
+  LispObj header;
+
+  while (start < end) {
+    header = *start;
+    tag = fulltag_of(header);
+
+    if ((nodeheader_tag_p(tag)) ||
+        (immheader_tag_p(tag))) {
+      elements = header_element_count(header);
+      if (nodeheader_tag_p(tag)) {
+        start += ((elements+2) & ~1);
+      } else {
+        subtag = header_subtag(header);
+
+        /* ppc-gc.c:1637-1654 (PPC64 class switch), arm64 classes */
+        switch(fulltag_of(header)) {
+        case ivector_class_64_bit:
+          bytes = 8 + (elements<<3);
+          break;
+        case ivector_class_32_bit:
+          bytes = 8 + (elements<<2);
+          break;
+        case ivector_class_other_bit:
+        default:
+          if (subtag == subtag_bit_vector) {
+            bytes = 8 + ((elements+7)>>3);
+          } else if (subtag >= subtag_s8_vector) {
+            bytes = 8 + elements;
+          } else if (subtag == subtag_complex_double_float_vector) {
+            bytes = 8 + (elements<<4);  /* 16m41; see mark_root */
+          } else {              /* 16-bit: s16, u16 */
+            bytes = 8 + (elements<<1);
+          }
+        }
+
+        bytes = (bytes+dnode_size-1) & ~(dnode_size-1);
+        total += bytes;
+        start += (bytes >> node_shift);
+      }
+    } else {
+      start += 2;
+    }
+  }
+  return total;
+}
+
+
+  /*
+     This assumes that it's getting called with an ivector
+     argument and that there's room for the object in the
+     destination area.
+  */
+
+
+LispObj
+purify_displaced_object(LispObj obj, area *dest, natural disp)
+{                                                    /* ppc-gc.c:1692-1727 */
+  BytePtr
+    free = dest->active,
+    *old = (BytePtr *) ptr_from_lispobj(untag(obj));
+  LispObj
+    header = header_of(obj),
+    new;
+  natural
+    start = (natural)old,
+    physbytes;
+
+  physbytes = ((natural)(skip_over_ivector(start,header))) - start;
+  dest->active += physbytes;
+
+  new = ptr_to_lispobj(free)+disp;
+
+  memcpy(free, (BytePtr)old, physbytes);
+  /* Leave a trail of breadcrumbs.  Or maybe just one breadcrumb. */
+  /* Actually, it's best to always leave a trail, for two reasons.
+     a) We may be walking the same heap that we're leaving forwaring
+     pointers in, so we don't want garbage that we leave behind to
+     look like a header.
+     b) We'd like to be able to forward code-vector locatives, and
+     it's easiest to do so if we leave a {forward_marker, dnode_locative}
+     pair at every doubleword in the old vector.
+  */
+  while(physbytes) {
+    *old++ = (BytePtr) forward_marker;   /* = fulltag_nil under -DARM64, see shim note */
+    *old++ = (BytePtr) free;
+    free += dnode_size;
+    physbytes -= dnode_size;
+  }
+  return new;
+}
+
+LispObj
+purify_object(LispObj obj, area *dest)               /* ppc-gc.c:1729-1733 */
+{
+  return purify_displaced_object(obj, dest, fulltag_of(obj));
+}
+
+
+
+void
+copy_ivector_reference(LispObj *ref, BytePtr low, BytePtr high, area *dest)
+{                                                    /* ppc-gc.c:1737-1758 */
+  LispObj obj = *ref, header;
+  natural tag = fulltag_of(obj), header_tag;
+
+  /* Only fulltag_misc references can name ivectors on arm64 (symbols and
+     functions are gvectors; a function's codevector slot is misc-tagged),
+     so PPC's misc-only test ports unchanged. */
+  if ((tag == fulltag_misc) &&
+      (((BytePtr)ptr_from_lispobj(obj)) > low) &&
+      (((BytePtr)ptr_from_lispobj(obj)) < high)) {
+    header = deref(obj, 0);
+    if (header == forward_marker) { /* already copied */
+      *ref = (untag(deref(obj,1)) + tag);
+    } else {
+      header_tag = fulltag_of(header);
+      if (immheader_tag_p(header_tag)) {
+        if (header_subtag(header) != subtag_macptr) {
+          *ref = purify_object(obj, dest);
+        }
+      }
+    }
+  }
+}
+
+void
+purify_locref(LispObj *locaddr, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1760-1814 (PPC64 branch) */
+  LispObj
+    loc = *locaddr,
+    *headerP;
+  opcode
+    *p,
+    insn;
+  natural
+    tag = fulltag_of(loc);
+
+  if (((BytePtr)ptr_from_lispobj(loc) > low) &&
+      ((BytePtr)ptr_from_lispobj(loc) < high)) {
+
+    headerP = (LispObj *)ptr_from_lispobj(untag(loc));
+    /* ARM64-DEVIATION: `(loc & 3) == 0' replaces PPC64's four-case
+       switch (even/odd fixnum, cons, misc â€” its 4-aligned residues);
+       arm64's are even_fixnum/misc/odd_fixnum/immheader_1, cf.
+       locative_forwarding_address. */
+    if ((loc & 3) == 0) {
+      if (*headerP == forward_marker) {
+        *locaddr = (headerP[1]+tag);                 /* ppc-gc.c:1784-1785 */
+      } else {
+        /* Grovel backwards until the code vector's udf#0 sentinel is
+           found; copy the code vector to to-space, then treat it as if
+           it hadn't already been copied.  (ppc-gc.c:1786-1798, 'CODE'
+           prefix â†’ sentinel.) */
+        p = (opcode *)headerP;
+        do {
+          p -= 2;
+          tag += 8;
+          insn = *p;
+        } while (insn != ARM64_CODE_VECTOR_SENTINEL);
+        /* VENDOR BUG FIXED (see file header note 6 / report Â§5.11):
+           the header word sits node_size below the sentinel, so the
+           displacement from the header is (loc - sentinel) + node_size;
+           vendor ppc-gc.c:1795-1798 passes tag = loc - sentinel,
+           relocating the locative one node low (the PPC32 branch at
+           ppc-gc.c:1800-1801, which grovels for the header itself, gets
+           it right). */
+        tag += node_size;
+        headerP = ((LispObj*)p)-1;
+        *locaddr = purify_displaced_object(((LispObj)headerP), to, tag);
+      }
+    }
+  }
+}
+
+void
+purify_range(LispObj *start, LispObj *end, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1816-1840 */
+  LispObj header;
+  unsigned tag, subtag;
+
+  while (start < end) {
+    header = *start;
+    if (header == forward_marker) {
+      start += 2;
+    } else {
+      tag = fulltag_of(header);
+      if (immheader_tag_p(tag)) {
+        start = (LispObj *)skip_over_ivector((natural)start, header);
+      } else {
+        if (!nodeheader_tag_p(tag)) {
+          copy_ivector_reference(start, low, high, to);
+        }
+        start++;
+        /* OPEN-ENTRYPOINT (ARM64-DEVIATION, arm-gc.c:1630-1645): a
+           function (pseudofunction removed upstream @ a6314ba)'s first slot is its entrypoint; if it
+           is an odd_fixnum-tagged locative into a purifiable code
+           vector, retag as misc, purify, retag back. */
+        subtag = header_subtag(header);
+        if (nodeheader_tag_p(tag) &&
+            (subtag == subtag_function)) {
+          LispObj entrypt = *start;
+          if ((entrypt > (LispObj)low) &&
+              (entrypt < (LispObj)high) &&
+              (fulltag_of(entrypt) == fulltag_odd_fixnum)) {
+            *start = untag(entrypt) + fulltag_misc;
+            copy_ivector_reference(start, low, high, to);
+            *start = untag(*start)+fulltag_odd_fixnum;
+          } else {
+            copy_ivector_reference(start, low, high, to);
+          }
+        } else {
+          copy_ivector_reference(start, low, high, to);
+        }
+        start++;
+      }
+    }
+  }
+}
+
+/* Purify references from tstack areas */
+void
+purify_tstack_area(area *a, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1843-1862 */
+  LispObj
+    *current,
+    *next,
+    *start = (LispObj *) (a->active),
+    *end = start,
+    *limit = (LispObj *) (a->high);
+
+  for (current = start;
+       end != limit;
+       current = next) {
+    next = (LispObj *) ptr_from_lispobj(*current);
+    end = ((next >= start) && (next < limit)) ? next : limit;
+    if (current[1] == 0) {
+      purify_range(current+2, end, low, high, to);
+    }
+  }
+}
+
+/* Purify a vstack area */
+void
+purify_vstack_area(area *a, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1865-1877 */
+  LispObj
+    *p = (LispObj *) a->active,
+    *q = (LispObj *) a->high;
+
+  if (((natural)p) & sizeof(natural)) {
+    copy_ivector_reference(p, low, high, to);
+    p++;
+  }
+  purify_range(p, q, low, high, to);
+}
+
+
+void
+purify_cstack_area(area *a, BytePtr low, BytePtr high, area *to)
+{                                                    /* arm-gc.c:1670-1716 */
+  /* ARM64-DEVIATION (whole function; ppc-gc.c:1880-1900 walks backlink
+     frames): marker-frame walk, case order corrected as in
+     mark_cstack_area. */
+  LispObj *current = (LispObj *)(a->active)
+    , *limit = (LispObj*)(a->high), header;
+  lisp_frame *frame;
+  unsigned subtag;
+
+  while(current < limit) {
+    header = *current;
+
+    if (header == lisp_frame_marker) {
+      frame = (lisp_frame *)current;
+
+      copy_ivector_reference(&(frame->savevsp), low, high, to); /* likely a fixnum */
+      copy_ivector_reference(&(frame->savefn), low, high, to);
+      purify_locref(&(frame->savelr), low, high, to);
+      current += sizeof(lisp_frame)/sizeof(LispObj);
+    } else if ((header == stack_alloc_marker) || (header == 0)) {
+      current += 2;
+    } else if (nodeheader_tag_p(fulltag_of(header))) { /* REORDERED, see mark_cstack_area */
+      natural elements = header_element_count(header);
+
+      current++;
+      /* OPEN-ENTRYPOINT (arm-gc.c:1696-1702) */
+      subtag = header_subtag(header);
+      if (subtag == subtag_function) {
+        purify_locref(current, low, high, to);
+        current++;
+        elements--;
+      }
+      while(elements--) {
+        copy_ivector_reference(current, low, high, to);
+        current++;
+      }
+      if (((natural)current) & sizeof(natural)) {
+        current++;
+      }
+    } else if (immheader_tag_p(fulltag_of(header))) {  /* REORDERED */
+      current=(LispObj *)skip_over_ivector((natural)current,header);
+    } else if ((header & fixnummask) == 0) {
+      current = (LispObj *)header;
+    } else {
+      Bug(NULL, "Unknown stack word at 0x" LISP ":\n", current);
+    }
+  }
+}
+
+void
+purify_xp(ExceptionInformation *xp, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1902-1922 */
+  natural *regs = (natural *) xpGPRvector(xp);
+
+  int r;
+
+  /* Same register SET as mark_xp (see file header); PC and LR are
+     treated as "locatives". */
+
+  for (r = fn; r <= rnil; r++) {
+    if (r != 18) {
+      copy_ivector_reference((LispObj*) (&(regs[r])), low, high, to);
+    }
+  }
+
+  purify_locref((LispObj*) (&(xpPC(xp))), low, high, to);
+  purify_locref((LispObj*) (&(xpLR(xp))), low, high, to);
+}
+
+void
+purify_tcr_tlb(TCR *tcr, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1924-1931 */
+  natural n = tcr->tlb_limit;
+  LispObj *start = tcr->tlb_pointer, *end = (LispObj *) ((BytePtr)start+n);
+
+  purify_range(start, end, low, high, to);
+}
+
+void
+purify_tcr_xframes(TCR *tcr, BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1933-1947 */
+  xframe_list *xframes;
+  ExceptionInformation *xp;
+
+  xp = tcr->gc_context;
+  if (xp) {
+    purify_xp(xp, low, high, to);
+  }
+
+  for (xframes = tcr->xframe; xframes; xframes = xframes->prev) {
+    purify_xp(xframes->curr, low, high, to);
+  }
+}
+
+void
+purify_gcable_ptrs(BytePtr low, BytePtr high, area *to)
+{                                                    /* ppc-gc.c:1949-1959 */
+  LispObj *prev = &(lisp_global(GCABLE_POINTERS)), next;
+
+  while ((*prev) != (LispObj)NULL) {
+    copy_ivector_reference(prev, low, high, to);
+    next = *prev;
+    prev = &(((xmacptr *)ptr_from_lispobj(untag(next)))->link);
+  }
+}
+
+
+void
+purify_areas(BytePtr low, BytePtr high, area *target)
+{                                                    /* ppc-gc.c:1962-1991 */
+  area *next_area;
+  area_code code;
+
+  for (next_area = active_dynamic_area; (code = next_area->code) != AREA_VOID; next_area = next_area->succ) {
+    switch (code) {
+    case AREA_TSTACK:
+      purify_tstack_area(next_area, low, high, target);
+      break;
+
+    case AREA_VSTACK:
+      purify_vstack_area(next_area, low, high, target);
+      break;
+
+    case AREA_CSTACK:
+      purify_cstack_area(next_area, low, high, target);
+      break;
+
+    case AREA_STATIC:
+    case AREA_DYNAMIC:
+      purify_range((LispObj *) next_area->low, (LispObj *) next_area->active, low, high, target);
+      break;
+
+    default:
+      break;
+    }
+  }
+}
+
+/*
+  So far, this is mostly for save_application's benefit.
+  We -should- be able to return to lisp code after doing this,
+  however.
+
+*/
+
+
+signed_natural
+purify(TCR *tcr, signed_natural param)               /* ppc-gc.c:2001-2048 */
+{
+  extern area *extend_readonly_area(unsigned);
+  area
+    *a = active_dynamic_area,
+    *new_pure_area;
+
+  TCR  *other_tcr;
+  natural max_pure_size;
+  BytePtr new_pure_start;
+
+
+  max_pure_size = unboxed_bytes_in_range((LispObj *)(a->low + (static_dnodes_for_area(a) << dnode_shift)),
+                                         (LispObj *) a->active);
+  new_pure_area = extend_readonly_area(max_pure_size);
+  if (new_pure_area) {
+    new_pure_start = new_pure_area->active;
+    lisp_global(IN_GC) = (1<<fixnumshift);
+
+
+    purify_areas(a->low, a->active, new_pure_area);
+
+    other_tcr = tcr;
+    do {
+      purify_tcr_xframes(other_tcr, a->low, a->active, new_pure_area);
+      purify_tcr_tlb(other_tcr, a->low, a->active, new_pure_area);
+      other_tcr = other_tcr->next;
+    } while (other_tcr != tcr);
+
+    purify_gcable_ptrs(a->low, a->active, new_pure_area);
+
+    {
+      natural puresize = (unsigned) (new_pure_area->active-new_pure_start);
+      if (puresize != 0) {
+        xMakeDataExecutable(new_pure_start, puresize);
+
+      }
+    }
+    ProtectMemory(new_pure_area->low,
+                  align_to_power_of_2(new_pure_area->active-new_pure_area->low,
+                                      log2_page_size));
+    lisp_global(IN_GC) = 0;
+    just_purified_p = true;
+    return 0;
+  }
+  return -1;
+}
+
+void
+impurify_locref(LispObj *p, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2050-2066 */
+  LispObj q = *p;
+
+  /* ARM64-DEVIATION: `(q & 3) == 0' replaces PPC64's switch over
+     {cons, misc, even_fixnum, odd_fixnum} â€” see locative_forwarding_address
+     for the residue analysis; conses are never purified (only ivectors
+     reach the readonly area), so excluding fulltag_cons(3) loses nothing. */
+  if (((q & 3) == 0) &&
+      (q >= low) && (q < high)) {
+    *p = (q+delta);
+  }
+}
+
+
+void
+impurify_noderef(LispObj *p, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2069-2079 */
+  LispObj q = *p;
+
+  if ((fulltag_of(q) == fulltag_misc) &&
+      (q >= low) &&
+      (q < high)) {
+    *p = (q+delta);
+  }
+}
+
+
+void
+impurify_cstack_area(area *a, LispObj low, LispObj high, int delta)
+{                                                    /* arm-gc.c:1889-1934 */
+  /* ARM64-DEVIATION (whole function; ppc-gc.c:2082-2104 walks backlink
+     frames): marker-frame walk, case order corrected as in
+     mark_cstack_area. */
+  LispObj *current = (LispObj *)(a->active)
+    , *limit = (LispObj*)(a->high), header;
+  lisp_frame *frame;
+  unsigned subtag;
+
+  while(current < limit) {
+    header = *current;
+
+    if (header == lisp_frame_marker) {
+      frame = (lisp_frame *)current;
+
+      impurify_noderef(&(frame->savevsp), low, high,delta); /* likely a fixnum */
+      impurify_noderef(&(frame->savefn), low, high, delta);
+      impurify_locref(&(frame->savelr), low, high, delta);
+      current += sizeof(lisp_frame)/sizeof(LispObj);
+    } else if ((header == stack_alloc_marker) || (header == 0)) {
+      current += 2;
+    } else if (nodeheader_tag_p(fulltag_of(header))) { /* REORDERED, see mark_cstack_area */
+      natural elements = header_element_count(header);
+
+      current++;
+      /* OPEN-ENTRYPOINT (arm-gc.c:1914-1920) */
+      subtag = header_subtag(header);
+      if (subtag == subtag_function) {
+        impurify_locref(current, low, high, delta);
+        current++;
+        elements--;
+      }
+      while(elements--) {
+        impurify_noderef(current, low, high, delta);
+        current++;
+      }
+      if (((natural)current) & sizeof(natural)) {
+        current++;
+      }
+    } else if (immheader_tag_p(fulltag_of(header))) {  /* REORDERED */
+      current=(LispObj *)skip_over_ivector((natural)current,header);
+    } else if ((header & fixnummask) == 0) {
+      current = (LispObj *) header;
+    } else {
+      Bug(NULL, "Unknown stack word at 0x" LISP ":\n", current);
+    }
+  }
+}
+
+
+void
+impurify_xp(ExceptionInformation *xp, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2106-2128 */
+  natural *regs = (natural *) xpGPRvector(xp);
+  int r;
+
+  /* Same register SET as mark_xp (see file header); PC and LR are
+     treated as "locatives". */
+
+  for (r = fn; r <= rnil; r++) {
+    if (r != 18) {
+      impurify_noderef((LispObj*) (&(regs[r])), low, high, delta);
+    }
+  }
+
+  impurify_locref((LispObj*) (&(xpPC(xp))), low, high, delta);
+  impurify_locref((LispObj*) (&(xpLR(xp))), low, high, delta);
+}
+
+
+void
+impurify_range(LispObj *start, LispObj *end, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2131-2151 */
+  LispObj header;
+  unsigned tag, subtag;
+
+  while (start < end) {
+    header = *start;
+    tag = fulltag_of(header);
+    if (immheader_tag_p(tag)) {
+      start = (LispObj *)skip_over_ivector((natural)start, header);
+    } else {
+      if (!nodeheader_tag_p(tag)) {
+        impurify_noderef(start, low, high, delta);
+      }
+      start++;
+      /* OPEN-ENTRYPOINT (ARM64-DEVIATION, arm-gc.c:1974-1988): mirror
+         of purify_range's entrypoint handling. */
+      subtag = header_subtag(header);
+      if (nodeheader_tag_p(tag) &&
+          (subtag == subtag_function)) {
+        LispObj entrypt = *start;
+        if ((entrypt > (LispObj)low) &&
+            (entrypt < (LispObj)high) &&
+            (fulltag_of(entrypt) == fulltag_odd_fixnum)) {
+          *start = untag(entrypt) + fulltag_misc;
+          impurify_noderef(start, low, high, delta);
+          *start = untag(*start)+fulltag_odd_fixnum;
+        } else {
+          impurify_noderef(start, low, high, delta);
+        }
+      } else {
+        impurify_noderef(start, low, high, delta);
+      }
+      start++;
+    }
+  }
+}
+
+
+
+
+void
+impurify_tcr_tlb(TCR *tcr,  LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2156-2163 */
+  unsigned n = tcr->tlb_limit;
+  LispObj *start = tcr->tlb_pointer, *end = (LispObj *) ((BytePtr)start+n);
+
+  impurify_range(start, end, low, high, delta);
+}
+
+void
+impurify_tcr_xframes(TCR *tcr, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2165-2179 */
+  xframe_list *xframes;
+  ExceptionInformation *xp;
+
+  xp = tcr->gc_context;
+  if (xp) {
+    impurify_xp(xp, low, high, delta);
+  }
+
+  for (xframes = tcr->xframe; xframes; xframes = xframes->prev) {
+    impurify_xp(xframes->curr, low, high, delta);
+  }
+}
+
+void
+impurify_tstack_area(area *a, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2181-2200 */
+  LispObj
+    *current,
+    *next,
+    *start = (LispObj *) (a->active),
+    *end = start,
+    *limit = (LispObj *) (a->high);
+
+  for (current = start;
+       end != limit;
+       current = next) {
+    next = (LispObj *) ptr_from_lispobj(*current);
+    end = ((next >= start) && (next < limit)) ? next : limit;
+    if (current[1] == 0) {
+      impurify_range(current+2, end, low, high, delta);
+    }
+  }
+}
+void
+impurify_vstack_area(area *a, LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2201-2213 */
+  LispObj
+    *p = (LispObj *) a->active,
+    *q = (LispObj *) a->high;
+
+  if (((natural)p) & sizeof(natural)) {
+    impurify_noderef(p, low, high, delta);
+    p++;
+  }
+  impurify_range(p, q, low, high, delta);
+}
+
+
+void
+impurify_areas(LispObj low, LispObj high, int delta)
+{                                                    /* ppc-gc.c:2216-2247 */
+  area *next_area;
+  area_code code;
+
+  for (next_area = active_dynamic_area; (code = next_area->code) != AREA_VOID; next_area = next_area->succ) {
+    switch (code) {
+    case AREA_TSTACK:
+      impurify_tstack_area(next_area, low, high, delta);
+      break;
+
+    case AREA_VSTACK:
+      impurify_vstack_area(next_area, low, high, delta);
+      break;
+
+    case AREA_CSTACK:
+      impurify_cstack_area(next_area, low, high, delta);
+      break;
+
+    case AREA_STATIC:
+    case AREA_DYNAMIC:
+      impurify_range((LispObj *) next_area->low, (LispObj *) next_area->active, low, high, delta);
+      break;
+
+    default:
+      break;
+    }
+  }
+}
+
+void
+impurify_gcable_ptrs(LispObj low, LispObj high, signed_natural delta)
+{                                                    /* ppc-gc.c:2249-2259 */
+  LispObj *prev = &(lisp_global(GCABLE_POINTERS)), next;
+
+  while ((*prev) != (LispObj)NULL) {
+    impurify_noderef(prev, low, high, delta);
+    next = *prev;
+    prev = &(((xmacptr *)ptr_from_lispobj(untag(next)))->link);
+  }
+}
+
+signed_natural
+impurify(TCR *tcr, signed_natural param)             /* ppc-gc.c:2261-2303 */
+{
+  area *r = readonly_area;
+
+  if (r) {
+    area *a = active_dynamic_area;
+    BytePtr ro_base = r->low, ro_limit = r->active, oldfree = a->active,
+      oldhigh = a->high, newhigh;
+    unsigned n = ro_limit - ro_base;
+    int delta = oldfree-ro_base;
+    TCR *other_tcr;
+
+    if (n) {
+      lisp_global(IN_GC) = 1;
+      newhigh = (BytePtr) (align_to_power_of_2(oldfree+n,
+                                               log2_heap_segment_size));
+      if (newhigh > oldhigh) {
+        grow_dynamic_area(newhigh-oldhigh);
+      }
+      a->active += n;
+      memmove(oldfree, ro_base, n);
+      munmap(ro_base, n);                            /* ppc-gc.c:2283 */
+      a->ndnodes = area_dnode(a, a->active);
+      pure_space_active = r->active = r->low;
+      r->ndnodes = 0;
+
+      impurify_areas(ptr_to_lispobj(ro_base), ptr_to_lispobj(ro_limit), delta);
+
+      other_tcr = tcr;
+      do {
+        impurify_tcr_xframes(other_tcr, ptr_to_lispobj(ro_base), ptr_to_lispobj(ro_limit), delta);
+        impurify_tcr_tlb(other_tcr, ptr_to_lispobj(ro_base), ptr_to_lispobj(ro_limit), delta);
+        other_tcr = other_tcr->next;
+      } while (other_tcr != tcr);
+
+      impurify_gcable_ptrs(ptr_to_lispobj(ro_base), ptr_to_lispobj(ro_limit), delta);
+      lisp_global(IN_GC) = 0;
+    }
+    return 0;
+  }
+  return -1;
 }

--- a/lisp-kernel/arm64-globals-proposed.s
+++ b/lisp-kernel/arm64-globals-proposed.s
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* ARM64-SPECIFIC — justification: access-macro design for AArch64 (no cheap
+   absolute addressing => rnil-relative); offsets are NOT invented — they
+   mirror the arch-independent lisp-kernel/lisp_globals.h indices and the
+   shared vendor lisp_globals.s nrs order, both present in Matt's tree. */
+
+/*
+ * PROPOSED (ratify with Matt): ARM64 lisp_globals / nrs anchoring idiom.
+ *
+ * Matt's arm64-constants.s ALREADY includes the shared generator
+ * (vendor lisp_globals.s via `include(lisp_globals.s)' with
+ * lisp_globals_limit = -node_size and nrs_origin = node_size), so the
+ * SYMBOLIC layout exists in his m4 layer.  This file provides:
+ *   (a) cpp/GNU-as equates for the subset our spentry drafts reference,
+ *       mirroring the canonical indices in lisp-kernel/lisp_globals.h
+ *       (which is arch-independent and present verbatim in his tree), and
+ *   (b) the AArch64 ACCESS MACROS: everything is rnil-relative.  rnil
+ *       holds nil_value = <static nil address> + fulltag_nil, and the
+ *       kernel globals live at negative node offsets below the untagged
+ *       nil address, exactly as on every other CCL target.  ARM64 has no
+ *       cheap absolute addressing, but rnil is pinned - so:
+ *           global N   is at   [rnil - (N*node_size + fulltag_nil)]
+ *       (the -fulltag_nil bias makes the address 8-aligned).
+ *
+ * RATIFY-GEOMETRY: for nrs, Matt's placeholder `nrs_origin = node_size'
+ * is INCONSISTENT with his own canonical-t-value: with
+ * canonical-nil = #x13000+fulltag_nil and canonical-t = #x13020+
+ * fulltag_symbol (arm64-arch.lisp:184-185), T's symbol object begins at
+ * untagged-nil + 32, i.e. nrs_origin MUST be 32 (and nrs_symbol_fulltag
+ * must be fulltag_symbol) for nrs.tsym to BE canonical T.  The equates
+ * below use origin 32; then  rnil + t_offset == rnil + nrs.tsym  holds
+ * identically (28 = 32 + 7 - 11).
+ */
+
+/* ---- kernel globals (indices: lisp-kernel/lisp_globals.h) ---- */
+.set lisp_globals.get_tcr,              (-(1*node_size)  - fulltag_nil)
+.set lisp_globals.ret1valn,             (-(9*node_size)  - fulltag_nil)
+.set lisp_globals.ret1val_addr,         lisp_globals.ret1valn
+.set lisp_globals.refbits,              (-(17*node_size) - fulltag_nil)
+.set lisp_globals.oldspace_dnode_count, (-(18*node_size) - fulltag_nil)
+.set lisp_globals.all_areas,            (-(29*node_size) - fulltag_nil)
+.set lisp_globals.lexpr_return,         (-(30*node_size) - fulltag_nil)
+.set lisp_globals.lexpr_return1v,       (-(31*node_size) - fulltag_nil)
+.set lisp_globals.ref_base,             (-(41*node_size) - fulltag_nil)
+.set lisp_globals.ephemeral_refidx,     (-(52*node_size) - fulltag_nil)
+
+/* Load the VALUE of a kernel global.  The offsets range past ldur's
+   +-256, so form the address first (sub imm12 covers all indices). */
+.macro ref_global reg, glob
+        sub \reg, rnil, #(0 - (lisp_globals.\glob))
+        ldr \reg, [\reg]
+.endm
+/* Address of a kernel global (for stores / atomics). */
+.macro ref_global_addr reg, glob
+        sub \reg, rnil, #(0 - (lisp_globals.\glob))
+.endm
+
+/* ---- nil-relative symbols (order: vendor lisp_globals.s _struct(nrs)) ----
+   nrs.<name> = tagged symbol, as an offset from rnil:
+   32 + k*symbol.size + fulltag_symbol - fulltag_nil = 64k + 28. */
+.set nrs_symbol_size, 64
+.macro def_nrs name, k
+.set nrs.\name, (32 + (\k)*nrs_symbol_size + fulltag_symbol - fulltag_nil)
+.endm
+        def_nrs tsym,               0
+        def_nrs nilsym,             1
+        def_nrs errdisp,            2
+        def_nrs cmain,              3
+        def_nrs eval,               4
+        def_nrs appevalfn,          5
+        def_nrs error,              6
+        def_nrs defun,              7
+        def_nrs defvar,             8
+        def_nrs defconstant,        9
+        def_nrs macrosym,          10
+        def_nrs kernelrestart,     11
+        def_nrs package,           12
+        def_nrs total_bytes_freed, 13
+        def_nrs kallowotherkeys,   14
+        def_nrs toplcatch,         15
+        def_nrs toplfunc,          16
+        def_nrs callbacks,         17
+        def_nrs restore_lisp_pointers, 18
+        def_nrs total_gc_microseconds, 19
+        def_nrs builtin_functions, 20
+        def_nrs udf,               21
+        def_nrs init_misc,         22
+        def_nrs macro_code,        23
+        def_nrs closure_code,      24
+        def_nrs new_gcable_ptr,    25
+
+/* symbol slot offsets via the dedicated symbol fulltag (own names to
+   avoid colliding with per-file symbol.* equates). */
+.set nrs_sym.vcell, (2*node_size - fulltag_symbol)
+.set nrs_sym.fcell, (3*node_size - fulltag_symbol)
+
+/* ---- PROPOSED uuo extension (goes with Matt's arm64-uuo.s @ c9e7ffb) ----
+   PPC's uuo_interr(errnum, reg): an error trap carrying an errors.s errnum
+   plus one register.  Matt's misc format (uuo_format_misc = 0 after the
+   c9e7ffb renumber; misc info must not be all-0) has 14 bits of info with
+   only values 1-8 assigned; we claim info bit 13 as the "interr" flag:
+   bits 12:5 = errnum (8 bits), bits 4:0 = register number.  Used for
+   stack-overflow (trllt), too-many-values, object-not-list -- errnum-
+   carrying traps with no slot in his sketch.  RATIFY. */
+.macro uuo_interr errnum, reg
+        udf #((((1<<13) | ((\errnum)<<5) | (R\reg)) << 2) | uuo_format_misc)
+.endm
+/* PROPOSED: sp as a uuo register operand (stack-overflow traps trap on
+   sp, which is not in Matt's R* list). */
+.set Rsp, 31
+
+/* The tagged symbol itself. */
+.macro ref_nrs_symbol reg, sym
+        add \reg, rnil, #nrs.\sym
+.endm
+/* The symbol's global value (vcell contents). */
+.macro ref_nrs_value reg, sym
+        add \reg, rnil, #nrs.\sym
+        ldur \reg, [\reg, #nrs_sym.vcell]
+.endm
+/* The symbol's function cell contents. */
+.macro ref_nrs_function reg, sym
+        add \reg, rnil, #nrs.\sym
+        ldur \reg, [\reg, #nrs_sym.fcell]
+.endm

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -1,5 +1,57 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+/* CLOZURE-WIP-FOUNDATION (source: lisp-kernel/arm64-spentry.s @ 33e61e6)
+ *
+ * His 5 subprim bodies (fix_overflow, makes64, makeu64, the self-described
+ * misc_ref "toy", ffcall) VERBATIM, plus THE SPTAB POPULATION, which is ours.
+ *
+ * WHY THIS IS AN OVERLAY FILE AND NOT A PATCH (16m30 — read before "tidying"
+ * it back into the patch series):
+ *
+ *   The sptab is the subprim dispatch table: the compiler emits every
+ *   subprim call as `ldr xN,[rcontext,#(tcr.sptab + 8*index)]` + `blr xN`, so
+ *   an unpopulated row is a jump to address 0.  His tip ships the table with
+ *   119 of 123 rows `.quad 0` ("slots not yet implemented hold 0") — only
+ *   fix_overflow/makeu64/makes64/misc_ref are wired.  Our 130-of-132 rows are
+ *   what make the port able to run at all; the bodies they point at live in
+ *   our spentry-{A..E}.s.
+ *
+ *   That population existed ONLY as a commit on a test machine's local
+ *   branch, in a work-in-progress snapshot atop 6b6540e that was never part
+ *   of the patch series.  No patch reproduced it.  It has now silently
+ *   evaporated TWICE: 16m22 (stamp-clear reverted it -> "cold-load wild blr
+ *   via [rnil+0x358]", recovered as patch 0036) and again in 16m30, when a
+ *   pin-advance sync reset this file to "pin + patches 0003/0004" — a state
+ *   that md5-matched the x86 BUILD box exactly, and which therefore looked
+ *   verified while carrying only 18 populated rows.  Boot died instantly at
+ *   `blr` on sptab index 56.
+ *
+ *   The x86 box is NOT a witness for this file: it cross-compiles level-0 and
+ *   never builds an ARM kernel, so its copy of arm64-spentry.s is dead weight
+ *   there and drifted to the patch-series state unnoticed.  Cross-box md5
+ *   equality proves synchronization, NOT correctness.
+ *
+ *   As a full-file overlay the table is version-controlled, ships with the
+ *   repo, and cannot be reverted by any patch/stamp operation — the same
+ *   reason arm64-exceptions.c and arm64-gc.c are overlays.
+ *
+ * RELATION TO THE PATCH SERIES: patches 0003 (ffcall) and 0004 (bind family)
+ * each carry an arm64-spentry.s half plus an arm64-constants.h half.  Their
+ * spentry.s halves are ALREADY CONTAINED here and are inert for the ARM build
+ * (the make-gate copies this file over the tree's).  Their constants.h halves
+ * are still live and must keep applying.  Upstream submission for the table is
+ * a diff of THIS file against his — not a re-derivation of the patches.
+ *
+ * STILL ZERO (live-verified in the booted TCR, 16m30): indices 64, 65, 86, 121.
+ * Each is a `blr` to 0 the moment the compiler emits a call to it.
+ *
+ * ⚠️ The row COMMENTS ("// 55 SPstack_misc_alloc") are his ARM32-derived
+ * numbering and are NOT the physical index — our inserted rows shifted them.
+ * The physical position is what the compiler indexes.  Never read the comment
+ * as the index; run tools/subprim-index-lint.py, which compares physical
+ * position against the compiler's *subprims* order.
+ */
+
 #include "arm64-constants.h"
 #include "arm64-macros.s"
 
@@ -57,6 +109,7 @@ spentry makeu64
         ret
 endsp makeu64
 
+
 /*
  * There's a miscobj reference in arg_y.  Reference index arg_z of
  * said miscobj, and return a properly-tagged lisp object in arg_z.
@@ -85,6 +138,174 @@ C(misc_ref_common):
         ret
 
 /*
+ * Call a foreign function.
+ *
+ * Entry (from the compiler's aapcs64-ff-call handler + alloc-c-frame):
+ *   sp -> c_frame: backlink@0 (SP from before the allocation),
+ *         savelr@8 (0), the 8 GPR argument words at c_frame.params,
+ *         any stack (overflow) argument words immediately above them,
+ *         FP staging words above those (dead here: d0-d7 already hold
+ *         the FP args, reloaded by compiled code before we're called).
+ *   arg_z = the foreign entry point: a macptr, or a fixnum-locative
+ *           (an 8-aligned raw address whose bits are their own fixnum).
+ *   lr    = return address in the compiled caller.
+ *
+ * Exit: C integer result in x0 (= imm0), FP result in d0; the c_frame
+ * is popped (sp restored from its backlink); no node register holds
+ * C garbage.
+ *
+ * Register notes: x19-x28 (save0-3, rnil, tsp, vsp, allocptr,
+ * allocbase, rcontext) are AAPCS64 callee-saved, so the pinned lisp
+ * registers survive the call for free.  fn (x7) is an argument
+ * register: park it on the value stack (GC-visible via
+ * tcr.save_vsp) before the argument load clobbers it.  We don't
+ * save/restore FPCR: lisp runs with the process-default FPCR and a
+ * conforming callee doesn't dirty it.  Cumulative FPSR exception
+ * flags from the callee are published to tcr.foreign_fpsr.
+ */
+spentry ffcall
+        str fn, [vsp, #-node_size]!
+        /* save3 carries the frame base across the call (callee-saved);
+         * its lisp value is parked next to fn. */
+        str save3, [vsp, #-node_size]!
+        mov save3, sp
+        /* ---- THE BOUNDARY LISP FRAME (16m30; canonical note, the two
+         * siblings in spentry-E-ffi.s point here) ----
+         *
+         * His alloc-c-frame vinsn (arm64-vinsns.lisp:287) builds this frame
+         * as {header@0, savedsp@8, params@16..} and RESERVES 4 words at the
+         * frame TOP for a boundary lisp_frame, with the header's element
+         * count deliberately covering them so the GC skips the uninitialized
+         * words; the ff-call sequence "builds the frame there and then
+         * shrinks the count by 4 to publish it" (arm642.lisp:6323).
+         *
+         * There is therefore NO savelr slot to park lr in, and [sp,#8] is
+         * the saved SP we must not touch.  We used to do
+         * `str lr,[sp,#c_frame.savelr]' with savelr=8 -- clobbering the
+         * saved SP -- and then restore sp from offset 0, which is the
+         * HEADER: sp became 0xded (the header for a 14-word frame,
+         * (13<<8)|subtag_u64_vector) and the caller's own epilogue
+         * `ldp x7,x30,[sp,#16]' took a SIGBUS.
+         *
+         * PPC64 is the shape reference: poweropen_ffcall (ppc-spentry.s:1595)
+         * likewise puts the return address in lisp_frame.savelr of a boundary
+         * frame, never in the c_frame.
+         *
+         * reserved_base = sp + node_size + node_size*(count - 4)
+         *               = sp + node_size*(count - 3).
+         * imm0-2 are free here; arg_z still holds the entry point. */
+        ldr imm0, [sp, #c_frame.header]
+        lsr imm1, imm0, #num_subtag_bits        /* element count = words-1 */
+        sub imm1, imm1, #3
+        mov imm2, sp                            /* add-shifted with Rn=sp is */
+        add imm2, imm2, imm1, lsl #node_shift   /* an encoding trap; go via a reg */
+        mov imm1, #lisp_frame_marker
+        str imm1, [imm2, #lisp_frame.marker]
+        str vsp, [imm2, #lisp_frame.savevsp]
+        str fn,  [imm2, #lisp_frame.savefn]
+        str lr,  [imm2, #lisp_frame.savelr]
+        sub imm0, imm0, #(4 << num_subtag_bits) /* publish the 4 words */
+        str imm0, [sp, #c_frame.header]
+        /* Unbox the entry point into temp4 (x16 = IP0). */
+        /* PPC-faithful discrimination (ppc:1802-1814 extract_typecode):
+         * macptr iff fulltag_misc AND header subtag == subtag_macptr;
+         * anything else the raw bits ARE the address.  A bare tst
+         * #tagmask misclassified 4-aligned C entry points (16m5l). */
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne 8f
+        ldurb w2, [arg_z, #misc_subtag_offset]
+        cmp imm2, #subtag_macptr
+        b.ne 8f
+        ldur temp4, [arg_z, #macptr.address]
+        b 9f
+8:      mov temp4, arg_z        // fixnum-locative / raw code address
+9:
+        /* Publish lisp state to the TCR for the GC, then go foreign. */
+        str vsp, [rcontext, #tcr.save_vsp]
+        str tsp, [rcontext, #tcr.save_tsp]
+        str allocptr, [rcontext, #tcr.save_allocptr]
+        str allocbase, [rcontext, #tcr.save_allocbase]
+        /* Load the outgoing GPR args (clobbers imm0-imm5/nargs/fn) and
+         * pop the frame head + param words so any stack args sit
+         * exactly at SP for the callee. */
+        ldp x0, x1, [sp, #c_frame.params]
+        ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
+        ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
+        ldp x6, x7, [sp, #(c_frame.params + 6*node_size)]
+        /* AAPCS64, no stack args (<=8 GPR/<=8 FP, enforced loud in the
+         * w13 codegen): keep SP at the frame head -- the callee's stack
+         * grows BELOW its incoming SP, so popping the frame here hands
+         * the saved lr/backlink to the callee as scratch (16m5c crash:
+         * return jumped into the c_frame).  Stack-arg layout = ratify
+         * item (frame head must move above the param area). */
+        /* Record the lisp<->foreign boundary for the GC (16m41; protocol note
+         * in spentry-E-ffi.s).  The walk must start at the c_frame base: word
+         * 0 there is the frame's own ivector header, whose (already shrunk)
+         * count strides exactly onto the boundary lisp_frame built above.
+         * Park the enclosing boundary in param word 0 -- dead now that the
+         * args are loaded, INSIDE the c_frame ivector so the GC never scans
+         * it, and above SP so the callee cannot touch it.
+         *
+         * ORDER MATTERS, and it is why the arg loads moved above the valence
+         * store: the boundary must be in place BEFORE this thread advertises
+         * foreign valence, or a GC in the window reads a stale boundary and
+         * walks the wrong region (ARM-family ff-call stores it first for the
+         * same reason).  temp0 is scratch: the return path re-nils every temp,
+         * and it is not an AAPCS64 argument register the way imm0 is. */
+        ldr temp0, [rcontext, #tcr.last_lisp_frame]
+        str temp0, [sp, #c_frame.params]
+        mov temp0, sp
+        str temp0, [rcontext, #tcr.last_lisp_frame]
+        mov temp0, #TCR_STATE_FOREIGN
+        str temp0, [rcontext, #tcr.valence]
+        blr temp4
+        /* Back.  x0/d0 hold the results; imm1/imm2 are scratch. */
+        mrs imm1, fpsr
+        str imm1, [rcontext, #tcr.foreign_fpsr]
+        msr fpsr, xzr
+        /* A GC may have run while we were foreign. */
+        ldr allocptr, [rcontext, #tcr.save_allocptr]
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        /* Recover lr from the boundary lisp_frame and sp from the SAVED SP
+         * word -- not from offset 0, which is the header (16m30, see the
+         * entry note).  The count has already been shrunk by 4, so
+         * reserved_base = save3 + node_size*(count + 1).  x0/d0 hold the
+         * results: imm1/imm2 only, never imm0.
+         * SUBPRIM-POPS is the w13 contract: the caller's epilogue runs with
+         * sp back at its own lisp frame (confirmed against the emitted
+         * MAKE-GCABLE-MACPTR epilogue, which pops a 32-byte frame at sp). */
+        ldr imm1, [save3, #c_frame.header]
+        lsr imm1, imm1, #num_subtag_bits
+        add imm1, imm1, #1
+        add imm2, save3, imm1, lsl #node_shift
+        ldr lr, [imm2, #lisp_frame.savelr]
+        ldr imm1, [save3, #c_frame.savedsp]
+        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
+        ldr imm2, [save3, #c_frame.params]
+        str imm2, [rcontext, #tcr.last_lisp_frame]
+        mov sp, imm1
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        /* Clear C garbage out of the volatile node registers, then --
+         * and only then -- declare lisp valence: the GC must never see
+         * a stale pointer in a node register of a lisp-valence thread. */
+        mov arg_w, rnil
+        mov arg_x, rnil
+        mov arg_y, rnil
+        mov arg_z, rnil
+        mov temp0, rnil
+        mov temp1, rnil
+        mov temp2, rnil
+        mov temp3, rnil
+        mov temp4, rnil
+        mov temp5, rnil
+        mov nargs, xzr
+        str xzr, [rcontext, #tcr.valence]   // TCR_STATE_LISP
+        ret
+endsp ffcall
+
+/*
  * A read-only vector of subprim addresses.  The loader fixes up the
  * symbol entries at load-time; init_arm_tcr_sptab() then copies the
  * whole block into each thread's tcr->sptab.  Calling a subprim is
@@ -103,127 +324,136 @@ C(misc_ref_common):
         .section RELRO
         .p2align 3
 C(sptab):
-        .quad 0 // 0 SPbuiltin_plus
-        .quad 0 // 1 SPbuiltin_minus
-        .quad 0 // 2 SPbuiltin_times
-        .quad 0 // 3 SPbuiltin_div
-        .quad 0 // 4 SPbuiltin_eq
-        .quad 0 // 5 SPbuiltin_ne
-        .quad 0 // 6 SPbuiltin_gt
-        .quad 0 // 7 SPbuiltin_ge
-        .quad 0 // 8 SPbuiltin_lt
-        .quad 0 // 9 SPbuiltin_le
-        .quad 0 // 10 SPbuiltin_eql
-        .quad 0 // 11 SPbuiltin_length
-        .quad 0 // 12 SPbuiltin_seqtype
-        .quad 0 // 13 SPbuiltin_assq
-        .quad 0 // 14 SPbuiltin_memq
-        .quad 0 // 15 SPbuiltin_logbitp
-        .quad 0 // 16 SPbuiltin_logior
-        .quad 0 // 17 SPbuiltin_logand
-        .quad 0 // 18 SPbuiltin_ash
-        .quad 0 // 19 SPbuiltin_negate
-        .quad 0 // 20 SPbuiltin_logxor
-        .quad 0 // 21 SPbuiltin_aref1
-        .quad 0 // 22 SPbuiltin_aset1
-        .quad 0 // 23 SPfuncall
-        .quad 0 // 24 SPmkcatch1v
-        .quad 0 // 25 SPmkcatchmv
-        .quad 0 // 26 SPmkunwind
-        .quad 0 // 27 SPbind
-        .quad 0 // 28 SPconslist
-        .quad 0 // 29 SPconslist_star
-        .quad 0 // 30 SPmakes32
-        .quad 0 // 31 SPmakeu32
+        .quad _SPbuiltin_plus // 0 SPbuiltin_plus
+        .quad _SPbuiltin_minus // 1 SPbuiltin_minus
+        .quad _SPbuiltin_times // 2 SPbuiltin_times
+        .quad _SPbuiltin_div // 3 SPbuiltin_div
+        .quad _SPbuiltin_eq // 4 SPbuiltin_eq
+        .quad _SPbuiltin_ne // 5 SPbuiltin_ne
+        .quad _SPbuiltin_gt // 6 SPbuiltin_gt
+        .quad _SPbuiltin_ge // 7 SPbuiltin_ge
+        .quad _SPbuiltin_lt // 8 SPbuiltin_lt
+        .quad _SPbuiltin_le // 9 SPbuiltin_le
+        .quad _SPbuiltin_eql // 10 SPbuiltin_eql
+        .quad _SPbuiltin_length // 11 SPbuiltin_length
+        .quad _SPbuiltin_seqtype // 12 SPbuiltin_seqtype
+        .quad _SPbuiltin_assq // 13 SPbuiltin_assq
+        .quad _SPbuiltin_memq // 14 SPbuiltin_memq
+        .quad _SPbuiltin_logbitp // 15 SPbuiltin_logbitp
+        .quad _SPbuiltin_logior // 16 SPbuiltin_logior
+        .quad _SPbuiltin_logand // 17 SPbuiltin_logand
+        .quad _SPbuiltin_ash // 18 SPbuiltin_ash
+        .quad _SPbuiltin_negate // 19 SPbuiltin_negate
+        .quad _SPbuiltin_logxor // 20 SPbuiltin_logxor
+        .quad _SPbuiltin_aref1 // 21 SPbuiltin_aref1
+        .quad _SPbuiltin_aset1 // 22 SPbuiltin_aset1
+        .quad _SPfuncall // 23 SPfuncall
+        .quad _SPmkcatch1v // 24 SPmkcatch1v
+        .quad _SPmkcatchmv // 25 SPmkcatchmv
+        .quad _SPmkunwind // 26 SPmkunwind
+        .quad _SPbind // 27 SPbind
+        .quad _SPconslist // 28 SPconslist
+        .quad _SPconslist_star // 29 SPconslist_star
+        .quad _SPmakes32 // 30 SPmakes32
+        .quad _SPmakeu32 // 31 SPmakeu32
         .quad _SPfix_overflow // 32
         .quad _SPmakeu64 // 33
         .quad _SPmakes64 // 34
-        .quad 0 // 35 SPmvpass
-        .quad 0 // 36 SPvalues
-        .quad 0 // 37 SPnvalret
-        .quad 0 // 38 SPthrow
-        .quad 0 // 39 SPnthrowvalues
-        .quad 0 // 40 SPnthrow1value
-        .quad 0 // 41 SPbind_self
-        .quad 0 // 42 SPbind_nil
-        .quad 0 // 43 SPbind_self_boundp_check
-        .quad 0 // 44 SPrplaca
-        .quad 0 // 45 SPrplacd
-        .quad 0 // 46 SPgvset
-        .quad 0 // 47 SPset_hash_key
-        .quad 0 // 48 SPstore_node_conditional
-        .quad 0 // 49 SPset_hash_key_conditional
-        .quad 0 // 50 SPstkconslist
-        .quad 0 // 51 SPstkconslist_star
-        .quad 0 // 52 SPmkstackv
-        .quad 0 // 53 SPsetqsym
-        .quad 0 // 54 SPprogvsave
-        .quad 0 // 55 SPstack_misc_alloc
-        .quad 0 // 56 SPgvector
-        .quad 0 // 57 SPfitvals
-        .quad 0 // 58 SPnthvalue
-        .quad 0 // 59 SPdefault_optional_args
-        .quad 0 // 60 SPopt_supplied_p
-        .quad 0 // 61 SPheap_rest_arg
-        .quad 0 // 62 SPreq_heap_rest_arg
-        .quad 0 // 63 SPheap_cons_rest_arg
+        .quad _SPmvpass // 35 SPmvpass
+        .quad _SPvalues // 36 SPvalues
+        .quad _SPnvalret // 37 SPnvalret
+        .quad _SPthrow // 38 SPthrow
+        .quad _SPnthrowvalues // 39 SPnthrowvalues
+        .quad _SPnthrow1value // 40 SPnthrow1value
+        .quad _SPbind_self // 41 SPbind_self
+        .quad _SPbind_nil // 42 SPbind_nil
+        .quad _SPbind_self_boundp_check // 43 SPbind_self_boundp_check
+        .quad _SPrplaca // 44 SPrplaca
+        .quad _SPrplacd // 45 SPrplacd
+        .quad _SPgvset // 46 SPgvset
+        .quad _SPset_hash_key // 47 SPset_hash_key
+        .quad _SPstore_node_conditional // 48 SPstore_node_conditional
+        .quad _SPset_hash_key_conditional // 49 SPset_hash_key_conditional
+        .quad _SPstkconslist // 50 SPstkconslist
+        .quad _SPstkconslist_star // 51 SPstkconslist_star
+        .quad _SPmkstackv // 52 SPmkstackv
+        .quad _SPsetqsym // 53 SPsetqsym
+        .quad _SPprogvsave // 54 SPprogvsave
+        .quad _SPstack_misc_alloc // 55 SPstack_misc_alloc
+        .quad _SPgvector // 56 SPgvector
+        .quad _SPfitvals // 57 SPfitvals
+        .quad _SPnthvalue // 58 SPnthvalue
+        .quad _SPdefault_optional_args // 59 SPdefault_optional_args
+        .quad _SPopt_supplied_p // 60 SPopt_supplied_p
+        .quad _SPheap_rest_arg // 61 SPheap_rest_arg
+        .quad _SPreq_heap_rest_arg // 62 SPreq_heap_rest_arg
+        .quad _SPheap_cons_rest_arg // 63 SPheap_cons_rest_arg
         .quad 0 // 64 SPcheck_fpu_exception
         .quad 0 // 65 SPdiscard_stack_object
-        .quad 0 // 66 SPksignalerr
-        .quad 0 // 67 SPstack_rest_arg
-        .quad 0 // 68 SPreq_stack_rest_arg
-        .quad 0 // 69 SPstack_cons_rest_arg
-        .quad 0 // 70 SPcall_closure
-        .quad 0 // 71 SPspreadargz
-        .quad 0 // 72 SPtfuncallgen
-        .quad 0 // 73 SPtfuncallslide
-        .quad 0 // 74 SPjmpsym
-        .quad 0 // 75 SPtcallsymgen
-        .quad 0 // 76 SPtcallsymslide
-        .quad 0 // 77 SPtcallnfngen
-        .quad 0 // 78 SPtcallnfnslide
+        .quad _SPksignalerr // 66 SPksignalerr
+        .quad _SPstack_rest_arg // 67 SPstack_rest_arg
+        .quad _SPreq_stack_rest_arg // 68 SPreq_stack_rest_arg
+        .quad _SPstack_cons_rest_arg // 69 SPstack_cons_rest_arg
+        .quad _SPcall_closure // 70 SPcall_closure
+        .quad _SPspreadargz // 71 SPspreadargz
+        .quad _SPtfuncallgen // 72 SPtfuncallgen
+        .quad _SPtfuncallslide // 73 SPtfuncallslide
+        .quad _SPjmpsym // 74 SPjmpsym
+        .quad _SPtcallsymgen // 75 SPtcallsymgen
+        .quad _SPtcallsymslide // 76 SPtcallsymslide
+        .quad _SPtcallnfngen // 77 SPtcallnfngen
+        .quad _SPtcallnfnslide // 78 SPtcallnfnslide
         .quad _SPmisc_ref // 79
-        .quad 0 // 80 SPsubtag_misc_ref
-        .quad 0 // 81 SPmakestackblock
-        .quad 0 // 82 SPmakestackblock0
-        .quad 0 // 83 SPmakestacklist
-        .quad 0 // 84 SPstkgvector
-        .quad 0 // 85 SPmisc_alloc
+        .quad _SPsubtag_misc_ref // 80 SPsubtag_misc_ref
+        .quad _SPmakestackblock // 81 SPmakestackblock
+        .quad _SPmakestackblock0 // 82 SPmakestackblock0
+        .quad _SPmakestacklist // 83 SPmakestacklist
+        .quad _SPstkgvector // 84 SPstkgvector
+        .quad _SPmisc_alloc // 85 SPmisc_alloc
         .quad 0 // 86 SPatomic_incf_node
-        .quad 0 // 87 SPrecover_values
-        .quad 0 // 88 SPinteger_sign
-        .quad 0 // 89 SPsubtag_misc_set
-        .quad 0 // 90 SPmisc_set
-        .quad 0 // 91 SPspread_lexprz
-        .quad 0 // 92 SPreset
-        .quad 0 // 93 SPmvslide
-        .quad 0 // 94 SPsave_values
-        .quad 0 // 95 SPadd_values
-        .quad 0 // 96 SPmisc_alloc_init
-        .quad 0 // 97 SPstack_misc_alloc_init
-        .quad 0 // 98 SPpopj
-        .quad 0 // 99 SPgetu64
-        .quad 0 // 100 SPgets64
-        .quad 0 // 101 SPspecref
-        .quad 0 // 102 SPspecrefcheck
-        .quad 0 // 103 SPspecset
-        .quad 0 // 104 SPgets32
-        .quad 0 // 105 SPgetu32
-        .quad 0 // 106 SPmvpasssym
-        .quad 0 // 107 SPunbind
-        .quad 0 // 108 SPunbind_n
-        .quad 0 // 109 SPunbind_to
-        .quad 0 // 110 SPprogvrestore
-        .quad 0 // 111 SPbind_interrupt_level_0
-        .quad 0 // 112 SPbind_interrupt_level_m1
-        .quad 0 // 113 SPbind_interrupt_level
-        .quad 0 // 114 SPunbind_interrupt_level
-        .quad 0 // 115 SParef2
-        .quad 0 // 116 SParef3
-        .quad 0 // 117 SPaset2
-        .quad 0 // 118 SPaset3
-        .quad 0 // 119 SPkeyword_bind
-        .quad 0 // 120 SPffcall
+        .quad _SPrecover_values // 87 SPrecover_values
+        .quad _SPinteger_sign // 88 SPinteger_sign
+        .quad _SPsubtag_misc_set // 89 SPsubtag_misc_set
+        .quad _SPmisc_set // 90 SPmisc_set
+        .quad _SPspread_lexprz // 91 SPspread_lexprz
+        .quad _SPreset // 92 SPreset
+        .quad _SPmvslide // 93 SPmvslide
+        .quad _SPsave_values // 94 SPsave_values
+        .quad _SPadd_values // 95 SPadd_values
+        .quad _SPmisc_alloc_init // 96 SPmisc_alloc_init
+        .quad _SPstack_misc_alloc_init // 97 SPstack_misc_alloc_init
+        .quad _SPpopj // 98 SPpopj
+        .quad _SPgetu64 // 99 SPgetu64
+        .quad _SPgets64 // 100 SPgets64
+        .quad _SPspecref // 101 SPspecref
+        .quad _SPspecrefcheck // 102 SPspecrefcheck
+        .quad _SPspecset // 103 SPspecset
+        .quad _SPgets32 // 104 SPgets32
+        .quad _SPgetu32 // 105 SPgetu32
+        .quad _SPmvpasssym // 106 SPmvpasssym
+        .quad _SPunbind // 107 SPunbind
+        .quad _SPunbind_n // 108 SPunbind_n
+        .quad _SPunbind_to // 109 SPunbind_to
+        .quad _SPprogvrestore // 110 SPprogvrestore
+        .quad _SPbind_interrupt_level_0 // 111 SPbind_interrupt_level_0
+        .quad _SPbind_interrupt_level_m1 // 112 SPbind_interrupt_level_m1
+        .quad _SPbind_interrupt_level // 113 SPbind_interrupt_level
+        .quad _SPunbind_interrupt_level // 114 SPunbind_interrupt_level
+        .quad _SParef2 // 115 SParef2
+        .quad _SParef3 // 116 SParef3
+        .quad _SPaset2 // 117 SPaset2
+        .quad _SPaset3 // 118 SPaset3
+        .quad _SPkeyword_bind // 119 SPkeyword_bind
+        .quad _SPffcall // 120 SPffcall
         .quad 0 // 121 SPdebind
-        .quad 0 // 122 SPcallback
+        .quad _SPcallback // 122 SPcallback
+        .quad _SPffcall_return_registers // 123 SPffcall_return_registers (PROPOSED extension, 16m5f)
+        .quad _SPtfuncallvsp // 124 SPtfuncallvsp (PROPOSED extension, 16m5f)
+        .quad _SPcallbuiltin // 125 SPcallbuiltin (PROPOSED extension, 16m5f)
+        .quad _SPcallbuiltin0 // 126 SPcallbuiltin0 (PROPOSED extension, 16m5f)
+        .quad _SPcallbuiltin1 // 127 SPcallbuiltin1 (PROPOSED extension, 16m5f)
+        .quad _SPcallbuiltin2 // 128 SPcallbuiltin2 (PROPOSED extension, 16m5f)
+        .quad _SPcallbuiltin3 // 129 SPcallbuiltin3 (PROPOSED extension, 16m5f)
+        .quad _SPlexpr_entry // 130 SPlexpr_entry (PROPOSED extension, 16m5f)
+        .quad _SPnmkunwind // 131 SPnmkunwind (PROPOSED extension, 16m5f)
 C(sptab_end):

--- a/lisp-kernel/arm64_print.c
+++ b/lisp-kernel/arm64_print.c
@@ -1,0 +1,631 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright 1994-2009 Clozure Associates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* ARM64-SPECIFIC — justification: ARM-family kernel printer ported from
+ * arm_print.c (no PPC64 analog file): the kernel debugger's lisp-object
+ * printer; its export print_lisp_object is the last undefined symbol in
+ * the arm64 kernel link (lisp.h:340, lispdcmd users).
+ *
+ * Source: arm_print.c (ARM32, 507 lines) @ upstream tip 115b7aa, remapped
+ * onto Matt Emerson's ARM64 low-tag design.  Layout reference for the
+ * 64-bit/low-tag deviations: x86_print.c (same tree; the x8664 sibling has
+ * the same 64-bit low-tag shape), cited x86_print.c:NNN.
+ * Tag authority: arm64-constants.h @ 115b7aa (fulltags :120-135, misc
+ * offsets :137-141, subtags :143-215); generic object accessors from
+ * macros.h:28-45 (mask-based, correct for this scheme as-is).
+ *
+ * PORT-NOTE — deviations from arm_print.c (each tagged inline):
+ *  1. Dispatch restructured for the 16-fulltag space: symbols have their
+ *     OWN pointer fulltag here (fulltag_symbol=7), not a misc subtag;
+ *     functions are ordinary miscobjs (fulltag_function removed, patch
+ *     0055); NIL has fulltag_nil=11; single-floats are immediates with
+ *     fulltag_single_float=1.
+ *  2. Single-float bits live in the top 32 bits of the immediate
+ *     (compiler/ARM64/arm64-lapmacros.lisp:49-51); extraction idiom from
+ *     x86_print.c:604-608.
+ *  3. KNOWN UPSTREAM BUG: subtag_s16_vector ==
+ *     subtag_complex_double_float_vector == 0x95 (arm64-constants.h:
+ *     164-166).  The one dispatch on that value here (vector_subtag_name)
+ *     treats it as s16 per lane ruling.
+ * See drafts/arm64-print-report.md for the full inventory and findings.
+ */
+
+#include <stdio.h>              /* arm_print.c:17 */
+#include <stdarg.h>             /* arm_print.c:18 */
+#include <setjmp.h>             /* arm_print.c:19 */
+#include <string.h>             /* ARM64-DEVIATION: arm_print.c calls strlen
+                                   (:68) with no declaration in scope (lisp.h
+                                   pulls no string.h); implicit decls are
+                                   errors on modern GCC and int-returning on
+                                   LP64.  arm64-exceptions.c:47 precedent. */
+
+#include "lisp.h"               /* arm_print.c:21 */
+#include "area.h"               /* arm_print.c:22 */
+#include "lisp-exceptions.h"    /* arm_print.c:23 */
+#include "lisp_globals.h"       /* arm_print.c:24 */
+
+/* lisp_global/nrs_symbol/unbound/fixnum_bitmask/immheader_tag_p are
+ * supplied (guarded) by platform-linuxarm64.h, which every kernel .c gets
+ * via `-include' (linuxarm64/Makefile:51); linuxarm64 builds define
+ * -DARM64, not -DARM (Makefile:26-27), so lisp_globals.h's #ifdef ARM
+ * ladder stays quiet.  Nothing is redefined here. */
+
+void
+sprint_lisp_object(LispObj, int);       /* arm_print.c:26-27 */
+
+#define PBUFLEN 252             /* arm_print.c:29 */
+
+char printbuf[PBUFLEN + 4];     /* arm_print.c:31 */
+int bufpos = 0;                 /* arm_print.c:32 */
+
+jmp_buf escape;                 /* arm_print.c:34 */
+
+void
+add_char(char c)                /* arm_print.c:36-44 */
+{
+  if (bufpos >= PBUFLEN) {
+    longjmp(escape, 1);
+  } else {
+    printbuf[bufpos++] = c;
+  }
+}
+
+void
+add_string(char *s, int len)    /* arm_print.c:46-52 */
+{
+  while(len--) {
+    add_char(*s++);
+  }
+}
+
+void
+add_lisp_base_string(LispObj str)  /* arm_print.c:54-63 */
+{
+  /* lisp_char_code is int32_t (lisptypes.h:32); simple_base_string is a
+   * 32-bit ivector on this target too (arm64-constants.h:159).
+   * misc_data_offset = +4 from the tagged pointer = untag+8
+   * (arm64-constants.h:139-140). */
+  lisp_char_code *src = (lisp_char_code *)  (ptr_from_lispobj(str + misc_data_offset));
+  natural i, n = header_element_count(header_of(str));
+
+  for (i=0; i < n; i++) {
+    add_char((char)(*src++));
+  }
+}
+
+void
+add_c_string(char *s)           /* arm_print.c:65-69 */
+{
+  add_string(s, strlen(s));
+}
+
+char numbuf[64];                /* arm_print.c:71 */
+
+void
+sprint_signed_decimal(signed_natural n)  /* arm_print.c:73-78 */
+{
+  sprintf(numbuf, "%ld", (long)n);      /* signed_natural = int64_t (lisptypes.h:25) */
+  add_c_string(numbuf);
+}
+
+void
+sprint_unsigned_decimal(natural n)  /* arm_print.c:80-85 */
+{
+  sprintf(numbuf, "%lu", (unsigned long)n);
+  add_c_string(numbuf);
+}
+
+void
+sprint_unsigned_hex(natural n)  /* arm_print.c:87-96; 64-bit (PPC64) branch
+                                   of the source's #ifdef selected —
+                                   WORD_SIZE == 64 (x86_print.c:112-113) */
+{
+  sprintf(numbuf, "#x%016lx", (unsigned long)n);  /* arm_print.c:91 */
+  add_c_string(numbuf);
+}
+
+void
+sprint_list(LispObj o, int depth)  /* arm_print.c:98-122 */
+{
+  /* car/cdr from macros.h:44-45 over constants.h:41-44 cons {cdr,car}:
+   * cdr@untag+0, car@untag+8 — correct for fulltag_cons=3 as-is. */
+  LispObj the_cdr;
+
+  add_char('(');
+  while(1) {
+    if (o != lisp_nil) {
+      sprint_lisp_object(ptr_to_lispobj(car(o)), depth);
+      the_cdr = ptr_to_lispobj(cdr(o));
+      if (the_cdr != lisp_nil) {
+        add_char(' ');
+        if (fulltag_of(the_cdr) == fulltag_cons) {
+          o = the_cdr;
+          continue;
+        }
+        add_c_string(". ");
+        sprint_lisp_object(the_cdr, depth);
+        break;
+      }
+    }
+    break;
+  }
+  add_char(')');
+}
+
+/*
+  Print a list of method specializers, using the class name instead of the class object.
+*/
+
+void
+sprint_specializers_list(LispObj o, int depth)  /* arm_print.c:128-171 */
+{
+  /* x86_print.c:183-234 adds a DARWIN-only foreign_class_name branch;
+   * arm_print.c (and LINUX) have none — the ARM32 shape is kept. */
+  LispObj the_cdr, the_car;
+
+  add_char('(');
+  while(1) {
+    if (o != lisp_nil) {
+      the_car = car(o);
+      if (fulltag_of(the_car) == fulltag_misc) {
+	LispObj header = header_of(the_car);
+	unsigned subtag = header_subtag(header);
+
+	if (subtag == subtag_instance) {
+          if (unbox_fixnum(deref(the_car,1)) < (1<<20)) {
+            sprint_lisp_object(deref(deref(the_car,3), 4), depth);
+          } else {
+            /* An EQL specializer */
+            add_c_string("(EQL ");
+            sprint_lisp_object(deref(deref(the_car,3), 3), depth);
+            add_char(')');
+          }
+	} else {
+	  sprint_lisp_object(the_car, depth);
+	}
+      } else {
+        sprint_lisp_object(the_car, depth);
+      }
+      the_cdr = cdr(o);
+      if (the_cdr != lisp_nil) {
+        add_char(' ');
+        if (fulltag_of(the_cdr) == fulltag_cons) {
+          o = the_cdr;
+          continue;
+        }
+        add_c_string(". ");
+        sprint_lisp_object(the_cdr, depth);
+        break;
+      }
+    }
+    break;
+  }
+  add_char(')');
+}
+
+char *
+vector_subtag_name(unsigned subtag)  /* arm_print.c:173-225 */
+{
+  switch (subtag) {
+  case subtag_bit_vector:
+    return "BIT-VECTOR";
+    break;
+  case subtag_instance:
+    return "INSTANCE";
+    break;
+  case subtag_bignum:
+    return "BIGNUM";
+    break;
+  case subtag_u8_vector:
+    return "(UNSIGNED-BYTE 8)";
+    break;
+  case subtag_s8_vector:
+    return "(SIGNED-BYTE 8)";
+    break;
+  case subtag_u16_vector:
+    return "(UNSIGNED-BYTE 16)";
+    break;
+  case subtag_s16_vector:
+    /* KNOWN UPSTREAM BUG: subtag_s16_vector ==
+     * subtag_complex_double_float_vector == 0x95 (arm64-constants.h:
+     * 164-166, both SUBTAG(ivector_class_other_bit,9)).  Per lane ruling
+     * this value dispatches as s16 here. */
+    return "(SIGNED-BYTE 16)";
+    break;
+  case subtag_u32_vector:
+    return "(UNSIGNED-BYTE 32)";
+    break;
+  case subtag_s32_vector:
+    return "(SIGNED-BYTE 32)";
+    break;
+  case subtag_u64_vector:      /* 64-bit target: x86_print.c:267-274
+                                  (X8664 branch); arm64-constants.h:155-156 */
+    return "(UNSIGNED-BYTE 64)";
+    break;
+  case subtag_s64_vector:
+    return "(SIGNED-BYTE 64)";
+    break;
+  case subtag_package:
+    return "PACKAGE";
+    break;
+  case subtag_code_vector:     /* arm_print.c:215-217; exists here too
+                                  (arm64-constants.h:181) */
+    return "CODE-VECTOR";
+    break;
+  case subtag_slot_vector:
+    return "SLOT-VECTOR";
+    break;
+  default:
+    return "";
+    break;
+  }
+}
+
+
+void
+sprint_random_vector(LispObj o, unsigned subtag, natural elements)  /* arm_print.c:228-240 */
+{
+  add_c_string("#<");
+  sprint_unsigned_decimal(elements);
+  add_c_string("-element vector subtag = ");
+  sprintf(numbuf, "%02X @", subtag);
+  add_c_string(numbuf);
+  sprint_unsigned_hex(o);
+  add_c_string(" (");
+  add_c_string(vector_subtag_name(subtag));
+  add_c_string(")>");
+}
+
+void
+sprint_symbol(LispObj o)        /* arm_print.c:242-264 */
+{
+  /* untag (macros.h:30) strips any fulltag, so this works both for
+   * fulltag_symbol pointers and for symbols reached via other tags;
+   * constants.h:48-57 lispsymbol field order matches the asm symbol
+   * struct (arm64-constants.h:332-340).  The source's #ifdef PPC64
+   * nil-check (arm_print.c:250-255) is dropped: fulltag_nil is dispatched
+   * before sprint_symbol can be reached (x86_print.c:303-319 precedent). */
+  lispsymbol *rawsym = (lispsymbol *) ptr_from_lispobj(untag(o));
+  LispObj
+    pname = rawsym->pname,
+    package = rawsym->package_predicate;
+
+  if (fulltag_of(package) == fulltag_cons) {
+    package = car(package);
+  }
+
+  if (package == nrs_KEYWORD_PACKAGE.vcell) {  /* lisp_globals.h:166 */
+    add_char(':');
+  }
+  add_lisp_base_string(pname);
+}
+
+void
+sprint_function(LispObj o, int depth)  /* arm_print.c:266-315 */
+{
+  /* deref/header_of are fulltag-agnostic; functions arrive misc-tagged
+   * (fulltag_function removed, patch 0055) via the sprint_gvector
+   * subtag dispatch.  lfbits is the last element, name the one before
+   * (macros.h:91-93 convention; lfbits masks constants.h:162-165). */
+  LispObj lfbits, header, name = lisp_nil;
+  natural elements;
+
+  header = header_of(o);
+  elements = header_element_count(header);
+  lfbits = deref(o, elements);
+
+  if ((lfbits & lfbits_noname_mask) == 0) {
+    name = deref(o, elements-1);
+  }
+
+  add_c_string("#<");
+  if (name == lisp_nil) {
+    add_c_string("Anonymous Function ");
+  } else {
+    if (lfbits & lfbits_method_mask) {
+      if (header_subtag(header_of(name)) == subtag_instance) {
+        LispObj
+          slot_vector = deref(name,3),
+          method_name = deref(slot_vector, 6),
+          method_qualifiers = deref(slot_vector, 2),
+          method_specializers = deref(slot_vector, 3);
+        add_c_string("Method-Function ");
+        sprint_lisp_object(method_name, depth);
+        add_char(' ');
+        if (method_qualifiers != lisp_nil) {
+          if (cdr(method_qualifiers) == lisp_nil) {
+            sprint_lisp_object(car(method_qualifiers), depth);
+          } else {
+            sprint_lisp_object(method_qualifiers, depth);
+          }
+          add_char(' ');
+        }
+        sprint_specializers_list(method_specializers, depth);
+      } else {
+        sprint_lisp_object(name, depth);
+      }
+      add_char(' ');
+    } else if (lfbits & lfbits_gfn_mask) {
+      /* x86_print.c:375-386 (64-bit shape: label only; the name-digging
+       * block there is X8632-specific and is omitted, as x8664 omits it) */
+      add_c_string("Generic Function ");
+    } else {
+      add_c_string("Function ");
+      sprint_lisp_object(name, depth);
+      add_char(' ');
+    }
+  }
+  sprint_unsigned_hex(o);
+  add_char('>');
+}
+
+void
+sprint_gvector(LispObj o, int depth)  /* arm_print.c:317-361 */
+{
+  LispObj header = header_of(o);
+  unsigned
+    elements = header_element_count(header),
+    subtag = header_subtag(header);
+
+  switch(subtag) {
+  /* subtag_function/subtag_symbol are retained although such objects
+   * normally carry their own fulltags here — header subtags still exist
+   * (arm64-constants.h:183,191) and x86_print.c:451-457 retains both on
+   * x8664 likewise. */
+  case subtag_function:
+    sprint_function(o, depth);
+    break;
+
+  case subtag_symbol:
+    sprint_symbol(o);
+    break;
+
+  case subtag_struct:
+  case subtag_istruct:
+    add_c_string("#<");
+    sprint_lisp_object(deref(o,1), depth);
+    add_c_string(" @");
+    sprint_unsigned_hex(o);
+    add_c_string(">");
+    break;
+
+  case subtag_simple_vector:
+    {
+      int i;
+      add_c_string("#(");
+      for(i = 1; i <= elements; i++) {
+        if (i > 1) {
+          add_char(' ');
+        }
+        sprint_lisp_object(deref(o, i), depth);
+      }
+      add_char(')');
+      break;
+    }
+
+  case subtag_instance:        /* x86_print.c:482-496 (64-bit sibling
+                                  addition; absent from arm_print.c) */
+    {
+      LispObj class_or_hash = deref(o,1);
+
+      if (tag_of(class_or_hash) == tag_fixnum) {
+	sprint_random_vector(o, subtag, elements);
+      } else {
+	add_c_string("#<CLASS ");
+	sprint_lisp_object(class_or_hash, depth);
+	add_c_string(" @");
+	sprint_unsigned_hex(o);
+	add_c_string(">");
+      }
+      break;
+    }
+
+  default:
+    sprint_random_vector(o, subtag, elements);
+    break;
+  }
+}
+
+void
+sprint_ivector(LispObj o)       /* arm_print.c:363-401 */
+{
+  LispObj header = header_of(o);
+  unsigned
+    elements = header_element_count(header),
+    subtag = header_subtag(header);
+
+  switch(subtag) {
+  case subtag_simple_base_string:
+    add_char('"');
+    add_lisp_base_string(o);
+    add_char('"');
+    return;
+
+  case subtag_bignum:
+    /* NOTE (inherited quirk, see report): bigits are 32-bit here
+     * (arm64-constants.h:377-378) but this reads 64-bit words —
+     * x86_print.c:521-529 ships exactly this shape on x8664 (same 32-bit
+     * bigits) and is followed verbatim; on 64-bit targets elements==1
+     * cannot occur and the elements==2 read yields the right LE value. */
+    if (elements == 1) {
+      sprint_signed_decimal((signed_natural)(deref(o, 1)));
+      return;
+    }
+    if ((elements == 2) && (deref(o, 2) == 0)) {
+      sprint_unsigned_decimal(deref(o, 1));
+      return;
+    }
+    break;
+
+  case subtag_double_float:
+    /* prints nothing — inherited from arm_print.c:389-390 ==
+     * x86_print.c:532-533 (both fall out of the switch with no output) */
+    break;
+
+  case subtag_macptr:
+    add_c_string("#<MACPTR ");
+    sprint_unsigned_hex(deref(o,1));
+    add_c_string(">");
+    break;
+
+  default:
+    sprint_random_vector(o, subtag, elements);
+  }
+}
+
+void
+sprint_vector(LispObj o, int depth)  /* arm_print.c:403-413 */
+{
+  /* immheader_tag_p over {immheader_0,immheader_1,immheader_2} comes from
+   * platform-linuxarm64.h:134-139 */
+  LispObj header = header_of(o);
+
+  if (immheader_tag_p(fulltag_of(header))) {
+    sprint_ivector(o);
+  } else {
+    sprint_gvector(o, depth);
+  }
+}
+
+void
+sprint_lisp_object(LispObj o, int depth)  /* arm_print.c:415-491 */
+{
+  if (--depth < 0) {
+    add_char('#');
+  } else {
+    /* ARM64-DEVIATION: dispatch restructured from ARM32's 8-fulltag
+     * switch (arm_print.c:421-489) onto this design's 16-fulltag space
+     * (arm64-constants.h:120-135), following x86_print.c:564-648's
+     * 64-bit shape.  The ARM32 switch was total over its tag space; this
+     * one is kept total too. */
+    switch (fulltag_of(o)) {
+    case fulltag_even_fixnum:           /* arm_print.c:422-424 */
+    case fulltag_odd_fixnum:
+      sprint_signed_decimal(unbox_fixnum(o));
+      break;
+
+    case fulltag_single_float:
+      /* ARM64-DEVIATION: single-floats are immediates with their own
+       * fulltag (arm64-arch.lisp:47,57,78 "single-float (and nothing
+       * but)"); no ARM32 analog.  Bits in the TOP 32 BITS
+       * (arm64-lapmacros.lisp:49-51); LE extraction idiom from
+       * x86_print.c:604-608. */
+      {
+        LispObj xx = o;
+        float f = ((float *)&xx)[1];
+        sprintf(numbuf, "%f", f);
+        add_c_string(numbuf);
+      }
+      break;
+
+    case fulltag_immheader_0:           /* arm_print.c:437-443; three imm-
+                                           header + two node-header fulltags
+                                           here (arm64-constants.h:125-126,
+                                           132-134) vs ARM32's one of each */
+    case fulltag_immheader_1:
+    case fulltag_immheader_2:
+    case fulltag_nodeheader_0:
+    case fulltag_nodeheader_1:
+      add_c_string("#<header ? ");
+      sprint_unsigned_hex(o);
+      add_c_string(">");
+      break;
+
+    case fulltag_imm_0:                 /* characters (arm64-constants.h:203) */
+    case fulltag_imm_1:                 /* markers (arm64-constants.h:205-215) */
+      /* arm_print.c:446-477 fulltag_imm case; both imm fulltags route
+       * here like x86_print.c:586-590's imm_0/imm_1.  The source's PPC64
+       * single-float sub-branch is not needed — singles have their own
+       * fulltag (case above). */
+      if (o == unbound) {               /* `unbound' alias: platform-linuxarm64.h:82-84 */
+        add_c_string("#<Unbound>");
+      } else {
+        if (header_subtag(o) == subtag_character) {
+          unsigned c = (o >> charcode_shift);
+          add_c_string("#\\");
+          if ((c >= ' ') && (c < 0x7f)) {
+            add_char(c);
+          } else {
+            sprintf(numbuf, "%o", c);
+            add_c_string(numbuf);
+          }
+        } else {
+          add_c_string("#<imm ");
+          sprint_unsigned_hex(o);
+          add_c_string(">");
+        }
+      }
+      break;
+
+    case fulltag_nil:
+      /* ARM64-DEVIATION (lane directive): NIL prints as NIL.  ARM32
+       * folded fulltag_nil into the cons case (arm_print.c:480-484) and
+       * x86_print.c:619-624 does the same (yielding "()"); flagged in the
+       * report as a reviewable choice. */
+      add_c_string("NIL");
+      break;
+
+    case fulltag_cons:                  /* arm_print.c:482-484 */
+      sprint_list(o, depth);
+      break;
+
+    case fulltag_misc:                  /* arm_print.c:486-488 */
+      sprint_vector(o, depth);
+      break;
+
+    case fulltag_symbol:
+      /* ARM64-DEVIATION: symbols have their own pointer fulltag here
+       * (arm64-constants.h:127), not a misc subtag as on ARM32;
+       * x86_print.c:631-633. */
+      sprint_symbol(o);
+      break;
+
+    /* fulltag_function removed (patch 0055): functions are ordinary
+     * miscobjs and reach sprint_function via the fulltag_misc case's
+     * subtag dispatch; tag 15 joins fulltag_reserved below so the
+     * dispatch stays total.  (No TRA case: TRA is x86-only; ARM64 is
+     * LR-based like ARM32, whose printer has none.) */
+
+    case 15:                            /* was fulltag_function */
+    case fulltag_reserved:
+      /* ARM64-DEVIATION: no analog in either source; fulltag 0b1001 is
+       * reserved (arm64-arch.lisp:65).  Case added so the dispatch stays
+       * total over the tag space, as ARM32's was. */
+      add_c_string("#<reserved-tag ");
+      sprint_unsigned_hex(o);
+      add_c_string(">");
+      break;
+    }
+  }
+}
+
+char *
+print_lisp_object(LispObj o)    /* arm_print.c:493-507 */
+{
+  bufpos = 0;
+  if (setjmp(escape) == 0) {
+    sprint_lisp_object(o, 5);
+    printbuf[bufpos] = 0;
+  } else {
+    printbuf[PBUFLEN+0] = '.';
+    printbuf[PBUFLEN+1] = '.';
+    printbuf[PBUFLEN+2] = '.';
+    printbuf[PBUFLEN+3] = 0;
+  }
+  return printbuf;
+}

--- a/lisp-kernel/bits.h
+++ b/lisp-kernel/bits.h
@@ -131,7 +131,7 @@ current_stack_pointer(void)
   natural _sp;
   __asm__("movl %%esp,%0" : "=r" (_sp));
 #endif
-#ifdef ARM
+#if defined(ARM) || defined(ARM64) /* PROPOSED */
   register natural _sp __asm__("sp");
 #endif
   return _sp;

--- a/lisp-kernel/imports.s
+++ b/lisp-kernel/imports.s
@@ -18,11 +18,15 @@ define(`PTR',`
         __ifdef(`PPC64')
         .quad $1
         __else
+         __ifdef(`ARM64')
+         .quad $1 /* PROPOSED */
+         __else
 	 __ifdef(`X8664')
 	 .quad $1
 	 __else
 	  .long $1
 	 __endif
+         __endif
         __endif
 ')
 	_beginfile

--- a/lisp-kernel/linuxarm64/Makefile
+++ b/lisp-kernel/linuxarm64/Makefile
@@ -46,20 +46,20 @@ endif
 
 
 .s.o:
-	$(M4) $(M4FLAGS) -I../ $< | $(AS)  $(ASFLAGS) -o $@
+	$(CC) -c -x assembler-with-cpp -I../ $< $(CDEFINES) -o $@
 .c.o:
 	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT)   $(WFORMAT)  -o $@
 
-SPOBJ = pad.o  arm64-spentry.o
+SPOBJ = pad.o  arm64-spentry.o spentry-A-alloc-numbers.o spentry-B-vectors-misc.o spentry-C-bind-catch-throw.o spentry-D-call-builtins.o spentry-E-ffi.o
 ASMOBJ = arm64-asmutils.o imports.o
 
 COBJ  = pmcl-kernel.o gc-common.o arm64-gc.o bits.o  arm64-exceptions.o \
 	image.o thread_manager.o lisp-debug.o memory.o unix-calls.o
 
-DEBUGOBJ = lispdcmd.o plprint.o plsym.o albt.o arm_print.o
+DEBUGOBJ = lispdcmd.o plprint.o plsym.o albt.o arm64_print.o
 KERNELOBJ= $(COBJ) arm64-asmutils.o  imports.o
 
-SPINC =	lisp.s m4macros.m4 arm64-constants.s arm64-macros.s errors.s arm64-uuo.s \
+SPINC =	lisp.s m4macros.m4 arm64-constants.h arm64-macros.s errors.s arm64-uuo.s \
 	lisp_globals.s
 
 CHEADERS = area.h bits.h arm64-constants.h lisp-errors.h gc.h lisp.h \
@@ -82,7 +82,7 @@ OSLIBS = -ldl -lm -lpthread -lrt
 
 
 ../../armcl64:	$(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ)
-	$(CC)  $(CDEBUG)  -Wl,--export-dynamic $(HASH_STYLE) -mfloat-abi=$(FLOAT_ABI) -o $@ -T ./armlinux.x $(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) -Wl,--no-as-needed $(OSLIBS)
+	$(CC)  $(CDEBUG)  -Wl,--export-dynamic $(HASH_STYLE)  -o $@ $(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) -Wl,--no-as-needed $(OSLIBS)
 
 
 $(SPOBJ): $(SPINC)
@@ -99,3 +99,6 @@ clean:	cclean
 
 strip:	../../armcl
 	strip -g ../../armcl
+
+imports.o: ../imports.s ../m4macros.m4
+	$(M4) $(M4FLAGS) -I../ ../imports.s | $(AS) $(ASFLAGS) -o $@

--- a/lisp-kernel/platform-linuxarm64.h
+++ b/lisp-kernel/platform-linuxarm64.h
@@ -1,0 +1,150 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* PPC64 LINE-PORT (source: vendor/ccl/lisp-kernel/ppc-exceptions.c lane;
+ * this header modeled line-for-line on Matt Emerson's
+ * lisp-kernel/platform-linuxarm.h (ARM-family structure) and
+ * lisp-kernel/platform-linuxppc64.h (64-bit values), tree pin d71a5ad.
+ *
+ * PORT-NOTE / deviations:
+ *  - PLATFORM_CPU: RATIFIED by Matt's tree — lisp.h:74 defines
+ *    PLATFORM_CPU_ARM64 (4<<3), and the arm64 backends stamp
+ *    platform-cpu-arm64 into the image header (darwinarm64 backend @
+ *    arm64-backend.lisp:229; our linuxarm64-backend-additions.lisp:36
+ *    matches).  Kernel must agree or image.c rejects the image
+ *    ("Heap image was saved for another platform", 16j).
+ *  - MAXIMUM_MAPPABLE_MEMORY / IMAGE_BASE_ADDRESS: PROPOSED values taken
+ *    from platform-linuxx8664.h:26-27 (the other 64-bit low-tag Linux
+ *    port; aarch64-linux user VA space is 48-bit like x86-64, and Matt's
+ *    low-tag scheme puts no constraint on the top byte).  Ratify.
+ *  - xp accessor field layout: aarch64-linux
+ *    arch/arm64/include/uapi/asm/sigcontext.h (fault_address; regs[31];
+ *    sp; pc; pstate).  Accessor idiom consulted from our high-tag
+ *    lisp-kernel/platform-linuxarm64.h (ucontext shapes only; no tag
+ *    logic lives here).
+ */
+
+#define WORD_SIZE 64
+#define PLATFORM_OS PLATFORM_OS_LINUX
+#define PLATFORM_CPU PLATFORM_CPU_ARM64    /* see PORT-NOTE above */
+#define PLATFORM_WORD_SIZE PLATFORM_WORD_SIZE_64
+
+#include <ucontext.h>
+
+typedef ucontext_t ExceptionInformation;   /* platform-linuxarm.h:31 */
+
+/* PROPOSED (platform-linuxx8664.h:26-27) — ratify */
+#define MAXIMUM_MAPPABLE_MEMORY (512L<<30L)
+#define IMAGE_BASE_ADDRESS 0x300000000000L
+
+#include "lisptypes.h"
+/* arm64-constants.h #includes constants.h itself since f067047 (the fix
+ * we'd PROPOSED here landed upstream). */
+#include "arm64-constants.h"               /* platform-linuxarm.h:36 pattern */
+
+/* PROPOSED additions to arm64-constants.h / area.h / threads.h (their
+ * per-arch #ifdef ladders have no ARM64 branch yet; values cited): */
+#ifndef TCR_BIAS
+#define TCR_BIAS (0)                       /* = PPC64/ARM32 (ppc-constants64.h:244) */
+#endif
+#ifndef heap_segment_size
+#define heap_segment_size 0x00020000L      /* = PPC64 (ppc-constants64.h:305-306) */
+#define log2_heap_segment_size 17L
+#endif
+/* CS_OVERFLOW_FORCE_LIMIT: now provided by his area.h arm64 branch
+   (-(sizeof(lisp_frame)), = our -32).  RECONCILED 556aebe8: dropped. */
+#ifndef STATIC_BASE_ADDRESS
+#define STATIC_BASE_ADDRESS 0x00012000     /* = X86 shape (x86-constants.h:74):
+                                              one page under canonical nil
+                                              (0x13000, arm64-arch.lisp:184) */
+#endif
+/* lisp_globals.h grew a real ARM64 branch @ 93d72a0 (nil-anchored:
+   nil_value = the runtime lisp_nil, set by set_nil() at image-load
+   time) -- the fixed-address shims that lived here are retired.
+   BOOT-CHECK: his nrs base (nil-fulltag+dnode) vs the xload two-cons
+   pun layout is unverified geometry; if T/nrs reads come back garbage,
+   probe here first. */
+/* pmcl-kernel.c:1461-1478's per-platform ladder has no LINUX+ARM64 arm;
+   aarch64 support entered mainline in Linux 3.7. */
+#ifndef min_os_version
+#define min_os_version "3.7"
+#endif
+/* C alias for the unbound marker (ARM32 precedent, arm-constants.h:247;
+   Matt's constants define unbound_marker but not the short name
+   pmcl-kernel.c:2583 uses). */
+#ifndef unbound
+#define unbound unbound_marker
+#endif
+#ifndef slot_unbound
+#define slot_unbound slot_unbound_marker   /* ARM32 precedent (arm-constants.h:251) */
+#endif
+/* stack-consed-object marker (albt.c stack walker; ARM32:
+   arm-constants.h:245 SUBTAG(fulltag_imm,1)).  PROPOSED value in Matt's
+   imm_1 subtag space, next free after lisp_frame_marker(5). */
+#ifndef stack_alloc_marker
+#define stack_alloc_marker SUBTAG(fulltag_imm_1, 6)
+#endif
+/* Image ABI version (image.c): fresh number for the new target; ARM32
+   uses 1045, PPC64 1040.  PROPOSED: 1046 (next free). */
+#ifndef ABI_VERSION_CURRENT
+#define ABI_VERSION_MIN 1046
+#define ABI_VERSION_CURRENT 1046
+#define ABI_VERSION_MAX 1046
+#endif
+/* C-side `struct lisp_frame` is now provided by his arm64-constants.h C
+   section (RECONCILED 556aebe8: our duplicate typedef dropped).  He does
+   NOT define lisp_frame_size, so keep that (ours-only). */
+#ifndef lisp_frame_size
+#define lisp_frame_size sizeof(lisp_frame)
+#endif
+
+/* fixnum_bitmask: 64-bit form (ppc-constants64.h:237 / x86-constants64.h:272). */
+#ifndef fixnum_bitmask
+#define fixnum_bitmask(n)  (1LL<<((n)+fixnumshift))
+#endif
+/* NSAVEREGS: save0-save3 (thread_manager.c:1885-1898 ladder; PPC 8, ARM32 4). */
+#ifndef NSAVEREGS
+#define NSAVEREGS 4
+#endif
+/* tcr->single_float_convert.tag (thread_manager.c:1293) wants a boxed
+   single-float subtag; singles are IMMEDIATE (fulltag_single_float) in
+   this design, so the convert box is vestigial here.  Alias for the
+   compile; RATIFY (likely the field or the store goes away). */
+#ifndef subtag_single_float
+#define subtag_single_float fulltag_single_float
+#endif
+/* gc.h / macros.h arch ladders have no ARM64 branch — the shims the gc
+   draft carries file-locally, hoisted so gc-common.c/image.c see REAL
+   definitions instead of implicit decls (would otherwise fail at link).
+   arm64 nodeheader fulltags = {nodeheader_0, nodeheader_1}; immheader =
+   {immheader_0, immheader_1, immheader_2} (arm64-constants.h:120-135);
+   node fulltags = cons|misc|symbol (fulltag_function removed, patch 0055). */
+/* nodeheader_tag_p / IMMHEADER_MASK / immheader_tag_p: now provided by his
+   macros.h arm64 branch (RECONCILED 556aebe8: our forward-fills dropped). */
+#ifndef is_node_fulltag
+#define is_node_fulltag(f)  ((1<<(f))&((1<<fulltag_cons)     |                                        (1<<fulltag_misc)     |                                        (1<<fulltag_symbol)))
+#endif
+
+/* AArch64 instructions are 32 bits wide; `pc' points at one.
+ * (arm-exceptions.h:120 `typedef u_int32_t opcode, *pc;' — ARM64-DEVIATION:
+ * hoisted into the platform header because arm64-exceptions.h does not yet
+ * define it and the gc also needs it.) */
+typedef uint32_t opcode, *pc;
+
+/* xp accessors — aarch64-linux mcontext_t:
+ *   struct sigcontext { __u64 fault_address; __u64 regs[31];
+ *                       __u64 sp; __u64 pc; __u64 pstate; ... };
+ * Same accessor shapes as platform-linuxarm.h:38-46, 64-bit fields. */
+#define xpGPRvector(x) ((natural *)&((x)->uc_mcontext.regs[0]))
+#define xpGPR(x,gprno) (xpGPRvector(x))[gprno]
+#define set_xpGPR(x,gpr,new) xpGPR((x),(gpr)) = (natural)(new)
+#define xpPC(x) (*((pc*)(&((x)->uc_mcontext.pc))))
+#define set_xpPC(x,new) (xpPC(x) = (pc)(new))
+#define xpLR(x) (*((pc*)(&(xpGPR(x,30)))))  /* x30 = LR */
+#define xpSP(x) (*((natural*)(&((x)->uc_mcontext.sp))))
+#define xpPSR(x) ((x)->uc_mcontext.pstate)
+#define xpFaultAddress(x) ((x)->uc_mcontext.fault_address)
+
+#define DarwinSigReturn(context)            /* platform-linuxarm.h:48-49 */
+#define SIGRETURN(context)
+
+#include "os-linux.h"

--- a/lisp-kernel/spentry-A-alloc-numbers.s
+++ b/lisp-kernel/spentry-A-alloc-numbers.s
@@ -1,0 +1,804 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "arm64-constants.h"
+#include "arm64-macros.s"   /* pulls arm64-uuo.s @ 115b7aa */
+#include "arm64-globals-proposed.s"
+
+/*
+ * Cluster A: alloc-numbers subprims
+ * Ported from vendor/ccl/lisp-kernel/ppc-spentry.s (PPC64 branch) to
+ * Matt Emerson's upstream ARM64 low-tag design.
+ *
+ * 20 subprims (per CLAUDE.md upstream-port task): stack_misc_alloc,
+ * makestackblock, makestacklist, misc_alloc, misc_alloc_init, integer_sign,
+ * builtin_div, getu64, gets64, makeu64, makeu128, makes128, specref,
+ * specrefcheck, makes32, makeu32, gets32, getu32, stack_misc_alloc_init,
+ * makestackblock0.
+ *
+ * makes64/fix_overflow are Matt's OWN already-real examples in his
+ * arm64-spentry.s (not owned by this cluster).  gets32/getu32 exist in our
+ * own high-tag arm64-spentry.s; makes32/makeu32 do not (derived from PPC64
+ * only).
+ *
+ * PORT-NOTE: the cross-cutting infrastructure this file's error paths and
+ * tail-jumps depend on is now PROPOSED (ratify with Matt) and shared with
+ * the sibling clusters:
+ * (a) NRS/global-relative addressing: arm64-globals-proposed.s
+ *     (rnil-relative ref_nrs_symbol/ref_nrs_value, indices from the vendor
+ *     lisp_globals.s nrs order) -- same idiom as spentry-C/D.
+ * (b) error/trap signalling: the `udf #imm16' UUO scheme (canonical:
+ *     arm64-asm.lisp:435-450; namespace doc = PROPOSED-CONSTANTS block
+ *     below, BINDING for all clusters) plus the _SPksignalerr subprim
+ *     (spentry-D-call-builtins.s:488, real body).
+ */
+
+/* PROPOSED-CONSTANTS (ratify with Matt) -- derived from PPC64 struct/header
+ * definitions using the SAME _struct/_structf macro conventions already
+ * present in arm64-constants.h; NOT invented.  Cited per-field below. */
+
+/* tsp_frame: ppc-constants64.s:228-233 (backlink, type, then fixed_overhead
+ * and data_offset alias the SAME offset -- Matt's _struct macro block in
+ * arm64-constants.h has no _struct_label primitive, so these are plain .set
+ * equates rather than routed through the struct-generator macros). */
+.set tsp_frame.backlink, 0
+.set tsp_frame.type, 8
+.set tsp_frame.fixed_overhead, 16
+.set tsp_frame.data_offset, 16
+.set tsp_frame.size, 16
+/* ppc-constants.s:171 "(UNSIGNED-BYTE 16), one less than TSTACK_SOFTPROT" */
+.set tstack_alloc_limit, 0xffff
+
+/* lisp_frame: Matt's ARM-family MARKER frame, NOT PPC's backlink frame.
+ * Ground truth: his popj vinsn (compiler/ARM64/arm64-vinsns.lisp:61-67)
+ * does ldp fn,lr,[sp,#16] / ldr vsp,[sp,#8] ("ignore marker") / add sp,#32,
+ * and arm64-constants.h:177-178 defines subtag_lisp_frame_marker.  Layout
+ * matches ARM32 (arm-constants.s:374-379): marker,savevsp,savefn,savelr. */
+.set lisp_frame.marker, 0
+.set lisp_frame.savevsp, 8
+.set lisp_frame.savefn, 16
+.set lisp_frame.savelr, 24
+.set lisp_frame.size, 32
+
+/* symbol: field order ppc-constants64.s:237-245, but biased by
+ * -fulltag_symbol: Matt's design gives symbols their OWN pointer tag
+ * (arm64-constants.h:90 fulltag_symbol=0b0111; arm64-arch.lisp:196
+ * misc-symbol-offset = node_size - fulltag_symbol), so slot n of a
+ * symbol-tagged pointer is at (n+1)*node_size - fulltag_symbol.
+ * (Was wrongly -misc_bias=-4; caught in the D-repair sibling sweep.
+ * These odd offsets are the ledger's "symbol.vcell=9" item.) */
+.set symbol.header, (0*node_size - fulltag_symbol)
+.set symbol.pname, (1*node_size - fulltag_symbol)
+.set symbol.vcell, (2*node_size - fulltag_symbol)
+.set symbol.fcell, (3*node_size - fulltag_symbol)
+.set symbol.package_predicate, (4*node_size - fulltag_symbol)
+.set symbol.flags, (5*node_size - fulltag_symbol)
+.set symbol.plist, (6*node_size - fulltag_symbol)
+.set symbol.binding_index, (7*node_size - fulltag_symbol)
+.set symbol.size, 64
+
+/* _function: slot order ppc-constants64.s:223-226 (codevector = slot 0),
+ * biased by -fulltag_misc: a function is an ordinary miscobj
+ * (fulltag_function removed, patch 0055; codevector offset -7 -> -4). */
+.set _function.header, misc_header_offset
+.set _function.codevector, misc_data_offset
+.set _function.size, 16
+
+/* bignum headers not already in arm64-constants.h (two/three/four_digit_
+ * bignum_header ARE already defined there).  Derived via the same
+ * def_header(name,count,subtag) formula as ppc-constants.s:330-333/
+ * ppc-constants32.s:388, using macptr.element_count/subtag_bignum which
+ * arm64-constants.h already defines for real. */
+.set one_digit_bignum_header, (1 << num_subtag_bits) | subtag_bignum
+.set five_digit_bignum_header, (5 << num_subtag_bits) | subtag_bignum
+.set macptr_header, (macptr.element_count << num_subtag_bits) | subtag_macptr
+
+/* T = rnil + t_offset.  Same derivation as spentry-D:75-81 (Matt's
+ * arm64-arch.lisp:184-188: canonical-t-value - canonical-nil-value); the
+ * absolute addresses are provisional but the OFFSET is ratified geometry. */
+.set t_offset, ((0x13020 + fulltag_symbol) - (0x13000 + fulltag_nil))
+
+/* %builtin-functions% vector index (ppc-constants.s:131; arch-independent
+ * lisp-level index, same table spentry-D's jump_builtin uses). */
+.set _builtin_div, 3
+
+/* Lisp error selector for _SPksignalerr (errors.s:195 deferr(XARRLIMIT,77):
+ * deferr makes a BOXED fixnum, same convention as spentry-C:66-75). */
+.set XARRLIMIT, (77 << fixnumshift)
+
+/* UUO / trap encodings: Matt's OWN lisp-kernel/arm64-uuo.s @ 115b7aa
+ * (2e10ffb "Sketch out a revised way to encode and write UUOs"),
+ * included above -- 2-bit format in the udf imm16 (0 reserved: udf #0 is
+ * the code-vector start sentinel; 1 unary reg+info; 2 binary ra+rb+info;
+ * 3 misc).  His macros are invoked directly below with register NAMES
+ * (they encode via the R* numbers in arm64-constants.h).
+ * PROPOSED on top (arm64-globals-proposed.s): uuo_interr (misc bit-13
+ * flag) for PPC's errnum-carrying traps.
+ * xtype VALUES: his arm64-uuo.s (included above) defines the full set
+ * (xtype_integer = 0x18 ... xtype_cons = 0xe8, "Keep these in sync with
+ * the values in arm64-arch.lisp"); *arm64-xtype-specifiers*
+ * (arm64-trap-support.lisp:215) decodes that numbering and the
+ * expected-type field is 8 bits wide.  16m41: ARM32-numbered local
+ * .sets here (integer=4, s64=8, ...) SHADOWED his values, so unboxing
+ * traps reported wrong expected types. */
+
+/* Construct a lisp integer out of the 32-bit signed value in imm0.
+ * ported from ppc-spentry.s:6762-6774 (PPC64 branch only: box_fixnum and
+ * return -- a (signed-byte 32) always fits in Matt's 61-bit-magnitude
+ * fixnum, so the PPC32-only bignum-overflow path in the same subprim is not
+ * reachable on a 64-bit target and is not ported). */
+spentry makes32
+        lsl     arg_z, imm0, #fixnumshift
+        ret
+endsp makes32
+
+/* Construct a lisp integer out of the 32-bit unsigned value in imm0.
+ * ported from ppc-spentry.s:6780-6783 (PPC64 branch): an (unsigned-byte 32)
+ * also always fits Matt's 61-bit-magnitude fixnum. */
+spentry makeu32
+        lsl     arg_z, imm0, #fixnumshift
+        ret
+endsp makeu32
+
+/* Construct a lisp integer out of the unsigned 128-bit value in imm0 (high
+ * 64 bits) : imm1 (low 64 bits) -- PPC64's "imm0:imm1" register-pair
+ * comment convention, high-part-first.
+ * ported from ppc-spentry.s:6621-6660 (PPC64 branch), logic re-derived from
+ * first principles (minimal-digit unsigned-bignum normalization: keep
+ * digits up through the highest nonzero one; append one more zero digit iff
+ * that digit's own top bit is set) rather than transliterating PPC's
+ * per-32-bit-half CR-probe sequence, which relies on POWER's multiple
+ * parallel condition-register fields with no 1:1 AArch64 (single NZCV)
+ * analog.  rotldi byte-swaps dropped throughout: AArch64 is little-endian,
+ * so a direct 64-bit store already places digit pairs in the correct
+ * byte order with no swap needed (PPC64/CCL historically ran big-endian). */
+spentry makeu128
+        cbz     imm0, 6f                       /* whole value fits in imm1 alone */
+        /* GC SAFETY (Matt, 2026-07-11 mail): scratch must be an IMM reg,
+         * never a node reg like temp0 -- an unboxed value there has an
+         * arbitrary tag the GC could see. */
+        lsr     imm3, imm0, #32
+        cbnz    imm3, 2f                       /* digit3 (imm0's high half) != 0 */
+        /* digit3 == 0: 3 or 4 digits, decided by imm0's bit31 (== digit2's
+         * own sign bit, since digit3==0 means imm0 < 2^32). */
+        lsr     imm3, imm0, #31
+        cbnz    imm3, 1f
+        mov     imm2, #three_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm2, aligned_bignum_size(3)
+        str     imm1, [arg_z, #misc_data_offset]
+        str     w0,   [arg_z, #(misc_data_offset + 8)]   /* w0 = low 32 bits of imm0 */
+        ret
+1:      mov     imm2, #four_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm2, aligned_bignum_size(4)
+        str     imm1, [arg_z, #misc_data_offset]
+        str     imm0, [arg_z, #(misc_data_offset + 8)]
+        ret
+2:      /* digit3 != 0: 4 or 5 digits, decided by imm0's sign (bit63). */
+        cmp     imm0, #0
+        b.ge    1b
+        mov     imm2, #five_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm2, aligned_bignum_size(5)
+        str     imm1, [arg_z, #misc_data_offset]
+        str     imm0, [arg_z, #(misc_data_offset + 8)]
+        str     xzr,  [arg_z, #(misc_data_offset + 16)]
+        ret
+6:      mov     imm0, imm1
+        b       _SPmakeu64
+endsp makeu128
+
+/* Construct a lisp integer out of the signed 128-bit value in imm0 (high 64
+ * bits) : imm1 (low 64 bits).
+ * ported from ppc-spentry.s:6667-6693 (PPC64 branch).  Unlike makeu128, a
+ * signed value never needs a 5th padding digit: a kept top digit's own
+ * bit31 already correctly encodes the sign, since the whole point of
+ * dropping a would-be digit is only valid when it's pure sign-extension of
+ * the one below -- which is exactly the "imm0 == sign_extend(imm1)" /
+ * "imm0 fits signed32" tests below.  rotldi byte-swaps dropped (see
+ * makeu128 comment -- little-endian AArch64 needs none). */
+spentry makes128
+        asr     imm2, imm1, #63
+        cmp     imm2, imm0
+        b.eq    2f
+        sxtw    imm3, w0                        /* sign-extend low 32 bits of imm0 */
+        cmp     imm3, imm0
+        b.eq    1f
+        mov     imm2, #four_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm2, aligned_bignum_size(4)
+        str     imm1, [arg_z, #misc_data_offset]
+        str     imm0, [arg_z, #(misc_data_offset + 8)]
+        ret
+1:      mov     imm2, #three_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm2, aligned_bignum_size(3)
+        str     imm1, [arg_z, #misc_data_offset]
+        str     w3,   [arg_z, #(misc_data_offset + 8)]
+        ret
+2:      mov     imm0, imm1
+        b       _SPmakes64
+endsp makes128
+
+/* makeu64: Matt's own implementation landed upstream @ 115b7aa
+ * (arm64-spentry.s spentry makeu64 -- GC-safe, imm regs only); ours is
+ * CEDED to his and removed (it also had the temp0 GC-safety bug he
+ * flagged in the 2026-07-11 mail). */
+
+/* arg_z should be (unsigned-byte 64); return unboxed value in imm0.
+ * ported from ppc-spentry.s:6437-6462 (PPC64 branch).  A 2-digit bignum's
+ * combined 64-bit value (digits stored little-endian, direct 64-bit load,
+ * no PPC-style rotldi swap needed) must be nonneg; a 3-digit bignum's 3rd
+ * (most-significant) 32-bit digit must be exactly 0. */
+spentry getu64
+        and     imm1, arg_z, #tagmask
+        cmp     imm1, #tag_fixnum
+        b.ne    1f
+        asr     imm0, arg_z, #fixnumshift
+        cmp     arg_z, #0
+        b.ge    8f
+        b       9f
+1:      and     imm1, arg_z, #fulltagmask
+        cmp     imm1, #fulltag_misc
+        b.ne    9f
+        ldrb    w1, [arg_z, #misc_subtag_offset]  /* ldrb needs a W reg (imm1=x1) */
+        cmp     imm1, #subtag_bignum
+        b.ne    9f
+        ldr     imm1, [arg_z, #misc_header_offset]
+        ldr     imm0, [arg_z, #misc_data_offset]
+        cmp     imm1, #two_digit_bignum_header
+        b.eq    2f
+        cmp     imm1, #three_digit_bignum_header
+        b.ne    9f
+        ldr     w2, [arg_z, #(misc_data_offset + 8)]   /* 3rd digit must be 0 */
+        cbnz    w2, 9f
+        b       8f
+2:      cmp     imm0, #0
+        b.lt    9f
+8:      ret
+9:      /* ppc-spentry.s:6446 uuo_interr(error_object_not_u64,arg_z) -> the
+         * udf xtype trap (fmt 4; same xtype our own tree uses here). */
+        uuo_error_reg_not_xtype arg_z, xtype_u64
+endsp getu64
+
+/* arg_z should be (signed-byte 64); return unboxed value in imm0.
+ * ported from ppc-spentry.s:6502-6514 (PPC64 branch).  A 2-digit bignum's
+ * combined 64-bit value IS the signed result directly (any bit pattern is
+ * valid for signed-64, no extra range check needed, unlike getu64). */
+spentry gets64
+        and     imm1, arg_z, #tagmask
+        cmp     imm1, #tag_fixnum
+        asr     imm0, arg_z, #fixnumshift
+        b.eq    8f
+        and     imm2, arg_z, #fulltagmask
+        cmp     imm2, #fulltag_misc
+        b.ne    9f
+        ldrb    w2, [arg_z, #misc_subtag_offset]  /* ldrb needs a W reg (imm2=x2) */
+        cmp     imm2, #subtag_bignum
+        b.ne    9f
+        ldr     imm1, [arg_z, #misc_header_offset]
+        ldr     imm0, [arg_z, #misc_data_offset]
+        cmp     imm1, #two_digit_bignum_header
+        b.ne    9f
+8:      ret
+9:      /* ppc-spentry.s:6532 uuo_interr(error_object_not_s64,arg_z) */
+        uuo_error_reg_not_xtype arg_z, xtype_s64
+endsp gets64
+
+/* arg_z should be (signed-byte 32); return unboxed value in imm0.
+ * ported from ppc-spentry.s:6804-6813 (PPC64 branch), reimplemented per the
+ * function's stated contract ("return unboxed result in imm0") rather than
+ * transliterated literally: the vendored PPC64 branch's last step reads
+ * `box_fixnum(imm0,arg_z)`, which would leave imm0 BOXED, contradicting the
+ * subprim's own header comment and every other get* subprim's convention --
+ * almost certainly a `box_fixnum`/`unbox_fixnum` transcription slip in the
+ * vendored source (flag for a future PPC64-diff audit).  Implemented here as
+ * the evident intent: arg_z is (signed-byte 32) iff unboxing it round-trips
+ * through a 32-bit sign-extend. */
+spentry gets32
+        and     imm0, arg_z, #tagmask
+        asr     imm1, arg_z, #fixnumshift
+        cmp     imm0, #tag_fixnum
+        b.ne    9f
+        sxtw    imm2, w1
+        cmp     imm2, imm1
+        b.ne    9f
+        mov     imm0, imm1
+        ret
+9:      /* ppc-spentry.s:6827 uuo_interr(error_object_not_signed_byte_32,
+         * arg_z) */
+        uuo_error_reg_not_xtype arg_z, xtype_s32
+endsp gets32
+
+/* arg_z should be (unsigned-byte 32); return unboxed value in imm0.
+ * ported from ppc-spentry.s:6833-6857.  Reimplemented digit-wise (a plain
+ * 32-bit LDR zero-extends into the 64-bit register, giving exactly the
+ * unsigned digit magnitude with no sign ambiguity) rather than PPC64's
+ * paired 64-bit vrefr reads, which fold digit-pair endianness assumptions
+ * that don't apply on little-endian AArch64. one_digit_bignum_header is a
+ * PROPOSED constant above (ppc-constants32.s:388 -- 64-bit targets normally
+ * never need it since a lone 32-bit digit always fits a fixnum, but getu32
+ * itself is not #ifdef(PPC64)-split in the vendored source, so it defensively
+ * accepts one). */
+spentry getu32
+        and     imm1, arg_z, #tagmask
+        asr     imm0, arg_z, #fixnumshift
+        cmp     imm1, #tag_fixnum
+        b.ne    1f
+        cmp     imm0, #0
+        b.lt    9f
+        lsr     imm2, imm0, #32
+        cbnz    imm2, 9f
+        ret
+1:      and     imm1, arg_z, #fulltagmask
+        cmp     imm1, #fulltag_misc
+        b.ne    9f
+        ldrb    w1, [arg_z, #misc_subtag_offset]  /* ldrb needs a W reg (imm1=x1) */
+        cmp     imm1, #subtag_bignum
+        b.ne    9f
+        ldr     imm1, [arg_z, #misc_header_offset]
+        ldr     w0, [arg_z, #misc_data_offset]        /* digit0, zero-extended */
+        cmp     imm1, #one_digit_bignum_header
+        b.eq    8f
+        cmp     imm1, #two_digit_bignum_header
+        b.ne    9f
+        ldr     w2, [arg_z, #(misc_data_offset + 4)]  /* digit1 must be 0 */
+        cbnz    w2, 9f
+8:      ret
+9:      /* ppc-spentry.s:6857 uuo_interr(error_object_not_unsigned_byte_32,
+         * arg_z) */
+        uuo_error_reg_not_xtype arg_z, xtype_u32
+endsp getu32
+
+/* On entry arg_z = symbol.  On exit arg_z = value (possibly unbound_marker),
+ * arg_y = symbol, imm3 = symbol.binding_index.
+ * ported from ppc-spentry.s:6697-6708 (direct, unmodified logic port --
+ * symbol.binding_index stores an already byte-scaled offset into the TCR's
+ * thread-local binding area, indexed here with a raw non-scaled add, exactly
+ * as PPC64's ldrx/cmpr do). */
+spentry specref
+        ldr     imm3, [arg_z, #symbol.binding_index]
+        ldr     imm0, [rcontext, #tcr.tlb_limit]
+        cmp     imm3, imm0
+        ldr     imm2, [rcontext, #tcr.tlb_pointer]
+        mov     arg_y, arg_z
+        b.ge    1f
+        ldr     arg_z, [imm2, imm3]
+        cmp     arg_z, #no_thread_local_binding_marker
+        b.ne    9f
+1:      ldr     arg_z, [arg_y, #symbol.vcell]
+9:      ret
+endsp specref
+
+/* As specref, but traps if the resulting value is unbound_marker.
+ * ported from ppc-spentry.s:6711-6723. */
+spentry specrefcheck
+        ldr     imm3, [arg_z, #symbol.binding_index]
+        ldr     imm0, [rcontext, #tcr.tlb_limit]
+        cmp     imm3, imm0
+        ldr     imm2, [rcontext, #tcr.tlb_pointer]
+        mov     arg_y, arg_z
+        b.ge    1f
+        ldr     arg_z, [imm2, imm3]
+        cmp     arg_z, #no_thread_local_binding_marker
+        b.ne    2f
+1:      ldr     arg_z, [arg_y, #symbol.vcell]
+2:      cmp     arg_z, #unbound_marker
+        b.ne    9f
+        /* ppc-spentry.s:6722 treqi(arg_z,unbound_marker): the equality is
+         * already established by the b.ne above, so trap unconditionally.
+         * The uuo register operand is the SYMBOL (handler contract,
+         * arm64-exceptions.c uuo_unary_unbound: gpr = symbol) — here the
+         * symbol is in arg_y; arg_z holds the loaded unbound_marker.
+         * (spentry-C's binding path passes arg_z because THERE the value
+         * went to temp0 and arg_z still holds the symbol.) */
+        uuo_error_unbound arg_y         /* macro fixed upstream @ c9e7ffb */
+9:      ret
+endsp specrefcheck
+
+/* arg_z is a fixnum or bignum.  Returns (in imm0): arg_z unchanged if a
+ * fixnum; else +1/-1 per the sign of the bignum's most-significant 32-bit
+ * digit (this is an internal digit-sign probe, not CL SIGNUM).
+ * ported from ppc-spentry.s:3882-3904. */
+spentry integer_sign
+        and     imm1, arg_z, #fulltagmask
+        and     imm0, arg_z, #tagmask
+        cmp     imm1, #fulltag_misc
+        b.ne    1f
+        ldrb    w0, [arg_z, #misc_subtag_offset]  /* ldrb needs a W reg (imm0=x0) */
+1:      cmp     imm0, #tag_fixnum
+        b.ne    2f
+        mov     imm0, arg_z
+        ret
+2:      cmp     imm0, #subtag_bignum
+        b.eq    3f
+        /* ppc-spentry.s:3904 uuo_interr(error_object_not_integer,arg_z) */
+        uuo_error_reg_not_xtype arg_z, xtype_integer
+3:      ldr     imm0, [arg_z, #misc_header_offset]
+        lsr     imm0, imm0, #num_subtag_bits      /* raw bigit (32-bit digit) count */
+        lsl     imm0, imm0, #2                     /* * bigit_size(4) -> byte offset past last bigit */
+        add     imm0, imm0, #(misc_data_offset - 4)
+        ldr     w1, [arg_z, imm0]                  /* w1 = last (most-significant) 32-bit bigit */
+        cmp     w1, #0
+        mov     imm0, #1
+        b.ge    9f
+        mov     imm0, #-1
+9:      ret
+endsp integer_sign
+
+/* No inline fixnum fast path -- division always dispatches to the Lisp
+ * builtin.  ported from ppc-spentry.s:5578-5579: jump_builtin(_builtin_div,2)
+ * expands to ref_nrs_value(fname,builtin_functions); set_nargs(2);
+ * vrefr(fname,fname,_builtin_div); jump_fname().  Same expansion as
+ * spentry-D-call-builtins.s's jump_builtin macro (D:122-130). */
+spentry builtin_div
+        ref_nrs_value fname, builtin_functions  /* ppc-spentry.s:38 */
+        mov     nargs, #(2 << fixnumshift)      /* ppc-spentry.s:39 set_nargs(2) */
+        ldr     fname, [fname, #(misc_data_offset + _builtin_div * node_size)] /* ppc:40 vrefr */
+        ldr     nfn, [fname, #symbol.fcell]     /* ppc:41 jump_fname            */
+        ldr     temp0, [nfn, #_function.codevector]
+        br      temp0
+endsp builtin_div
+
+/* Allocate a "fulltag_misc" object.  arg_y = element count (boxed fixnum,
+ * unsigned), arg_z = subtag (boxed fixnum whose raw value is the subtag
+ * byte).  On exit arg_z = the tagged object (header set, contents zero);
+ * imm0 = the header word used.
+ * ported from ppc-spentry.s:3438-3480 (PPC64 branch).  Matt's ARM64 shares
+ * PPC64's fixnumshift=3 == log2(node_size=8) identity, so "arg_y tagged"
+ * already equals raw_count*node_size for the node/64-bit-per-element
+ * classes with no extra shift needed -- the same trick PPC64 exploits.
+ * AArch64's single NZCV flags register (vs. POWER's several parallel CR
+ * fields) means the parallel cr1..cr5 compares are serialized below into an
+ * if/elif cascade; the VALUES/arithmetic are unchanged. */
+spentry misc_alloc
+        /* GC SAFETY: imm scratch, not temp0 (see makeu128 note). */
+        lsr     imm4, arg_y, #59                  /* bounds: raw count fits unsigned-byte-56 */
+        cbnz    imm4, 9f
+        asr     imm0, arg_z, #fixnumshift          /* imm0 = raw subtag byte */
+        lsl     imm2, arg_y, #(num_subtag_bits - fixnumshift)
+        orr     imm0, imm2, imm0                   /* imm0 = header word */
+        and     imm2, imm0, #fulltagmask
+        and     imm3, imm0, #subtagmask            /* imm3 = subtag byte (count bits live at 8+, so compare the MASKED subtag, matching PPC's cmp on the boxed arg_z) */
+        mov     imm1, arg_y
+        cmp     imm2, #fulltag_nodeheader_0
+        b.eq    1f
+        cmp     imm2, #fulltag_nodeheader_1
+        b.eq    1f
+        cmp     imm2, #ivector_class_64_bit
+        b.eq    1f
+        cmp     imm3, #subtag_complex_double_float_vector
+        b.eq    3f
+        lsr     imm1, imm1, #1
+        cmp     imm2, #ivector_class_32_bit
+        b.eq    1f
+        cmp     imm3, #subtag_bit_vector
+        b.eq    2f
+        lsr     imm1, imm1, #1
+        /* Matt's scheme has no ivector_class_8_bit (only 64/32/other,
+         * arm64-constants.h:112-114); within class other_bit the 8-bit
+         * subtags are s8/u8 >= subtag_s8_vector, below that s16/u16
+         * (x86-spentry64.s:2977-2981 misc_alloc, the same tag scheme). */
+        cmp     imm3, #subtag_s8_vector
+        b.lt    1f                                 /* 16-bit: n*2 stands */
+        lsr     imm1, imm1, #1                     /* 8-bit: n*1 */
+1:      add     imm1, imm1, #(node_size + dnode_size - 1)   /* dnode_align(imm1,imm1,node_size) */
+        and     imm1, imm1, #0xfffffffffffffff0
+        Misc_Alloc arg_z, imm0, imm1
+        ret
+2:      add     imm1, arg_y, #(7 << fixnumshift)
+        lsr     imm1, imm1, #(3 + fixnumshift)
+        b       1b
+3:      add     imm1, arg_y, arg_y
+        b       1b
+9:      /* ppc-spentry.s:3477-3480: li arg_x,XARRLIMIT; set_nargs(3);
+         * b _SPksignalerr (real subprim: spentry-D-call-builtins.s:488). */
+        mov     arg_x, #XARRLIMIT               /* ppc:3478 li arg_x,XARRLIMIT  */
+        mov     nargs, #(3 << fixnumshift)      /* ppc:3479 set_nargs(3)        */
+        b       _SPksignalerr                   /* ppc:3480                     */
+endsp misc_alloc
+
+/* Allocate a uvector on the tstack (push a tsp frame and heap-cons the
+ * object via misc_alloc if there's no room).  Same (arg_y=count,
+ * arg_z=subtag) convention and byte-count arithmetic as misc_alloc above.
+ * ported from ppc-spentry.s:1025-1069 (PPC64 branch): dnode_align + a
+ * tstack_alloc_limit check, then TSP_Alloc_Var_Boxed_nz (real tsp=x24
+ * register, PPC discipline) with heap-cons fallback via TSP_Alloc_Fixed_
+ * Unboxed(0) + tail to misc_alloc. */
+spentry stack_misc_alloc
+        asr     imm0, arg_z, #fixnumshift
+        lsl     imm2, arg_y, #(num_subtag_bits - fixnumshift)
+        orr     imm0, imm2, imm0
+        and     imm2, imm0, #fulltagmask
+        and     imm3, imm0, #subtagmask            /* masked subtag byte (see misc_alloc note) */
+        mov     imm1, arg_y
+        cmp     imm2, #fulltag_nodeheader_0
+        b.eq    1f
+        cmp     imm2, #fulltag_nodeheader_1
+        b.eq    1f
+        cmp     imm2, #ivector_class_64_bit
+        b.eq    1f
+        cmp     imm3, #subtag_complex_double_float_vector
+        b.eq    6f
+        lsr     imm1, imm1, #1
+        cmp     imm2, #ivector_class_32_bit
+        b.eq    1f
+        cmp     imm3, #subtag_bit_vector
+        b.eq    5f
+        lsr     imm1, imm1, #1
+        cmp     imm3, #subtag_s8_vector            /* no 8_bit class: 8-bit subtags are >= s8 within class other (see misc_alloc note) */
+        b.lt    1f
+        lsr     imm1, imm1, #1
+1:      /* imm1 = byte count; dnode_align(imm1,imm1,tsp_frame.fixed_overhead
+         * +node_size) -- the total tsp allocation (frame header + object
+         * header + data), ppc-spentry.s:1058. */
+        add     imm1, imm1, #(tsp_frame.fixed_overhead + node_size + (dnode_size - 1))
+        and     imm1, imm1, #0xfffffffffffffff0
+        mov     imm3, #tstack_alloc_limit
+        cmp     imm1, imm3
+        b.ge    9f
+        /* TSP_Alloc_Var_Boxed_nz(imm1): push a new tsp frame of size imm1,
+         * zero its data area, mark it boxed (type=0).  "_nz": imm1 always
+         * includes the fixed frame overhead, so the frame can never be
+         * empty -- ppc-macros.s:695-704,721-725. */
+        mov     temp4, tsp                        /* old tsp -> backlink */
+        sub     tsp, tsp, imm1
+        str     temp4, [tsp, #tsp_frame.backlink]
+        mov     temp0, tsp
+        add     temp1, tsp, imm1
+        sub     temp1, temp1, #8
+7:      str     xzr, [temp0, #8]!
+        cmp     temp0, temp1
+        b.ne    7b
+        str     xzr, [tsp, #tsp_frame.type]
+        str     imm0, [tsp, #tsp_frame.data_offset]
+        add     arg_z, tsp, #(tsp_frame.data_offset + fulltag_misc)
+        ret
+5:      /* bit-vector: byte_count = (arg_y + 7<<fixnumshift) >> (3+fixnumshift) */
+        add     imm1, arg_y, #(7 << fixnumshift)
+        lsr     imm1, imm1, #(3 + fixnumshift)
+        b       1b
+6:      /* complex-double-float-vector: byte_count = arg_y + arg_y */
+        add     imm1, arg_y, arg_y
+        b       1b
+9:      /* Too large for the tstack: push one empty UNBOXED tsp frame
+         * (TSP_Alloc_Fixed_Unboxed(0), ppc-spentry.s:1068 -- type=self,
+         * nonzero, so GC skips it) so the compiler's balancing discard-
+         * temp-frame still has a frame to pop, then heap-cons via
+         * misc_alloc instead; arg_y/arg_z are unchanged, matching
+         * misc_alloc's own (count, subtag) calling convention. */
+        mov     temp4, tsp
+        sub     tsp, tsp, #tsp_frame.data_offset
+        str     temp4, [tsp, #tsp_frame.backlink]
+        str     tsp,   [tsp, #tsp_frame.type]
+        b       _SPmisc_alloc
+endsp stack_misc_alloc
+
+/* arg_z = size in bytes (boxed fixnum).  Allocate a macptr-tagged block of
+ * that size on the tstack (or heap-cons a gcable macptr via %new-gcable-ptr
+ * if it won't fit).
+ * ported from ppc-spentry.s:3297-3321.  macptr.address/domain/type offsets
+ * come from arm64-constants.h's already-real _structf macptr; macptr_header
+ * is a PROPOSED constant above. */
+spentry makestackblock
+        asr     imm0, arg_z, #fixnumshift
+        add     imm0, imm0, #(tsp_frame.fixed_overhead + macptr.size + (dnode_size - 1))
+        and     imm0, imm0, #0xfffffffffffffff0
+        mov     imm1, #tstack_alloc_limit
+        cmp     imm0, imm1
+        b.ge    1f
+        /* TSP_Alloc_Var_Unboxed(imm0): push a new tsp frame, leave it
+         * "raw"/unboxed (type=self, nonzero) -- ppc-macros.s:708-712. */
+        mov     temp4, tsp
+        sub     tsp, tsp, imm0
+        str     temp4, [tsp, #tsp_frame.backlink]
+        str     tsp,   [tsp, #tsp_frame.type]
+        mov     imm0, #macptr_header
+        add     imm1, tsp, #(tsp_frame.data_offset + macptr.size)
+        str     imm0, [tsp, #tsp_frame.data_offset]
+        add     arg_z, tsp, #(tsp_frame.data_offset + fulltag_misc)
+        str     imm1, [arg_z, #macptr.address]
+        str     xzr,  [arg_z, #macptr.domain]
+        str     xzr,  [arg_z, #macptr.type]
+        ret
+1:      /* Too big: push one empty unboxed tsp frame, then heap-cons via
+         * %new-gcable-ptr (ppc-spentry.s:3317-3321). */
+        mov     temp4, tsp
+        sub     tsp, tsp, #tsp_frame.data_offset
+        str     temp4, [tsp, #tsp_frame.backlink]
+        str     tsp,   [tsp, #tsp_frame.type]
+        mov     nargs, #(1 << fixnumshift)      /* ppc:3319 set_nargs(1)          */
+        ref_nrs_symbol fname, new_gcable_ptr    /* ppc:3320 li fname,nrs.new_gcable_ptr */
+        ldr     nfn, [fname, #symbol.fcell]     /* ppc:3321 jump_fname()          */
+        ldr     temp0, [nfn, #_function.codevector]
+        br      temp0
+endsp makestackblock
+
+/* arg_y = length (boxed fixnum), arg_z = initial-element (boxed).  Return a
+ * fresh list of that length on the tstack, cell by cell (or heap-cons via
+ * Cons if it won't fit).  Fully real -- no missing constants/ABI needed.
+ * ported from ppc-spentry.s:3351-3388.  rnil used directly for Matt's ARM64
+ * dedicated nil register in place of PPC64's `li reg,nil_value` absolute
+ * load. */
+spentry makestacklist
+        add     imm0, arg_y, arg_y
+        mov     imm3, #((tstack_alloc_limit + 1) - cons.size)
+        cmp     imm0, imm3
+        add     imm0, imm0, #tsp_frame.fixed_overhead
+        b.ge    3f
+        /* TSP_Alloc_Var_Boxed(imm0): push frame, zero its data area (may be
+         * empty when arg_y=0, hence the leading compare instead of the "_nz"
+         * do-while form), mark boxed -- ppc-macros.s:681-692,714-718. */
+        mov     temp4, tsp
+        sub     tsp, tsp, imm0
+        str     temp4, [tsp, #tsp_frame.backlink]
+        mov     temp0, tsp
+        add     temp1, tsp, imm0
+        sub     temp1, temp1, #8
+1:      cmp     temp0, temp1
+        b.eq    2f
+        str     xzr, [temp0, #8]!
+        b       1b
+2:      str     xzr, [tsp, #tsp_frame.type]
+        mov     imm1, arg_y                       /* count */
+        cmp     imm1, #0
+        mov     arg_y, arg_z                       /* initial value */
+        mov     arg_z, rnil                         /* result so far */
+        ldr     imm2, [tsp, #tsp_frame.backlink]
+        sub     imm2, imm2, #(tsp_frame.fixed_overhead - fulltag_cons)
+        b       10f
+4:      sub     imm1, imm1, #(1 << fixnumshift)
+        cmp     imm1, #0
+        str     arg_z, [imm2, #cons.cdr]
+        str     arg_y, [imm2, #cons.car]
+        mov     arg_z, imm2
+        sub     imm2, imm2, #cons.size
+10:     b.ne    4b
+        ret
+3:      /* Too big for the tstack: push one empty BOXED (zeroed) tsp frame
+         * (TSP_Alloc_Fixed_Boxed(0), ppc-spentry.s:3377), then heap-cons
+         * cell by cell via Cons. */
+        mov     temp4, tsp
+        sub     tsp, tsp, #tsp_frame.data_offset
+        str     temp4, [tsp, #tsp_frame.backlink]
+        str     xzr,   [tsp, #tsp_frame.type]
+        mov     imm1, arg_y
+        mov     arg_y, arg_z
+        mov     arg_z, rnil
+        /* Loop test POST-Cons: Matt's Cons macro does `cmp allocptr,
+         * allocbase` and CLOBBERS NZCV (the spentry-D:404 class; the
+         * pre-Cons cmp here span an infinite loop, 16m5n).  Entry test
+         * added -- the old code fell into 11f on the stale size-check
+         * flags. */
+        cmp     imm1, #0
+        b       11f
+6:      Cons    arg_z, arg_y, arg_z
+        subs    imm1, imm1, #(1 << fixnumshift)
+11:     b.ne    6b
+        ret
+endsp makestacklist
+
+/* On entry: arg_x = element count, arg_y = subtag, arg_z = initial value
+ * (all boxed).  Allocate via misc_alloc, then tail-call %init-misc% to fill
+ * the contents with the initial value.
+ * ported from ppc-spentry.s:5231-5247.  lisp_frame is a plain native-SP call
+ * frame (PROPOSED-CONSTANTS above); AArch64 needs no PPC-style mflr/mtlr
+ * dance since x30 (lr) is directly readable/writable, so build/discard_
+ * lisp_frame collapse to a plain sub/str.../ldr.../add sp sequence. */
+spentry misc_alloc_init
+        /* 16m41 PARITY NOTE: this twin keeps PPC's temp0 park and is CORRECT,
+         * but only because _SPmisc_alloc preserves temp0 -- registers survive
+         * the allocation trap, and the initval is a node, so a GC there
+         * relocates it in place.  The TSTACK twin below could not keep it:
+         * _SPstack_misc_alloc uses temp0 as its frame-zeroing cursor.  If
+         * misc_alloc ever grows a temp0 use, this breaks the same way. */
+        sub     sp, sp, #lisp_frame.size
+        mov     temp4, #lisp_frame_marker
+        str     temp4, [sp, #lisp_frame.marker]
+        str     vsp,   [sp, #lisp_frame.savevsp]
+        str     fn,    [sp, #lisp_frame.savefn]
+        str     x30,   [sp, #lisp_frame.savelr]
+        mov     fn, xzr
+        mov     temp0, arg_z                       /* initval */
+        mov     arg_z, arg_y                        /* subtag */
+        mov     arg_y, arg_x                         /* element-count */
+        bl      _SPmisc_alloc
+        ldr     x30, [sp, #lisp_frame.savelr]
+        ldr     fn,  [sp, #lisp_frame.savefn]
+        ldr     vsp, [sp, #lisp_frame.savevsp]
+        add     sp, sp, #lisp_frame.size
+        mov     arg_y, temp0                    /* ppc:5246 mr arg_y,temp0        */
+        mov     nargs, #(2 << fixnumshift)      /* ppc:5245 set_nargs(2)          */
+        ref_nrs_symbol fname, init_misc         /* ppc:5244 li fname,nrs.init_misc */
+        ldr     nfn, [fname, #symbol.fcell]     /* ppc:5247 jump_fname()          */
+        ldr     temp0, [nfn, #_function.codevector]
+        br      temp0
+endsp misc_alloc_init
+
+/* As misc_alloc_init above, but allocates on the tstack via
+ * stack_misc_alloc.  ported from ppc-spentry.s:5251-5267. */
+spentry stack_misc_alloc_init
+        /* 16m41 BUG FIX (regression stage 11, DYNAMIC-EXTENT.13/14): PPC parks
+         * the initval in temp0 across the alloc (ppc:5266 mr arg_y,temp0) and
+         * that does NOT port -- our _SPstack_misc_alloc uses temp0 as the
+         * ZEROING CURSOR for the new tsp frame (`mov temp0,tsp' / `str xzr,
+         * [temp0,#8]!'), so the initval came back as a raw tstack address and
+         * init_misc type-errored.  ARM64-DEVIATION: park it on the VSTACK
+         * instead, which no callee can clobber and which the GC scans as a node
+         * (unlike a register whose safety depends on the callee's clobber set --
+         * see the note on the heap twin above).  The push precedes savevsp so an
+         * unwind restores a vsp that still covers the parked word. */
+        str     arg_z, [vsp, #-node_size]!      /* park the initval */
+        sub     sp, sp, #lisp_frame.size
+        mov     temp4, #lisp_frame_marker
+        str     temp4, [sp, #lisp_frame.marker]
+        str     vsp,   [sp, #lisp_frame.savevsp]
+        str     fn,    [sp, #lisp_frame.savefn]
+        str     x30,   [sp, #lisp_frame.savelr]
+        mov     fn, xzr
+        mov     arg_z, arg_y                        /* subtag */
+        mov     arg_y, arg_x                         /* element-count */
+        bl      _SPstack_misc_alloc
+        ldr     x30, [sp, #lisp_frame.savelr]
+        ldr     fn,  [sp, #lisp_frame.savefn]
+        ldr     vsp, [sp, #lisp_frame.savevsp]
+        add     sp, sp, #lisp_frame.size
+        ldr     arg_y, [vsp], #node_size        /* initval back (ppc:5266 used temp0) */
+        mov     nargs, #(2 << fixnumshift)      /* ppc:5265 set_nargs(2)          */
+        ref_nrs_symbol fname, init_misc         /* ppc:5264 li fname,nrs.init_misc */
+        ldr     nfn, [fname, #symbol.fcell]     /* ppc:5267 jump_fname()          */
+        ldr     temp0, [nfn, #_function.codevector]
+        br      temp0
+endsp stack_misc_alloc_init
+
+/* As makestackblock above, but zero the block's contents.
+ * arg_z = size in bytes (boxed fixnum).  Allocate a zeroed macptr-tagged
+ * block on the tstack (or heap-cons a gcable macptr with clear-p=T).
+ * ported from ppc-spentry.s:3324-3348 (PPC64 branch).  Parity sibling of
+ * makestackblock (above, line 545); differences: (1) Zero_TSP_Frame after
+ * alloc, (2) only macptr.domain zeroed explicitly (not .type -- already zero
+ * from the frame-zero pass), (3) too-big path passes 2 args (size, t=clear). */
+spentry makestackblock0
+        asr     imm0, arg_z, #fixnumshift
+        add     imm0, imm0, #(tsp_frame.fixed_overhead + macptr.size + (dnode_size - 1))
+        and     imm0, imm0, #0xfffffffffffffff0
+        mov     imm1, #tstack_alloc_limit
+        cmp     imm0, imm1
+        b.ge    makestackblock0_too_big
+        /* TSP_Alloc_Var_Unboxed(imm0): push a new tsp frame, leave it
+         * "raw"/unboxed (type=self, nonzero) -- ppc-macros.s:708-712. */
+        mov     temp4, tsp
+        sub     tsp, tsp, imm0
+        str     temp4, [tsp, #tsp_frame.backlink]
+        str     tsp,   [tsp, #tsp_frame.type]
+        /* Zero_TSP_Frame(imm0, imm1): zero from tsp+data_offset through
+         * old_tsp-8 inclusive.  ppc-macros.s:681-692. */
+        add     imm0, tsp, #tsp_frame.data_offset
+        sub     imm1, temp4, #node_size
+        b       makestackblock0_zero_test
+makestackblock0_zero_loop:
+        str     xzr, [imm0], #node_size
+makestackblock0_zero_test:
+        cmp     imm0, imm1
+        b.ls    makestackblock0_zero_loop
+        /* Write macptr header + address (same as makestackblock) */
+        mov     imm0, #macptr_header
+        add     imm1, tsp, #(tsp_frame.data_offset + macptr.size)
+        str     imm0, [tsp, #tsp_frame.data_offset]
+        add     arg_z, tsp, #(tsp_frame.data_offset + fulltag_misc)
+        str     imm1, [arg_z, #macptr.address]
+        /* PPC64: stfd fp_zero,macptr.domain -- zeros domain only (type already
+         * zero from Zero_TSP_Frame pass above). */
+        str     xzr, [arg_z, #macptr.domain]
+        ret
+makestackblock0_too_big:
+        /* Too big: push one empty unboxed tsp frame, then heap-cons via
+         * %new-gcable-ptr with clear-p=T (ppc-spentry.s:3340-3347).
+         * Two args: arg_y=size, arg_z=t_value (clear-p). */
+        mov     temp4, tsp
+        sub     tsp, tsp, #tsp_frame.data_offset
+        str     temp4, [tsp, #tsp_frame.backlink]
+        str     tsp,   [tsp, #tsp_frame.type]
+        mov     arg_y, arg_z                    /* ppc:3343 mr arg_y,arg_z (save block size) */
+        add     arg_z, rnil, #t_offset          /* ppc:3344 li arg_z,t_value (clear-p = T)   */
+        mov     nargs, #(2 << fixnumshift)      /* ppc:3345 set_nargs(2)          */
+        ref_nrs_symbol fname, new_gcable_ptr    /* ppc:3346 li fname,nrs.new_gcable_ptr */
+        ldr     nfn, [fname, #symbol.fcell]     /* ppc:3347 jump_fname()          */
+        ldr     temp0, [nfn, #_function.codevector]
+        br      temp0
+endsp makestackblock0

--- a/lisp-kernel/spentry-B-vectors-misc.s
+++ b/lisp-kernel/spentry-B-vectors-misc.s
@@ -1,0 +1,1652 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "arm64-constants.h"
+#include "arm64-macros.s"
+#include "arm64-globals-proposed.s"
+
+/*
+ * Cluster B: vectors-misc subprims
+ * Ported from vendor/ccl/lisp-kernel/ppc-spentry.s (PPC64 branch)
+ *
+ * 22 subprims: gvset, set_hash_key, store_node_conditional,
+ * set_hash_key_conditional, conslist, conslist_star, stkconslist,
+ * stkconslist_star, mkstackv, progvsave, gvector, misc_ref,
+ * subtag_misc_ref, stkconsyz, stkgvector, subtag_misc_set, misc_set,
+ * progvrestore, aref2, aref3, aset2, aset3
+ */
+
+/* PORT-NOTE: All 22 subprims ported line-by-line from PPC64.
+   misc_ref (~150 lines) and misc_set (~180 lines) cover integer/node/string/bit
+   vectors, and since 16m37/16m41 ALSO the four float-vector subtags
+   (single/double) and the two complex ones -- the note here that they were
+   "omitted pending Misc_Alloc_Fixed and subtag constants" is stale; both exist
+   and both are used by those legs. aref2/3 and aset2/3 provide
+   2D/3D array indexing with displaced-array follow chains. File builds once
+   missing constants are defined (35 #error directives guard missing definitions). */
+
+/* Derived constants (same derivations as spentry-A/-C/-D):
+ * dnode_shift: ppc-constants64.s:37 (log2 dnode_size=16);
+ * bitmap_shift: ppc-constants64.s (log2 nbits_in_word=64);
+ * t_offset: Matt's arm64-arch.lisp:184-188 (T = NIL + t_offset). */
+.set dnode_shift, 4
+.set bitmap_shift, 6
+.set t_offset, ((0x13020 + fulltag_symbol) - (0x13000 + fulltag_nil))
+
+/* tsp_frame: ppc-constants64.s:228-233 {backlink@0, type@8}; fixed_overhead
+   and data_offset alias offset 16 (same equates as spentry-A:42-46).
+   dnode_size itself is already real in Matt's arm64-constants.h. */
+.set tsp_frame.backlink, 0
+.set tsp_frame.type, 8
+.set tsp_frame.fixed_overhead, 16
+.set tsp_frame.data_offset, 16
+.set tsp_frame.size, 16
+
+/* Lisp error selectors: errors.s deferr(NAME,N) = boxed fixnum N. */
+.set XBADVEC,    (2<<fixnumshift)       /* errors.s:177 */
+.set XSETBADVEC, (7<<fixnumshift)       /* errors.s:182 */
+.set XNOTELT,    (174<<fixnumshift)     /* errors.s:227 */
+.set XIMPROPERLIST, (170<<fixnumshift)  /* errors.s:223 */
+.set tstack_alloc_limit, 0xffff         /* ppc-constants.s:171 (as spentry-A) */
+
+/* symbol.binding_index: slot 7 via the dedicated symbol fulltag
+   (ppc-constants64.s:237-245 order; arm64 bias = -fulltag_symbol). */
+.set symbol.binding_index, (7*node_size - fulltag_symbol)
+
+/* misc_complex_dfloat_offset (16m48) — Matt's arm64-arch.lisp:259-261:
+     ;;; There is a pad word after the uvector header so that the
+     ;;; complex-double-float elements are 16-byte aligned.
+     (defconstant misc-complex-dfloat-offset (+ misc-data-offset node-size))
+   Element 0 of a complex-double-float VECTOR starts one word past the normal
+   data offset, exactly as on x86-64 (x8664-arch.lisp:442).  The lisp side
+   already relies on it -- l0-array.lisp's %uvector-replace biases its
+   %copy-ivector-to-ivector offsets by (- misc-complex-dfloat-offset
+   misc-data-offset), and %init-misc's cdf leg starts at
+   complex-double-float.realpart, which is the same 4 -- but misc_ref/misc_set
+   here used the unpadded misc_data_offset, so every bulk fill or copy landed
+   one double ahead of what an element read saw.  That is MAKE-SEQUENCE.30 and
+   SUBSEQ.SPECIALIZED-VECTOR.3.
+   Costs no space and no GC change: misc_alloc computes dnode_align(16n + 8) =
+   16n + 16 (spentry-A:479-481), i.e. a 16n+8-byte data area, and the GC's
+   suffix_dnodes = ((total+15)>>4)-1 is n for total = 8+16n and for 16+16n
+   alike, so the pad was already reserved and already walked. */
+.set misc_complex_dfloat_offset, (misc_data_offset + node_size)
+
+/* UUO scheme: Matt's own arm64-uuo.s @ 115b7aa (included above).  It
+   ALREADY defines xtype_array2d = 0x30 / xtype_array3d = 0x40 ("Keep
+   these in sync with the values in arm64-arch.lisp"), which is the
+   numbering *arm64-xtype-specifiers* (arm64-trap-support.lisp:215)
+   decodes; the expected-type field is 8 bits wide, so nothing here
+   needs compacting.  16m41: local .sets of 40/44 shadowed his values
+   and made a tripped aset2/aref2 trap report "(SIGNED-BYTE 64)"
+   (0x28 = his xtype_s64) with the ARRAY as datum. */
+
+/* Variable-sized BOXED tstack frame (ppc-macros.s:714-719
+   TSP_Alloc_Var_Boxed): link the old tsp, mark boxed (type=0), and ZERO
+   the data area so the GC never scans garbage.  \size = total bytes
+   including tsp_frame.fixed_overhead; clobbers both operands and NZCV. */
+.macro tsp_alloc_var_boxed size, tmp
+        mov \tmp, tsp
+        sub tsp, tsp, \size
+        str \tmp, [tsp, #tsp_frame.backlink]
+        str xzr, [tsp, #tsp_frame.type]
+        add \size, tsp, #tsp_frame.fixed_overhead
+        b 8886f
+8885:   str xzr, [\size], #node_size
+8886:   cmp \size, \tmp
+        b.ne 8885b
+.endm
+
+/* ===== gvset ===== */
+/* ported from ppc-spentry.s:568-608 (PPC64 branch) */
+        .globl C(egc_gvset)
+        .globl C(egc_gvset_did_store)
+spentry gvset
+C(egc_gvset):
+        cmp arg_z, arg_x
+        add imm0, arg_y, #misc_data_offset
+        str arg_z, [imm0, arg_x]
+C(egc_gvset_did_store):
+        b.le 9f
+        add imm0, imm0, arg_x
+        /* GC write barrier (ppc:575-608).  Shift constants are real; the
+           four GLOBALS need the ARM64 lisp_globals anchor - #error +
+           intended instruction until that idiom is ratified. */
+        ref_global imm2, ref_base       /* ppc:575 (idiom: arm64-globals-proposed.s) */
+        mov imm3, #0x8000000000000000 /* load_highbit */
+        ref_global imm1, oldspace_dnode_count   /* ppc:580 */
+        sub imm0, imm0, imm2
+        lsr imm0, imm0, #dnode_shift
+        cmp imm0, imm1
+        lsr imm2, imm0, #8              /* refidx granule = 256 dnodes     */
+        and imm4, imm0, #0x3f           /* extract_bit_shift_count         */
+        lsr imm0, imm0, #bitmap_shift
+        lsr imm3, imm3, imm4
+        ref_global temp0, refbits       /* ppc:585 */
+        b.hs 9f                         /* ppc cmplr = UNSIGNED bge        */
+        lsl imm0, imm0, #3 /* word_shift */
+        ldr imm1, [temp0, imm0]
+        tst imm1, imm3
+        b.ne 9f
+        add temp0, temp0, imm0          /* ldxr/stxr take [Xn] only        */
+1:      ldxr imm1, [temp0]
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp0]         /* status=temp5/x17: w2 aliases imm2,
+                                           which is STILL LIVE (granule) */
+        cbnz w17, 1b
+        dmb ish
+        and imm4, imm2, #0x3f /* extract_bit_shift_count */
+        lsr imm2, imm2, #bitmap_shift
+        mov imm3, #0x8000000000000000
+        ref_global temp0, ephemeral_refidx      /* ppc:600 */
+        lsl imm2, imm2, #3
+        lsr imm3, imm3, imm4
+        add temp0, temp0, imm2          /* ldxr/stxr take [Xn] only        */
+2:      ldxr imm1, [temp0]
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp0]
+        cbnz w17, 2b
+        dmb ish
+9:      ret
+endsp gvset
+
+/* ===== set_hash_key ===== */
+/* ported from ppc-spentry.s:615-683 (PPC64 branch) */
+        .globl C(egc_set_hash_key)
+        .globl C(egc_set_hash_key_did_store)
+spentry set_hash_key
+C(egc_set_hash_key):
+        cmp arg_z, arg_x
+        add imm0, arg_y, #misc_data_offset
+        str arg_z, [imm0, arg_x]
+C(egc_set_hash_key_did_store):
+        b.le 9f
+        add imm0, imm0, arg_x           /* ppc:622 slot address            */
+        /* -- memoize the stored reference (ppc:623-654) -- */
+        ref_global imm2, ref_base       /* ppc:623                         */
+        mov imm3, #0x8000000000000000   /* ppc:624 load_highbit            */
+        ref_global imm1, oldspace_dnode_count   /* ppc:625                 */
+        sub imm0, imm0, imm2            /* ppc:626                         */
+        lsr imm0, imm0, #dnode_shift    /* ppc:627                         */
+        cmp imm0, imm1                  /* ppc:628 cmplr                   */
+        lsr imm2, imm0, #8              /* ppc:629 refidx granule          */
+        and imm4, imm0, #0x3f           /* ppc:630                         */
+        lsr imm0, imm0, #bitmap_shift   /* ppc:631                         */
+        lsr imm3, imm3, imm4            /* ppc:632                         */
+        ref_global temp0, refbits       /* ppc:633 (base kept for part 2)  */
+        ref_global temp1, ephemeral_refidx      /* ppc:634 (kept)          */
+        b.hs 9f                         /* ppc:635 bgelr (UNSIGNED)        */
+        lsl imm0, imm0, #3              /* ppc:636 word_shift              */
+        ldr imm1, [temp0, imm0]         /* ppc:637                         */
+        tst imm1, imm3                  /* ppc:638 and.                    */
+        b.ne 3f                         /* ppc:639 already memoized        */
+        add temp2, temp0, imm0          /* ldxr/stxr take [Xn] only        */
+1:      ldxr imm1, [temp2]              /* ppc:640 lrarx                   */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp2]         /* status=temp5/x17 (imm2 live)        */
+        cbnz w17, 1b
+        dmb ish                         /* ppc:644 isync                   */
+        mov imm3, #0x8000000000000000   /* ppc:645                         */
+        and imm4, imm2, #0x3f           /* ppc:646                         */
+        lsr imm2, imm2, #bitmap_shift   /* ppc:647                         */
+        lsr imm3, imm3, imm4            /* ppc:648                         */
+        lsl imm2, imm2, #3              /* ppc:649                         */
+        add temp2, temp1, imm2
+2:      ldxr imm1, [temp2]              /* ppc:650                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp2]
+        cbnz w17, 2b
+        dmb ish                         /* ppc:654                         */
+3:      /* -- memoize the hash VECTOR itself (ppc:656-683) -- */
+        ref_global imm1, ref_base       /* ppc:656                         */
+        sub imm0, arg_x, imm1           /* ppc:657                         */
+        lsr imm0, imm0, #dnode_shift    /* ppc:658                         */
+        lsr imm2, imm0, #8              /* ppc:659                         */
+        mov imm3, #0x8000000000000000   /* ppc:660                         */
+        and imm4, imm0, #0x3f           /* ppc:661                         */
+        lsr imm0, imm0, #bitmap_shift   /* ppc:662                         */
+        lsr imm3, imm3, imm4            /* ppc:663                         */
+        lsl imm0, imm0, #3              /* ppc:664                         */
+        ldr imm1, [temp0, imm0]         /* ppc:665 (refbits base kept)     */
+        tst imm1, imm3                  /* ppc:666                         */
+        b.ne 9f                         /* ppc:667 bnelr                   */
+        add temp2, temp0, imm0
+4:      ldxr imm1, [temp2]              /* ppc:668                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp2]
+        cbnz w17, 4b
+        dmb ish                         /* ppc:672                         */
+        mov imm3, #0x8000000000000000   /* ppc:673                         */
+        and imm4, imm2, #0x3f           /* ppc:674                         */
+        lsr imm2, imm2, #bitmap_shift   /* ppc:675                         */
+        lsr imm3, imm3, imm4            /* ppc:676                         */
+        lsl imm2, imm2, #3              /* ppc:677                         */
+        add temp2, temp1, imm2
+5:      ldxr imm1, [temp2]              /* ppc:678                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp2]
+        cbnz w17, 5b
+        dmb ish                         /* ppc:682                         */
+9:      ret                             /* ppc:683                         */
+endsp set_hash_key
+
+/* ===== store_node_conditional ===== */
+/* ported from ppc-spentry.s:705-748 (PPC64 branch) */
+        .globl C(egc_store_node_conditional)
+spentry store_node_conditional
+C(egc_store_node_conditional):
+        cmp arg_z, arg_x
+        ldr temp0, [vsp], #node_size          /* vpop(temp0) */
+        asr imm4, temp0, #fixnumshift         /* unbox_fixnum(imm4,temp0) */
+        add imm0, arg_x, imm4                 /* ldxr/stxr take [Xn] only */
+1:      ldxr temp1, [imm0]
+        cmp temp1, arg_y
+        b.ne 9f
+        stxr w17, arg_z, [imm0]               /* status=temp5/x17 (uniform)    */
+        .globl C(egc_store_node_conditional_test)
+C(egc_store_node_conditional_test):
+        cbnz w17, 1b
+        dmb ish
+        /* -- memoize the stored reference (ppc:718-748) -- */
+        ref_global imm2, ref_base       /* ppc:719 (imm0 = slot addr)      */
+        ref_global imm1, oldspace_dnode_count   /* ppc:720                 */
+        sub imm0, imm0, imm2            /* ppc:721                         */
+        mov imm3, #0x8000000000000000   /* ppc:722                         */
+        lsr imm0, imm0, #dnode_shift    /* ppc:723                         */
+        cmp imm0, imm1                  /* ppc:724 cmplr                   */
+        lsr imm2, imm0, #8              /* ppc:725                         */
+        and imm4, imm0, #0x3f           /* ppc:726                         */
+        lsr imm0, imm0, #bitmap_shift   /* ppc:727                         */
+        lsr imm3, imm3, imm4            /* ppc:728                         */
+        ref_global temp1, refbits       /* ppc:729                         */
+        b.hs 8f                         /* ppc:730 bge (UNSIGNED)          */
+        lsl imm0, imm0, #3              /* ppc:731                         */
+        add temp1, temp1, imm0
+2:      ldxr imm1, [temp1]              /* ppc:732                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp1]
+        cbnz w17, 2b
+        dmb ish                         /* ppc:736                         */
+        mov imm3, #0x8000000000000000   /* ppc:737                         */
+        and imm4, imm2, #0x3f           /* ppc:738                         */
+        lsr imm2, imm2, #bitmap_shift   /* ppc:739                         */
+        ref_global temp1, ephemeral_refidx      /* ppc:740                 */
+        lsr imm3, imm3, imm4            /* ppc:741                         */
+        lsl imm2, imm2, #3              /* ppc:742                         */
+        add temp1, temp1, imm2
+3:      ldxr imm1, [temp1]              /* ppc:743                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp1]
+        cbnz w17, 3b
+        dmb ish                         /* ppc:747                         */
+        /* NOTE: PPC puts C(egc_write_barrier_end) at the END of
+           set_hash_key_conditional (the runtime checks the whole family
+           as one PC range); moved there - MERGE-ORDER NOTE: when these
+           drafts land in Matt's arm64-spentry.s, the EGC family
+           (rplaca..set_hash_key_conditional) must stay contiguous. */
+8:      add arg_z, rnil, #t_offset            /* success => T              */
+        ret
+9:      clrex                                 /* PPC strcx-to-RESERVATION_
+                                                 DISCHARGE = discharge the
+                                                 reservation; AArch64 has a
+                                                 dedicated insn (our v2
+                                                 arm64-spentry.s uses it) */
+        mov arg_z, rnil                       /* failure => NIL            */
+        ret
+endsp store_node_conditional
+
+/* ===== set_hash_key_conditional ===== */
+/* ported from ppc-spentry.s:754-835 (PPC64 branch) */
+spentry set_hash_key_conditional
+        .globl C(egc_set_hash_key_conditional)
+C(egc_set_hash_key_conditional):
+        cmp arg_z, arg_x
+        ldr temp0, [vsp], #node_size
+        asr imm4, temp0, #fixnumshift
+        add imm0, arg_x, imm4                 /* ldxr/stxr take [Xn] only */
+1:      ldxr temp1, [imm0]
+        cmp temp1, arg_y
+        b.ne 9f
+        stxr w17, arg_z, [imm0]               /* status=temp5/x17 (uniform)    */
+        .globl C(egc_set_hash_key_conditional_test)
+C(egc_set_hash_key_conditional_test):
+        cbnz w17, 1b
+        dmb ish
+        /* -- memoize the stored reference (ppc:768-797) -- */
+        ref_global imm2, ref_base       /* ppc:769 (imm0 = slot addr)      */
+        ref_global imm1, oldspace_dnode_count   /* ppc:770                 */
+        sub imm0, imm0, imm2            /* ppc:771                         */
+        mov imm3, #0x8000000000000000   /* ppc:772                         */
+        lsr imm0, imm0, #dnode_shift    /* ppc:773                         */
+        cmp imm0, imm1                  /* ppc:774 cmplr                   */
+        lsr imm2, imm0, #8              /* ppc:775                         */
+        and imm4, imm0, #0x3f           /* ppc:776                         */
+        lsr imm0, imm0, #bitmap_shift   /* ppc:777                         */
+        lsr imm3, imm3, imm4            /* ppc:778                         */
+        ref_global temp2, refbits       /* ppc:779                         */
+        ref_global temp1, ephemeral_refidx      /* ppc:780                 */
+        b.hs 8f                         /* ppc:781 bge (UNSIGNED)          */
+        lsl imm0, imm0, #3              /* ppc:782                         */
+        add temp0, temp2, imm0          /* [Xn] form (temp0 free)          */
+2:      ldxr imm1, [temp0]              /* ppc:783                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp0]
+        cbnz w17, 2b
+        dmb ish                         /* ppc:787                         */
+        mov imm3, #0x8000000000000000   /* ppc:788                         */
+        and imm4, imm2, #0x3f           /* ppc:789                         */
+        lsr imm2, imm2, #bitmap_shift   /* ppc:790                         */
+        lsr imm3, imm3, imm4            /* ppc:791                         */
+        lsl imm2, imm2, #3              /* ppc:792                         */
+        add temp0, temp1, imm2
+3:      ldxr imm1, [temp0]              /* ppc:793                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp0]
+        cbnz w17, 3b
+        dmb ish                         /* ppc:797                         */
+        /* -- memoize the hash VECTOR itself (ppc:799-828) -- */
+        ref_global temp1, refbits       /* ppc:800                         */
+        ref_global imm1, ref_base       /* ppc:801                         */
+        sub imm0, arg_x, imm1           /* ppc:802                         */
+        lsr imm0, imm0, #dnode_shift    /* ppc:803                         */
+        mov imm3, #0x8000000000000000   /* ppc:804                         */
+        lsr imm2, imm0, #8              /* ppc:805                         */
+        and imm4, imm0, #0x3f           /* ppc:806                         */
+        lsr imm0, imm0, #bitmap_shift   /* ppc:807                         */
+        lsr imm3, imm3, imm4            /* ppc:808                         */
+        lsl imm0, imm0, #3              /* ppc:809                         */
+        ldr imm1, [temp1, imm0]         /* ppc:810                         */
+        tst imm1, imm3                  /* ppc:811 and.                    */
+        b.ne 8f                         /* ppc:812                         */
+        add temp0, temp1, imm0
+4:      ldxr imm1, [temp0]              /* ppc:813                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp0]
+        cbnz w17, 4b
+        dmb ish                         /* ppc:817                         */
+        ref_global temp1, ephemeral_refidx      /* ppc:818                 */
+        mov imm3, #0x8000000000000000   /* ppc:819                         */
+        and imm4, imm2, #0x3f           /* ppc:820                         */
+        lsr imm2, imm2, #bitmap_shift   /* ppc:821                         */
+        lsr imm3, imm3, imm4            /* ppc:822                         */
+        lsl imm2, imm2, #3              /* ppc:823                         */
+        add temp0, temp1, imm2
+5:      ldxr imm1, [temp0]              /* ppc:824                         */
+        orr imm1, imm1, imm3
+        stxr w17, imm1, [temp0]
+        cbnz w17, 5b
+        dmb ish                         /* ppc:828                         */
+        .globl C(egc_write_barrier_end)
+C(egc_write_barrier_end):               /* ppc:829 (family END marker)     */
+8:      add arg_z, rnil, #t_offset            /* success => T              */
+        ret
+9:      clrex                                 /* PPC strcx-to-RESERVATION_
+                                                 DISCHARGE = discharge the
+                                                 reservation; AArch64 has a
+                                                 dedicated insn (our v2
+                                                 arm64-spentry.s uses it) */
+        mov arg_z, rnil                       /* failure => NIL            */
+        ret
+endsp set_hash_key_conditional
+
+/* ===== conslist ===== */
+/* ported from ppc-spentry.s:839-851 (PPC64 branch) */
+spentry conslist
+        mov arg_z, rnil                 /* li arg_z,nil_value -> rnil      */
+        cmp nargs, #0
+        b 2f
+        /* Loop test POST-Cons: Matt's Cons macro clobbers NZCV via its
+         * allocptr,allocbase compare (spentry-D:404 class) -- the old
+         * pre-Cons cmp made b.ne test the ALLOCATION flags = infinite
+         * loop (16m5n, first &key fn via keyword_bind). */
+1:      ldr temp0, [vsp]
+        add vsp, vsp, #node_size
+        Cons arg_z, temp0, arg_z
+        subs nargs, nargs, #(1<<fixnumshift)
+2:      b.ne 1b
+        ret
+endsp conslist
+
+/* ===== conslist_star ===== */
+/* ported from ppc-spentry.s:855-866 (PPC64 branch) */
+spentry conslist_star
+        cmp nargs, #0
+        b 2f
+        /* Same post-Cons loop-test discipline as conslist above. */
+1:      ldr temp0, [vsp]
+        add vsp, vsp, #node_size
+        Cons arg_z, temp0, arg_z
+        subs nargs, nargs, #(1<<fixnumshift)
+2:      b.ne 1b
+        ret
+endsp conslist_star
+
+/* ===== stkconslist ===== */
+/* ported from ppc-spentry.s:870-888 (PPC64 branch) */
+spentry stkconslist
+        mov arg_z, rnil                 /* ppc:871 li arg_z,nil_value (was
+                                           wrongly the TAG constant)       */
+        add imm1, nargs, nargs          /* ppc:873                         */
+        add imm1, imm1, #tsp_frame.fixed_overhead  /* ppc:874              */
+        tsp_alloc_var_boxed imm1, imm2  /* ppc:875 (links+marks+ZEROES;
+                                           PPC has no ts_area limit check
+                                           here - drafter confusion)       */
+        add imm1, tsp, #(tsp_frame.data_offset + fulltag_cons) /* ppc:876  */
+        cmp nargs, #0                   /* ppc:872 cmpri cr1 - recomputed
+                                           AFTER the alloc (macro clobbers
+                                           NZCV)                           */
+        b 2f
+1:      ldr temp0, [vsp]
+        cmp nargs, #(1<<fixnumshift)
+        add vsp, vsp, #node_size
+        /* _rplaca/_rplacd: PPC64 881-882 */
+        str temp0, [imm1, #cons.car]
+        str arg_z, [imm1, #cons.cdr]
+        mov arg_z, imm1
+        add imm1, imm1, #cons.size
+        sub nargs, nargs, #(1<<fixnumshift)
+2:      b.ne 1b
+        ret
+endsp stkconslist
+
+/* ===== stkconslist_star ===== */
+/* ported from ppc-spentry.s:892-909 (PPC64 branch) */
+spentry stkconslist_star
+        add imm1, nargs, nargs          /* ppc:894                         */
+        add imm1, imm1, #tsp_frame.fixed_overhead  /* ppc:895              */
+        tsp_alloc_var_boxed imm1, imm2  /* ppc:896                         */
+        add imm1, tsp, #(tsp_frame.data_offset + fulltag_cons) /* ppc:897  */
+        cmp nargs, #0                   /* ppc:893 cmpri cr1 (post-alloc)  */
+        b 2f
+1:      ldr temp0, [vsp]
+        cmp nargs, #(1<<fixnumshift)
+        add vsp, vsp, #node_size
+        str temp0, [imm1, #cons.car]
+        str arg_z, [imm1, #cons.cdr]
+        mov arg_z, imm1
+        add imm1, imm1, #cons.size
+        sub nargs, nargs, #(1<<fixnumshift)
+2:      b.ne 1b
+        ret
+endsp stkconslist_star
+
+/* ===== mkstackv ===== */
+/* ported from ppc-spentry.s:914-933 (PPC64 branch) */
+spentry mkstackv
+        cmp nargs, #0
+        /* dnode_align + TSP_Alloc_Var_Boxed_nz: PPC64 916-917 */
+        add imm1, nargs, #(dnode_size + node_size - 1)  /* dnode_size is real (arm64-constants.h:33) */
+        and imm1, imm1, #(~(dnode_size - 1))
+        add imm1, imm1, #tsp_frame.fixed_overhead
+        tsp_alloc_var_boxed imm1, imm2  /* ppc:917 TSP_Alloc_Var_Boxed_nz
+                                           (was a bare sub: no backlink/
+                                           type/zeroing - GC hazard)       */
+        lsl imm0, nargs, #(num_subtag_bits - fixnumshift)
+        mov temp0, #subtag_simple_vector    /* not a valid logical-imm:    */
+        orr imm0, imm0, temp0               /* materialize, then orr       */
+        str imm0, [tsp, #tsp_frame.data_offset]      /* store header (data_offset=16, was mis-guessed 8) */
+        add arg_z, tsp, #(tsp_frame.data_offset + fulltag_misc)
+        cmp nargs, #0                   /* ppc:915 cr0 (post-alloc)        */
+        b.eq 2f
+        add imm0, arg_z, #misc_data_offset
+        add imm1, imm0, nargs
+1:      sub nargs, nargs, #node_size
+        cmp nargs, #0
+        ldr temp1, [vsp]
+        add vsp, vsp, #node_size
+        str temp1, [imm1, #-node_size]!
+        b.ne 1b
+2:      ret
+endsp mkstackv
+
+/* ===== progvsave ===== */
+/* ported from ppc-spentry.s:949-1019 (PPC64 branch) - ~70 lines */
+spentry progvsave
+        /* Error unless arg_z is a proper list (Floyd; ppc:953-969).  All
+           nil tests compare against rnil (the VALUE - the old #fulltag_nil
+           comparands were the TAG, never equal to a pointer).
+           ARM64-DEVIATION: PPC's trap_unless_list passes nil (nil is
+           list-tagged there); nil has its OWN fulltag here, so the
+           nil check is hoisted BEFORE each cons-tag check.  BOTH of them
+           (16m48): the hoist was originally applied only to the temp2 =
+           cdr(fast) check, and fast lands exactly ON nil whenever the list
+           has EVEN length -- fast advances two conses per iteration and so
+           steps over the last cons of an even list.  A missing nil test at
+           the loop top therefore made every even-length values list report
+           XIMPROPERLIST, which is PROGV.8 and MISC.299/301/305/644.  PPC
+           needs no such test because cdr(nil) reads back as nil there. */
+        cmp arg_z, rnil                 /* ppc:953                         */
+        mov arg_x, arg_z                /* ppc:954 fast                    */
+        mov temp1, arg_z                /* ppc:955 slow                    */
+        b.eq 9f                         /* ppc:956 null list is proper     */
+0:      cmp arg_x, rnil                 /* fast ran off the end => proper  */
+        b.eq 9f                         /*   (ppc: trap_unless_list(nil) ok)*/
+        and imm0, arg_x, #fulltagmask   /* ppc:958 trap_unless_list(fast)  */
+        cmp imm0, #fulltag_cons
+        b.ne progvsave_improper
+        ldr temp2, [arg_x, #cons.cdr]   /* ppc:959 cdr(fast)               */
+        cmp temp2, rnil                 /* ppc:960 cmpri cr3               */
+        b.eq 9f                         /* ppc:963 (hoisted: see header)   */
+        and imm0, temp2, #fulltagmask   /* ppc:961 trap_unless_list        */
+        cmp imm0, #fulltag_cons
+        b.ne progvsave_improper
+        ldr arg_x, [temp2, #cons.cdr]   /* ppc:962 cdr(cdr(fast))          */
+        ldr temp1, [temp1, #cons.cdr]   /* ppc:964 cdr(slow)               */
+        cmp arg_x, temp1                /* ppc:965                         */
+        b.ne 0b                         /* ppc:966                         */
+progvsave_improper:                     /* circular or non-list            */
+        mov arg_y, #XIMPROPERLIST       /* ppc:967 (errors.s:223)          */
+        mov nargs, #(2<<fixnumshift)    /* ppc:968                         */
+        b _SPksignalerr                 /* ppc:969                         */
+9:      /* Length of arg_y (a proper list); imm0 = boxed count (ppc:974-980) */
+        mov imm0, #(-node_size)
+        mov arg_x, arg_y
+1:      cmp arg_x, rnil                 /* ppc:977                         */
+        add imm0, imm0, #node_size      /* ppc:978                         */
+        ldr arg_x, [arg_x, #cons.cdr]   /* ppc:979 (cdr of nil is read but
+                                           discarded - loop exits on Z)    */
+        b.ne 1b                         /* ppc:980                         */
+        cmp imm0, #0                    /* ppc:984                         */
+        add imm1, imm0, imm0            /* ppc:985                         */
+        add imm1, imm1, imm0            /* ppc:986 3*count*node_size       */
+        add imm1, imm1, #(dnode_size + node_size - 1)   /* ppc:987         */
+        and imm1, imm1, #(~(dnode_size - 1))            /* dnode_align     */
+        b.ne 2f                         /* ppc:988                         */
+        /* count 0: empty boxed frame (ppc:989 TSP_Alloc_Fixed_Boxed(16)) */
+        mov imm2, tsp
+        sub tsp, tsp, #(2*node_size + tsp_frame.fixed_overhead)
+        str imm2, [tsp, #tsp_frame.backlink]
+        str xzr, [tsp, #tsp_frame.type]                 /* boxed           */
+        str xzr, [tsp, #tsp_frame.data_offset]          /* count = 0       */
+        str xzr, [tsp, #(tsp_frame.data_offset + node_size)]
+        ret                             /* ppc:990                         */
+2:      add imm1, imm1, #tsp_frame.fixed_overhead       /* ppc:992         */
+        tsp_alloc_var_boxed imm1, imm2  /* ppc:993 (zeroes; clobbers NZCV) */
+        str imm0, [tsp, #tsp_frame.data_offset]         /* ppc:994 count   */
+        ldr imm2, [tsp, #tsp_frame.backlink]            /* ppc:995 cursor
+                                           = frame end (triplets push down)*/
+        mov arg_x, arg_y                /* ppc:996                         */
+        ldr imm1, [rcontext, #tcr.db_link]              /* ppc:997         */
+        ldr imm3, [rcontext, #tcr.tlb_limit]            /* ppc:998         */
+3:      /* Binding loop (ppc:999-1017).  PPC keeps cr1 (arg_z nil) live
+           from loop top; the trlle-trap cmp clobbers NZCV here, so the
+           arg_z test is recomputed just before its branch. */
+        ldr temp0, [arg_x, #cons.car]   /* ppc:1000 symbol                 */
+        ldur imm0, [temp0, #symbol.binding_index]       /* ppc:1001 (=49)  */
+        ldr arg_x, [arg_x, #cons.cdr]   /* ppc:1002                        */
+        cmp imm3, imm0                  /* ppc:1003 trlle(imm3,imm0):      */
+        b.hi 10f                        /*   trap if tlb_limit <= index    */
+        uuo_error_tlb_too_small imm0      /*   (same code as spentry-C:202)  */
+10:     ldr imm4, [rcontext, #tcr.tlb_pointer]  /* ppc:1004 reload post-trap */
+        ldr temp3, [imm4, imm0]         /* ppc:1005 old value              */
+        mov temp2, #unbound_marker      /* ppc:1007 (arm64-constants.h:169)*/
+        cmp arg_z, rnil                 /* ppc:999 cmpri cr1 (recomputed)  */
+        b.eq 4f                         /* ppc:1008 beq cr1                */
+        ldr temp2, [arg_z, #cons.car]   /* ppc:1009 new value              */
+        ldr arg_z, [arg_z, #cons.cdr]   /* ppc:1010                        */
+4:      /* triplet: (old-value, binding-index, db-link) pushed downward */
+        str temp3, [imm2, #-node_size]! /* ppc:1011                        */
+        str imm0, [imm2, #-node_size]!  /* ppc:1012                        */
+        str imm1, [imm2, #-node_size]!  /* ppc:1013                        */
+        str temp2, [imm4, imm0]         /* ppc:1014 install new value      */
+        mov imm1, imm2                  /* ppc:1015                        */
+        cmp arg_x, rnil                 /* ppc:1006 cmpri cr0 (recomputed) */
+        b.ne 3b                         /* ppc:1016                        */
+        str imm2, [rcontext, #tcr.db_link]              /* ppc:1017        */
+        ret                             /* ppc:1018                        */
+endsp progvsave
+
+/* ===== gvector ===== */
+/* ported from ppc-spentry.s:1125-1149 (PPC64 branch).  Caller vpushes the
+ * boxed subtype first, then the elements in order; nargs = byte-scaled
+ * (count+1)*node_size counting the subtype (boot-16m5: observed live call
+ * site vpush x4 + mov nargs,#0x20).  Result (fulltag_misc) in arg_z. */
+spentry gvector
+        sub nargs, nargs, #node_size
+        ldr arg_z, [vsp, nargs]               /* boxed subtype (deepest)  */
+        asr imm0, arg_z, #fixnumshift         /* unbox_fixnum(imm0,arg_z) */
+        lsl imm1, nargs, #(num_subtag_bits - fixnumshift)
+        orr imm0, imm0, imm1                  /* header = count<<8 | subtag */
+        add imm1, nargs, #(node_size + (dnode_size - 1))
+        and imm1, imm1, #~(dnode_size - 1)    /* dnode_align(nargs+node_size) */
+        Misc_Alloc arg_z, imm0, imm1
+        mov imm1, nargs
+        mov imm2, #misc_data_offset           /* negative; keep out of add-imm */
+        add imm2, imm1, imm2
+        b 2f
+1:      str temp0, [arg_z, imm2]
+2:      sub imm1, imm1, #node_size
+        cmp imm1, #0
+        sub imm2, imm2, #node_size
+        ldr temp0, [vsp], #node_size          /* vpop; fencepost pops subtype too */
+        b.ge 1b
+        ret
+endsp gvector
+
+/* ===== misc_ref ===== */
+/* ported from ppc-spentry.s:2405-3203 (PPC64 branch) - ~450 lines with dispatch + type handlers */
+spentry misc_ref
+        /* Validate fulltag misc and fixnum index */
+        and imm0, arg_y, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne misc_ref_invalid
+        and imm0, arg_z, #fixnummask
+        cbnz imm0, misc_ref_invalid
+        /* Bounds check */
+        ldr imm0, [arg_y, #misc_header_offset]
+        lsr imm1, imm0, #num_subtag_bits
+        lsl imm1, imm1, #fixnumshift
+        cmp arg_z, imm1
+        b.ge misc_ref_invalid
+        /* Extract subtag */
+        and imm1, imm0, #subtagmask
+misc_ref_common:
+        /* Compare-chain dispatch (subtag values from arm64-constants.h).
+           All node uvectors first: fulltag_nodeheader_0 (6) and _1 (0xe)
+           share low-3-bits #b110, and PPC64's jump table routes EVERY
+           real nodeheader subtag to the plain node read (ppc:2405ff) —
+           the per-subtag chain missed catch-frame/hash-vector/slot-vector/
+           lock/instance/istruct/… (boot-16m5b sibling sweep). */
+        and imm2, imm1, #7
+        cmp imm2, #6                    /* fulltag_nodeheader_{0,1} & 7 */
+        b.eq misc_ref_node
+        cmp imm1, #subtag_u8_vector
+        b.eq misc_ref_u8
+        cmp imm1, #subtag_s8_vector
+        b.eq misc_ref_s8
+        cmp imm1, #subtag_u16_vector
+        b.eq misc_ref_u16
+        cmp imm1, #subtag_s16_vector
+        b.eq misc_ref_s16
+        cmp imm1, #subtag_u32_vector
+        b.eq misc_ref_u32
+        cmp imm1, #subtag_s32_vector
+        b.eq misc_ref_s32
+        cmp imm1, #subtag_u64_vector
+        b.eq misc_ref_u64
+        cmp imm1, #subtag_s64_vector
+        b.eq misc_ref_s64
+        cmp imm1, #subtag_fixnum_vector
+        b.eq misc_ref_fixnum_vector
+        /* Float vectors (16m37).  These were absent from BOTH this chain and
+           misc_set_common's, so uvref/uvset on a single- or double-float
+           vector fell through to misc_ref_invalid.  PPC64 routes all four
+           float-vector subtags (ppc:2620/2641/2658/2616). */
+        cmp imm1, #subtag_single_float_vector
+        b.eq misc_ref_single_float_vector
+        cmp imm1, #subtag_double_float_vector
+        b.eq misc_ref_double_float_vector
+        /* COMPLEX float vectors (16m41): 16m37 added only the two real float
+           subtags, so :initial-contents on a (complex single-float) or
+           (complex double-float) array still fell through to
+           misc_ref_invalid -- regression stage 11, EVERY.32. */
+        cmp imm1, #subtag_complex_single_float_vector
+        b.eq misc_ref_complex_single_float_vector
+        cmp imm1, #subtag_complex_double_float_vector
+        b.eq misc_ref_complex_double_float_vector
+        cmp imm1, #subtag_simple_base_string
+        b.eq misc_ref_string
+        cmp imm1, #subtag_bit_vector
+        b.eq misc_ref_bit_vector
+        cmp imm1, #subtag_code_vector
+        b.eq misc_ref_u32
+        cmp imm1, #subtag_bignum
+        b.eq misc_ref_u32
+        /* PPC64 jump table (ppc:2454/2471): macptr + dead_macptr read as
+           raw 64-bit words; double-float/xcode-vector as 2×u32. */
+        cmp imm1, #subtag_macptr
+        b.eq misc_ref_u64
+        cmp imm1, #subtag_dead_macptr
+        b.eq misc_ref_u64
+        cmp imm1, #subtag_double_float
+        b.eq misc_ref_u32
+        cmp imm1, #subtag_xcode_vector
+        b.eq misc_ref_u32
+        b misc_ref_invalid
+misc_ref_node:
+        add imm0, arg_y, arg_z
+        ldr arg_z, [imm0, #misc_data_offset]
+        ret
+misc_ref_u8:
+        lsr imm0, arg_z, #fixnumshift
+        add imm2, arg_y, #misc_data_offset
+        ldrb w0, [imm2, imm0]
+        lsl arg_z, x0, #fixnumshift
+        ret
+misc_ref_s8:
+        lsr imm0, arg_z, #fixnumshift
+        add imm2, arg_y, #misc_data_offset
+        ldrsb x0, [imm2, imm0]
+        lsl arg_z, x0, #fixnumshift
+        ret
+misc_ref_u16:
+        lsr imm0, arg_z, #fixnumshift
+        lsl imm0, imm0, #1
+        add imm2, arg_y, #misc_data_offset
+        ldrh w0, [imm2, imm0]
+        lsl arg_z, x0, #fixnumshift
+        ret
+misc_ref_s16:
+        lsr imm0, arg_z, #fixnumshift
+        lsl imm0, imm0, #1
+        add imm2, arg_y, #misc_data_offset
+        ldrsh x0, [imm2, imm0]
+        lsl arg_z, x0, #fixnumshift
+        ret
+misc_ref_u32:
+        lsr imm0, arg_z, #fixnumshift
+        lsl imm0, imm0, #2
+        add imm2, arg_y, #misc_data_offset
+        ldr w0, [imm2, imm0]
+        lsl arg_z, x0, #fixnumshift
+        ret
+misc_ref_s32:
+        lsr imm0, arg_z, #fixnumshift
+        lsl imm0, imm0, #2
+        add imm2, arg_y, #misc_data_offset
+        ldrsw x0, [imm2, imm0]
+        lsl arg_z, x0, #fixnumshift
+        ret
+misc_ref_u64:
+        add imm0, arg_y, arg_z
+        ldr imm0, [imm0, #misc_data_offset]
+        b _SPmakeu64
+misc_ref_s64:
+        add imm0, arg_y, arg_z
+        ldr imm0, [imm0, #misc_data_offset]
+        b _SPmakes64
+misc_ref_fixnum_vector:
+        add imm0, arg_y, arg_z
+        ldr imm0, [imm0, #misc_data_offset]
+        lsl arg_z, imm0, #fixnumshift
+        ret
+misc_ref_string:
+        /* 32-bit chars (see misc_set_string); PPC64 misc_ref_new_string. */
+        lsr imm0, arg_z, #1             /* boxed idx -> idx*4              */
+        add imm2, arg_y, #misc_data_offset
+        ldr w0, [imm2, imm0]
+        lsl imm0, x0, #charcode_shift
+        orr arg_z, imm0, #subtag_character
+        ret
+misc_ref_bit_vector:
+        /* ARM64 LSB0 bit order */
+        lsr imm0, arg_z, #fixnumshift
+        lsr imm2, imm0, #5
+        lsl imm2, imm2, #2
+        add imm2, arg_y, imm2
+        ldr w3, [imm2, #misc_data_offset]
+        and imm1, imm0, #31
+        lsr w3, w3, w1
+        and w3, w3, #1
+        lsl arg_z, x3, #fixnumshift
+        ret
+misc_ref_single_float_vector:
+        /* ppc:2757-2762.  32-bit elements, so the same index math as
+           misc_ref_u32: boxed idx >> fixnumshift, then << 2. */
+        lsr imm0, arg_z, #fixnumshift
+        lsl imm0, imm0, #2
+        add imm2, arg_y, #misc_data_offset
+        ldr w0, [imm2, imm0]
+        /* ppc:2761-2762 (rldicr 32,31 + ori).  Single-floats are IMMEDIATE on
+           arm64, the raw IEEE bits riding the high 32 with the tag in the low
+           byte.  NB the tag spelling: arm64-arch.lisp:83 defines
+           subtag-single-float AS fulltag-single-float, but that alias is
+           Lisp-side only -- arm64-constants.h defines fulltag_single_float and
+           has no subtag_ name, so #subtag_single_float does not assemble. */
+        lsl arg_z, x0, #32
+        orr arg_z, arg_z, #fulltag_single_float
+        ret
+misc_ref_double_float_vector:
+        /* ppc:2700-2705.  64-bit elements: fixnumshift == word_shift == 3, so
+           the boxed index IS the byte offset, exactly as in misc_ref_u64. */
+        add imm0, arg_y, arg_z
+        ldr imm0, [imm0, #misc_data_offset]
+        /* Unlike PPC, arm64-constants.h defines no double_float_header, so
+           build it here -- but the count is a LITERAL 2, not
+           double_float.element_count.  _endstructf derives element_count as
+           (size - header) / NODE_SIZE, and a header count is in the units of
+           the object's IVECTOR CLASS: double_float is ivector_class_32_bit
+           with an 8-byte payload, so the count is 2 thirty-two-bit elements
+           and the node-derived value is 1.  Both 64-bit reference ports
+           hardcode the literal for exactly this reason
+           (ppc-constants64.s:362, x86-constants64.s:691
+           def_header(double_float_header,2,...)); only the 32-bit ports
+           derive it, where node_size == the element size.  Deriving it here
+           made every kernel-boxed double claim one element, so (uvref d 1)
+           was out of bounds: DOUBLE-FLOAT-BITS -- on every float print path
+           -- signalled $XARROOB, and EQL against a Lisp-boxed double was
+           false because the two headers disagreed (16m45).
+           imm0 must survive Misc_Alloc_Fixed (including a uuo_alloc trip
+           through the allocator) -- PPC relies on exactly that, ppc:2701-2704. */
+        mov imm1, #((2 << num_subtag_bits) | subtag_double_float)
+        Misc_Alloc_Fixed arg_z, imm1, double_float.size
+        str imm0, [arg_z, #double_float.value]
+        ret
+misc_ref_complex_single_float_vector:
+        /* 16m41.  Vector element = 2 packed singles = 8 bytes, and the subtag
+           is in ivector_class_64_bit, so the boxed index IS the byte offset
+           (fixnumshift == 3), exactly as misc_ref_double_float_vector.  The
+           SCALAR complex_single_float is {realpart:4, imagpart:4}
+           (arm64-constants.h:344-347), i.e. the same 8-byte word, so one load
+           and one store carry both parts.
+           imm0 must survive Misc_Alloc_Fixed with the header in imm2 -- the
+           makeu128 precedent (spentry-A:167-176) depends on exactly that. */
+        add imm0, arg_y, arg_z
+        ldr imm0, [imm0, #misc_data_offset]
+        /* Literal 2, not complex_single_float.element_count: ivector_class_32_bit
+           over an 8-byte payload, so the count is 2 thirty-two-bit elements
+           where _endstructf's node-derived value is 1.  x8664 canon:
+           setup-complex-single-float-allocation, (make-vheader 2 ...),
+           x8664-vinsns:2527 -- and our own complex-single-float->heap vinsn
+           already uses the literal.  See the note at
+           misc_ref_double_float_vector. */
+        mov imm2, #((2 << num_subtag_bits) | subtag_complex_single_float)
+        Misc_Alloc_Fixed arg_z, imm2, complex_single_float.size
+        str imm0, [arg_z, #complex_single_float.realpart]
+        ret
+misc_ref_complex_double_float_vector:
+        /* 16m41.  Vector element = 2 doubles = 16 bytes; the subtag is in
+           ivector_class_other_bit, so compute the offset: 16i = boxed<<1.
+           16m48: the note here used to say "vector data starts right after
+           the header (no x8664-style pad)".  That is FALSE and it is the
+           MAKE-SEQUENCE.30 / SUBSEQ.SPECIALIZED-VECTOR.3 bug -- Matt's own
+           arm64-arch.lisp:259-261 declares the pad, and every LISP-side
+           writer already honours it.  See misc_complex_dfloat_offset above.
+           The SCALAR complex_double_float carries its own pad
+           (arm64-constants.h:349-353: {pad, realpart, imagpart}), so the
+           store side still uses .realpart. */
+        lsl imm3, arg_z, #1
+        add imm3, imm3, arg_y
+        add imm3, imm3, #misc_complex_dfloat_offset
+        ldp imm0, imm1, [imm3]
+        /* Literal 6, not complex_double_float.element_count: ivector_class_32_bit
+           over a 24-byte payload {pad, realpart, imagpart}, so 6 thirty-two-bit
+           elements where the node-derived value is 3.  Worse than the other two
+           here: an under-count of 3 makes the GC size this 32-byte object at 24
+           (8 + (3<<2), dnode-rounded), so a heap walk would resume INSIDE it.
+           x8664 canon: (make-vheader 6 ...), x8664-vinsns:2522 /
+           def_header(complex_double_float_header,6,...) in both 64-bit
+           constants files; our complex-double-float->heap vinsn already uses
+           the literal.  See the note at misc_ref_double_float_vector. */
+        mov imm2, #((6 << num_subtag_bits) | subtag_complex_double_float)
+        Misc_Alloc_Fixed arg_z, imm2, complex_double_float.size
+        /* stur, not stp: _structf offsets are tag-biased (realpart = header +
+           pad - fulltag_misc), so the immediate is not a multiple of 8 and
+           ldp/stp -- which have no unscaled form -- will not assemble.  Same
+           reason the rest of this file reaches tagged slots with ldur/stur. */
+        stur imm0, [arg_z, #complex_double_float.realpart]
+        stur imm1, [arg_z, #(complex_double_float.realpart + 8)]
+        ret
+misc_ref_invalid:
+        mov arg_x, #XBADVEC             /* errors.s:177 deferr           */
+        mov nargs, #(3<<fixnumshift)
+        b _SPksignalerr
+endsp misc_ref
+
+/* ===== subtag_misc_ref ===== */
+/* ported from ppc-spentry.s:3205-3224 (PPC64 branch) */
+spentry subtag_misc_ref
+        and imm0, arg_y, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne 1f
+        and imm0, arg_z, #fixnummask
+        cbnz imm0, 1f
+        ldr imm0, [arg_y, #misc_header_offset]
+        lsr imm1, imm0, #num_subtag_bits
+        lsl imm1, imm1, #fixnumshift
+        cmp arg_z, imm1
+        b.ge 1f
+        asr imm1, arg_x, #fixnumshift         /* unbox_fixnum(imm1,arg_x) = subtag override */
+        b misc_ref_common
+1:      mov arg_x, #XBADVEC             /* errors.s:177 deferr           */
+        mov nargs, #(3<<fixnumshift)
+        b _SPksignalerr
+endsp subtag_misc_ref
+
+/* ===== stkconsyz ===== */
+/* ported from ppc-spentry.s:3226-3241 (PPC64 branch) */
+spentry stkconsyz
+        mov imm0, rnil                  /* li imm0,nil_value -> rnil       */
+        str imm0, [vsp, #-node_size]!         /* vpush(imm0) */
+        str imm0, [vsp, #-node_size]!
+        str imm0, [vsp, #-node_size]!
+        and imm0, vsp, #(1<<node_shift)       /* Check alignment */
+        cbz imm0, 1f
+        str arg_y, [vsp, #(node_size*2)]
+        str arg_z, [vsp, #node_size]
+        add arg_z, vsp, #(fulltag_cons + node_size)
+        ret
+1:      str arg_y, [vsp, #node_size]
+        str arg_z, [vsp]
+        add arg_z, vsp, #fulltag_cons
+        ret
+endsp stkconsyz
+
+/* ===== stkgvector ===== */
+/* ported from ppc-spentry.s:3393-3420 (PPC64 branch) - ~30 lines */
+spentry stkgvector
+        sub imm0, nargs, #(1<<fixnumshift)
+        add imm1, vsp, nargs
+        ldr temp0, [imm1, #-node_size]!          /* pop subtag from stack */
+        lsl imm2, imm0, #(num_subtag_bits - fixnumshift)  /* element_count << num_subtag_bits (PPC slri = shift LEFT; the earlier lsr right-shifted the count into the low byte -> header count field always 0 -> malformed stack closures overflowed the vstack in _SPcall_closure) */
+        asr imm3, temp0, #fixnumshift            /* unbox subtag */
+        orr imm2, imm3, imm2                     /* header = (element_count << num_subtag_bits) | subtag */
+        /* dnode_align: (imm0 + node_size + tsp_frame.fixed_overhead + dnode_size - 1) & ~(dnode_size-1) */
+        add imm0, imm0, #(node_size + tsp_frame.fixed_overhead + dnode_size - 1)  /* fixed_overhead=16, was mis-guessed 8 */
+        and imm0, imm0, #(~(dnode_size - 1))
+        /* TSP_Alloc_Var_Boxed_nz (ppc-macros.s:721-725): push frame WITH
+           backlink, zero the data area, mark boxed.  The previous bare
+           `sub tsp` dropped the backlink (PPC's stru writes it as a
+           store-with-update side effect) — the frame's [tsp]=0 then fed
+           tsp:=0 into the caller's tsp_unlink on the toplevel fn's second
+           lap (16m5k wall, gdb-observed 2026-07-17). */
+        mov imm4, tsp
+        sub tsp, tsp, imm0
+        str imm4, [tsp, #tsp_frame.backlink]
+        mov imm3, tsp
+        sub imm0, imm4, #node_size
+3:      cmp imm3, imm0
+        b.eq 4f
+        str xzr, [imm3, #node_size]!
+        b 3b
+4:      str xzr, [tsp, #tsp_frame.type]          /* Set_TSP_Frame_Boxed */
+        str imm2, [tsp, #tsp_frame.data_offset]  /* store header (data_offset=16, was mis-guessed 8) */
+        add arg_z, tsp, #(tsp_frame.data_offset + fulltag_misc)
+        add imm3, arg_z, #misc_header_offset     /* pointer to header area for data copy */
+        mov imm0, #(1<<fixnumshift)
+        cmp imm0, nargs                          /* re-derive the entry test (nargs==fixnum 1 => no elements); the old cmp-at-top flags don't survive the zero loop */
+        b 2f
+1:      /* Copy loop */
+        add imm0, imm0, #(1<<fixnumshift)
+        cmp imm0, nargs
+        ldr temp0, [imm1, #-node_size]!
+        str temp0, [imm3, #node_size]!
+2:      b.ne 1b
+        add vsp, vsp, nargs
+        ret
+endsp stkgvector
+
+/* ===== subtag_misc_set ===== */
+/* ported from ppc-spentry.s:3907-4871 (PPC64 branch) */
+spentry subtag_misc_set
+        and imm0, arg_x, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne 1f
+        and imm0, arg_y, #fixnummask
+        cbnz imm0, 1f
+        ldr imm0, [arg_x, #misc_header_offset]
+        lsr imm1, imm0, #num_subtag_bits
+        lsl imm1, imm1, #fixnumshift
+        cmp arg_y, imm1
+        b.ge 1f
+        asr imm1, temp0, #fixnumshift         /* unbox subtag override from temp0 */
+        b misc_set_common
+1:      mov arg_w, #XBADVEC             /* errors.s:177 deferr           */
+        mov nargs, #(4<<fixnumshift)
+        b _SPksignalerr
+endsp subtag_misc_set
+
+/* ===== misc_set ===== */
+/* ported from ppc-spentry.s:4873-6950 (PPC64 branch) - ~500 lines */
+spentry misc_set
+        and imm0, arg_x, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne misc_set_invalid
+        and imm0, arg_y, #fixnummask
+        cbnz imm0, misc_set_invalid
+        ldr imm0, [arg_x, #misc_header_offset]
+        lsr imm1, imm0, #num_subtag_bits
+        lsl imm1, imm1, #fixnumshift
+        cmp arg_y, imm1
+        b.ge misc_set_invalid
+        and imm1, imm0, #subtagmask
+misc_set_common:
+        /* Node vectors -> delegate to gvset for write barrier.  Class
+           test, not per-subtag: nodeheader_{0,1} share low-3-bits #b110
+           and PPC64's table routes every real nodeheader subtag to gvset
+           (ppc:3921ff) — the chain missed catch-frame/hash-vector/
+           slot-vector/lock/instance/istruct/… (boot-16m5b). */
+        and imm2, imm1, #7
+        cmp imm2, #6                    /* fulltag_nodeheader_{0,1} & 7 */
+        b.eq _SPgvset
+        /* Integer vectors */
+        cmp imm1, #subtag_u8_vector
+        b.eq misc_set_u8
+        cmp imm1, #subtag_s8_vector
+        b.eq misc_set_s8
+        cmp imm1, #subtag_u16_vector
+        b.eq misc_set_u16
+        cmp imm1, #subtag_s16_vector
+        b.eq misc_set_s16
+        cmp imm1, #subtag_u32_vector
+        b.eq misc_set_u32
+        cmp imm1, #subtag_s32_vector
+        b.eq misc_set_s32
+        cmp imm1, #subtag_u64_vector
+        b.eq misc_set_u64
+        cmp imm1, #subtag_s64_vector
+        b.eq misc_set_s64
+        cmp imm1, #subtag_fixnum_vector
+        b.eq misc_set_fixnum_vector
+        /* Float vectors (16m37) -- parity twin of the misc_ref_common
+           addition; both sides were missing all four float-vector subtags. */
+        cmp imm1, #subtag_single_float_vector
+        b.eq misc_set_single_float_vector
+        cmp imm1, #subtag_double_float_vector
+        b.eq misc_set_double_float_vector
+        /* COMPLEX float vectors (16m41) -- parity twin of the misc_ref_common
+           addition; this is the side EVERY.32 actually reached, via
+           :initial-contents -> init-uvector-contents -> uvset. */
+        cmp imm1, #subtag_complex_single_float_vector
+        b.eq misc_set_complex_single_float_vector
+        cmp imm1, #subtag_complex_double_float_vector
+        b.eq misc_set_complex_double_float_vector
+        cmp imm1, #subtag_simple_base_string
+        b.eq misc_set_string
+        cmp imm1, #subtag_bit_vector
+        b.eq misc_set_bit_vector
+        cmp imm1, #subtag_code_vector
+        b.eq misc_set_u32
+        cmp imm1, #subtag_bignum
+        b.eq misc_set_u32
+        /* PPC64 jump table (ppc:3954/3971): macptr + dead_macptr store as
+           raw 64-bit words (cold load does misc_set(macptr,0,0) to null
+           the address — boot-16m5b wall); double-float/xcode-vector as
+           2×u32. */
+        cmp imm1, #subtag_macptr
+        b.eq misc_set_u64
+        cmp imm1, #subtag_dead_macptr
+        b.eq misc_set_u64
+        cmp imm1, #subtag_double_float
+        b.eq misc_set_u32
+        cmp imm1, #subtag_xcode_vector
+        b.eq misc_set_u32
+        b misc_set_invalid
+misc_set_u8:
+        and imm0, arg_z, #fixnummask
+        cbnz imm0, misc_set_bad
+        lsr imm0, arg_z, #fixnumshift
+        cmp imm0, #256
+        b.hs misc_set_bad
+        lsr imm4, arg_y, #fixnumshift   /* ppc:4297 idx                    */
+        add imm2, arg_x, #misc_data_offset
+        strb w0, [imm2, imm4]           /* ppc:4301 stbx (was [imm4,imm4]) */
+        ret
+misc_set_s8:
+        and imm2, arg_z, #fixnummask
+        cbnz imm2, misc_set_bad
+        asr imm0, arg_z, #fixnumshift
+        sxtb imm1, w0
+        cmp x0, x1
+        b.ne misc_set_bad
+        lsr imm4, arg_y, #fixnumshift   /* ppc:4286 idx                    */
+        add imm2, arg_x, #misc_data_offset
+        strb w0, [imm2, imm4]           /* ppc:4293 stbx (was [imm4,imm4]) */
+        ret
+misc_set_u16:
+        and imm0, arg_z, #fixnummask
+        cbnz imm0, misc_set_bad
+        lsr imm0, arg_z, #fixnumshift
+        cmp imm0, #65536
+        b.hs misc_set_bad
+        lsr imm1, arg_y, #fixnumshift   /* ppc:4266 idx                    */
+        lsl imm1, imm1, #1              /* *2 bytes                        */
+        add imm2, arg_x, #misc_data_offset
+        strh w0, [imm2, imm1]           /* (index was clobbered; store hit
+                                           element 0 for every index)      */
+        ret
+misc_set_s16:
+        and imm2, arg_z, #fixnummask
+        cbnz imm2, misc_set_bad
+        asr imm0, arg_z, #fixnumshift
+        sxth imm1, w0
+        cmp x0, x1
+        b.ne misc_set_bad
+        lsr imm1, arg_y, #fixnumshift
+        lsl imm1, imm1, #1
+        add imm2, arg_x, #misc_data_offset
+        strh w0, [imm2, imm1]
+        ret
+misc_set_u32:
+        /* ppc:4256-4263.  extract_unsigned_byte_bits_(imm0,arg_z,32): on
+           a 64-bit target every (unsigned-byte 32) IS a fixnum, so a
+           non-fixnum is simply bad - there is no bignum arm (the old
+           old guard had a wrong premise). */
+        and imm2, arg_z, #fixnummask
+        cbnz imm2, misc_set_bad
+        asr imm1, arg_z, #fixnumshift
+        lsr imm2, imm1, #32             /* sign or high bits => not u32    */
+        cbnz imm2, misc_set_bad
+        lsr imm4, arg_y, #1             /* ppc:4258 boxed idx -> idx*4     */
+        add imm2, arg_x, #misc_data_offset
+        str w1, [imm2, imm4]            /* ppc:4262 stwx                   */
+        ret
+misc_set_s32:
+        /* ppc:4243-4255; fixnum-only for the same reason as u32. */
+        and imm2, arg_z, #fixnummask
+        cbnz imm2, misc_set_bad
+        asr imm0, arg_z, #fixnumshift
+        sxtw imm1, w0                   /* ppc:4248-4249 sign-extend probe */
+        cmp x0, x1
+        b.ne misc_set_bad
+        lsr imm4, arg_y, #1             /* boxed idx -> idx*4              */
+        add imm2, arg_x, #misc_data_offset
+        str w0, [imm2, imm4]            /* ppc:4254 stwx                   */
+        ret
+misc_set_u64:
+        /* ppc:4303-4332.  Value > most-positive-fixnum arrives as a 2- or
+           3-digit bignum.  ARM64-DEVIATION: PPC64 rotldi-swaps the two
+           32-bit digits after the 64-bit load (big-endian); little-endian
+           reads digit1:digit0 = the value directly - no rotate. */
+        and imm0, arg_z, #fixnummask
+        cbnz imm0, setu64_maybe_bignum  /* ppc:4310                        */
+        asr imm0, arg_z, #fixnumshift   /* ppc:4311                        */
+        tbnz imm0, #63, misc_set_bad    /* ppc:4312 blt (negative fixnum)  */
+2:      add imm4, arg_x, arg_y
+        str imm0, [imm4, #misc_data_offset]     /* ppc:4313 stdx           */
+        ret
+setu64_maybe_bignum:                    /* ppc:4315-4332                   */
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc         /* ppc:4308/4316                   */
+        b.ne misc_set_bad
+        ldur imm1, [arg_z, #misc_header_offset] /* ppc:4317 getvheader     */
+        ldur imm0, [arg_z, #misc_data_offset]   /* ppc:4318 (no rotldi)    */
+        mov imm3, #two_digit_bignum_header      /* ppc:4320                */
+        cmp imm1, imm3
+        b.eq 3f
+        mov imm3, #three_digit_bignum_header    /* ppc:4321                */
+        cmp imm1, imm3
+        b.ne misc_set_bad               /* ppc:4324                        */
+        ldur w3, [arg_z, #(misc_data_offset+8)] /* ppc:4325 third digit    */
+        cbnz w3, misc_set_bad           /* ppc:4326-4327 must be sign 0    */
+        b 2b                            /* ppc:4328 store                  */
+3:      tbnz imm0, #63, misc_set_bad    /* ppc:4330 2-digit must be >= 0   */
+        b 2b                            /* ppc:4331 store                  */
+misc_set_s64:
+        /* ppc:4369-4387; bignum arm = exactly a 2-digit bignum (LE: no
+           rotldi, see misc_set_u64). */
+        and imm2, arg_z, #fixnummask
+        cbnz imm2, sets64_maybe_bignum  /* ppc:4376                        */
+        asr imm0, arg_z, #fixnumshift   /* ppc:4372                        */
+2:      add imm4, arg_x, arg_y
+        str imm0, [imm4, #misc_data_offset]     /* ppc:4377 stdx           */
+        ret
+sets64_maybe_bignum:                    /* ppc:4379-4387                   */
+        and imm3, arg_z, #fulltagmask
+        cmp imm3, #fulltag_misc         /* ppc:4374/4380                   */
+        b.ne misc_set_bad
+        ldur imm1, [arg_z, #misc_header_offset] /* ppc:4381 getvheader     */
+        ldur imm0, [arg_z, #misc_data_offset]   /* ppc:4382 (no rotldi)    */
+        mov imm3, #two_digit_bignum_header      /* ppc:4383                */
+        cmp imm1, imm3
+        b.ne misc_set_bad               /* ppc:4385                        */
+        b 2b                            /* ppc:4386 store                  */
+misc_set_fixnum_vector:
+        and imm2, arg_z, #fixnummask
+        cbnz imm2, misc_set_bad
+        asr imm0, arg_z, #fixnumshift
+        add imm4, arg_x, arg_y
+        str imm0, [imm4, #misc_data_offset]
+        ret
+misc_set_string:
+        /* ppc:4264-4272 misc_set_new_string: this design's strings are
+           32-BIT chars (subtag_simple_base_string is ivector-class-32-bit)
+           - the old byte-char body stored 1 byte at element 0 and masked
+           the code to 8 bits.  Character check = full low byte. */
+        and imm0, arg_z, #255           /* ppc:4265 extract_lowbyte        */
+        cmp imm0, #subtag_character     /* ppc:4267                        */
+        b.ne misc_set_bad
+        lsr imm0, arg_z, #charcode_shift        /* ppc:4269 code           */
+        lsr imm4, arg_y, #1             /* ppc:4266 boxed idx -> idx*4     */
+        add imm2, arg_x, #misc_data_offset
+        str w0, [imm2, imm4]            /* ppc:4271 stwx                   */
+        ret
+misc_set_bit_vector:
+        /* ARM64 LSB0 bit order */
+        cmp arg_z, #(1<<fixnumshift)
+        b.hi misc_set_bad
+        lsr imm0, arg_y, #fixnumshift
+        lsr imm2, imm0, #5
+        lsl imm2, imm2, #2
+        add imm2, arg_x, imm2
+        ldr w3, [imm2, #misc_data_offset]
+        and imm1, imm0, #31
+        mov w4, #1
+        lsl w4, w4, w1
+        bic w3, w3, w4
+        lsr imm0, arg_z, #fixnumshift
+        lsl w0, w0, w1
+        orr w3, w3, w0
+        str w3, [imm2, #misc_data_offset]
+        ret
+misc_set_single_float_vector:
+        /* ppc:4234-4241.  arg_x=vector arg_y=boxed index arg_z=value. */
+        and imm3, arg_z, #fulltagmask
+        cmp imm3, #fulltag_single_float  /* see misc_ref_single_float_vector  */
+        b.ne misc_set_bad
+        lsr imm4, arg_y, #1             /* ppc:4236 boxed idx -> idx*4     */
+        lsr imm0, arg_z, #32            /* ppc:4239 the IEEE bits ride high */
+        add imm2, arg_x, #misc_data_offset
+        str w0, [imm2, imm4]            /* ppc:4240 stwx                   */
+        ret
+misc_set_double_float_vector:
+        /* ppc:4333-4339.  PPC's extract_typecode is tag-safe; we have no such
+           macro, so use this file's own precedent (setu64_maybe_bignum): check
+           fulltag_misc FIRST, or reading the header of an immediate faults
+           instead of signalling. */
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne misc_set_bad
+        ldur imm1, [arg_z, #misc_header_offset]
+        and imm1, imm1, #subtagmask
+        cmp imm1, #subtag_double_float
+        b.ne misc_set_bad
+        ldr imm0, [arg_z, #double_float.value]   /* ppc:4337 misc_dfloat_offset */
+        /* 64-bit elements: boxed index IS the byte offset (fixnumshift 3). */
+        add imm4, arg_x, arg_y
+        str imm0, [imm4, #misc_data_offset]      /* ppc:4338 stdx           */
+        ret
+misc_set_complex_single_float_vector:
+        /* 16m41, parity twin of misc_ref_complex_single_float_vector.
+           Type-check like misc_set_double_float_vector: fulltag_misc FIRST,
+           or reading the header of an immediate faults instead of signalling. */
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne misc_set_bad
+        ldur imm1, [arg_z, #misc_header_offset]
+        and imm1, imm1, #subtagmask
+        cmp imm1, #subtag_complex_single_float
+        b.ne misc_set_bad
+        ldr imm0, [arg_z, #complex_single_float.realpart]  /* both parts */
+        add imm4, arg_x, arg_y                  /* boxed idx IS the byte offset */
+        str imm0, [imm4, #misc_data_offset]
+        ret
+misc_set_complex_double_float_vector:
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne misc_set_bad
+        ldur imm1, [arg_z, #misc_header_offset]
+        and imm1, imm1, #subtagmask
+        cmp imm1, #subtag_complex_double_float
+        b.ne misc_set_bad
+        ldur imm0, [arg_z, #complex_double_float.realpart]   /* ldur: see the */
+        ldur imm1, [arg_z, #(complex_double_float.realpart + 8)] /* ref leg  */
+        lsl imm4, arg_y, #1                     /* 16i = boxed<<1 */
+        add imm4, imm4, arg_x
+        add imm4, imm4, #misc_complex_dfloat_offset  /* 16m48: pad; see ref leg */
+        stp imm0, imm1, [imm4]
+        ret
+misc_set_bad:
+        mov arg_y, arg_z
+        mov arg_z, arg_x
+        mov arg_x, #XNOTELT             /* errors.s:227 deferr           */
+        mov nargs, #(3<<fixnumshift)
+        b _SPksignalerr
+misc_set_invalid:
+        mov temp0, #XSETBADVEC          /* errors.s:182 deferr           */
+        mov nargs, #(4<<fixnumshift)
+        b _SPksignalerr
+endsp misc_set
+
+/* ===== progvrestore ===== */
+/* ported from ppc-spentry.s:6952-6958 (PPC64 branch) */
+spentry progvrestore
+        ldr imm0, [tsp, #tsp_frame.backlink]     /* ppc:6953 (backlink=0, was mis-guessed 16) */
+        ldr imm0, [imm0, #tsp_frame.data_offset]  /* ppc:6954 (data_offset=16, was mis-guessed 8) */
+        cmp imm0, #0
+        asr imm0, imm0, #fixnumshift
+        b.ne _SPunbind_n
+        ret
+endsp progvrestore
+
+/* ===== aref2 ===== */
+/* ported from ppc-spentry.s:7053-7083 (PPC64 branch) */
+/* ABI inputs: arg_x=array, arg_y=i, arg_z=j
+ * Computes row-major index, follows displaced-array chain, then branches to
+ * misc_ref_common with: arg_y=underlying-vector, arg_z=row-major-index(boxed),
+ * imm1=subtag. */
+
+/* PROPOSED-CONSTANTS: arrayH struct offsets (not yet in arm64-constants.h).
+ * define-lisp-object arrayH fulltag-misc (arm64-arch.lisp:683): slots
+ * header, rank, physsize, data-vector, displacement, flags, then dims --
+ * slot k sits at (k*node_size - fulltag_misc) from the tagged pointer
+ * (fulltag_misc = 12, arm64-constants.h:144; misc-data-offset = -4).
+ * 16m41: this block used to hand-number the offsets with PPC64's bias
+ * (-4, i.e. rank@4 ... dim0@44), +8 off for every slot, so the rank
+ * check read physsize and aset2/aref2/aset3/aref3 trapped on EVERY
+ * valid array.  Symbolic now: correct by construction.  */
+#ifndef ARRAYH_STRUCT_DEFINED
+.set arrayH.rank,         (1*node_size - fulltag_misc)
+.set arrayH.physsize,     (2*node_size - fulltag_misc)
+.set arrayH.data_vector,  (3*node_size - fulltag_misc)
+.set arrayH.displacement, (4*node_size - fulltag_misc)
+.set arrayH.flags,        (5*node_size - fulltag_misc)
+.set arrayH.dim0,         (6*node_size - fulltag_misc)
+#define ARRAYH_STRUCT_DEFINED
+#endif
+
+spentry aref2
+        /* extract_typecode(imm2, arg_x): get fulltag, then if misc load subtag */
+        and     imm2, arg_x, #fulltagmask
+        cmp     imm2, #fulltag_misc
+        b.ne    aref2_not_arrayH
+        ldrb    w2, [arg_x, #misc_subtag_offset]
+        /* trap_unless_lisptag_equal(arg_y, tag_fixnum) */
+        tst     arg_y, #fixnummask
+        b.ne    aref2_not_arrayH
+        /* trap_unless_lisptag_equal(arg_z, tag_fixnum) */
+        tst     arg_z, #fixnummask
+        b.ne    aref2_not_arrayH
+        /* Now test subtag == subtag_arrayH (PPC64 cmpri cr2 + bne cr2) */
+        cmp     imm2, #subtag_arrayH
+        b.ne    aref2_not_arrayH
+        /* Check rank == 2 */
+        ldr     imm1, [arg_x, #arrayH.rank]
+        cmp     imm1, #(2 << fixnumshift)
+        b.ne    aref2_not_arrayH
+        /* Bounds check dim0: trlge(arg_y, dim0[0]) */
+        ldr     imm0, [arg_x, #arrayH.dim0]
+        cmp     arg_y, imm0
+        b.hs    aref2_not_arrayH
+        /* Bounds check dim1: trlge(arg_z, dim0[1]) */
+        ldr     imm0, [arg_x, #(arrayH.dim0 + node_size)]
+        cmp     arg_z, imm0
+        b.hs    aref2_not_arrayH
+        /* Row-major index: arg_z = arg_z + arg_y * unbox(dim1)
+         * unbox_fixnum(imm0, imm0): imm0 still holds dim1 */
+        asr     imm0, imm0, #fixnumshift
+        mul     arg_y, arg_y, imm0
+        add     arg_z, arg_z, arg_y
+        /* Follow displaced-array chain: arg_y = array (the arrayH) */
+        mov     arg_y, arg_x
+aref2_follow:
+        ldr     imm0, [arg_y, #arrayH.displacement]
+        ldr     arg_y, [arg_y, #arrayH.data_vector]
+        /* extract_subtag(imm1, arg_y) */
+        ldrb    w1, [arg_y, #misc_subtag_offset]
+        add     arg_z, arg_z, imm0
+        cmp     imm1, #subtag_vectorH
+        b.eq    aref2_follow
+        cmp     imm1, #subtag_arrayH
+        b.eq    aref2_follow
+        /* Contract: arg_y=vector, arg_z=index(boxed), imm1=subtag */
+        b       misc_ref_common
+aref2_not_arrayH:
+        uuo_error_reg_not_xtype arg_x, xtype_array2d /* ppc uuo_interr -> xtype trap */
+endsp aref2
+
+/* ===== aref3 ===== */
+/* ported from ppc-spentry.s:7086-7122 (PPC64 branch) */
+/* ABI inputs: temp0=array, arg_x=i, arg_y=j, arg_z=k
+ * Computes row-major index, follows displaced-array chain, then branches to
+ * misc_ref_common with: arg_y=underlying-vector, arg_z=row-major-index(boxed),
+ * imm1=subtag. */
+spentry aref3
+        /* extract_typecode(imm2, temp0) */
+        and     imm2, temp0, #fulltagmask
+        cmp     imm2, #fulltag_misc
+        b.ne    aref3_not_arrayH
+        ldrb    w2, [temp0, #misc_subtag_offset]
+        /* trap_unless_lisptag_equal(arg_x, tag_fixnum) */
+        tst     arg_x, #fixnummask
+        b.ne    aref3_not_arrayH
+        /* trap_unless_lisptag_equal(arg_y, tag_fixnum) */
+        tst     arg_y, #fixnummask
+        b.ne    aref3_not_arrayH
+        /* trap_unless_lisptag_equal(arg_z, tag_fixnum) */
+        tst     arg_z, #fixnummask
+        b.ne    aref3_not_arrayH
+        /* Now test subtag == subtag_arrayH (PPC64 cmpri cr2 + bne cr2) */
+        cmp     imm2, #subtag_arrayH
+        b.ne    aref3_not_arrayH
+        /* Check rank == 3 */
+        ldr     imm1, [temp0, #arrayH.rank]
+        cmp     imm1, #(3 << fixnumshift)
+        b.ne    aref3_not_arrayH
+        /* Load dims: dim2, dim1, dim0 (PPC64 loads in this order) */
+        ldr     imm2, [temp0, #(arrayH.dim0 + (node_size * 2))]
+        ldr     imm1, [temp0, #(arrayH.dim0 + node_size)]
+        ldr     imm0, [temp0, #arrayH.dim0]
+        /* Bounds: trlge(arg_z, imm2) */
+        cmp     arg_z, imm2
+        b.hs    aref3_not_arrayH
+        asr     imm2, imm2, #fixnumshift    /* unbox dim2 */
+        /* Bounds: trlge(arg_y, imm1) */
+        cmp     arg_y, imm1
+        b.hs    aref3_not_arrayH
+        asr     imm1, imm1, #fixnumshift    /* unbox dim1 */
+        /* Bounds: trlge(arg_x, imm0) */
+        cmp     arg_x, imm0
+        b.hs    aref3_not_arrayH
+        /* Row-major: arg_z = k + j*dim2 + i*(dim1*dim2)
+         * PPC64: mullr(arg_y,arg_y,imm2); mullr(imm1,imm2,imm1);
+         *        mullr(arg_x,imm1,arg_x); add arg_z,arg_z,arg_y;
+         *        add arg_z,arg_z,arg_x */
+        mul     arg_y, arg_y, imm2
+        mul     imm1, imm2, imm1
+        mul     arg_x, imm1, arg_x
+        add     arg_z, arg_z, arg_y
+        add     arg_z, arg_z, arg_x
+        /* Follow displaced-array chain: arg_y = temp0 (the arrayH) */
+        mov     arg_y, temp0
+aref3_follow:
+        ldr     imm0, [arg_y, #arrayH.displacement]
+        ldr     arg_y, [arg_y, #arrayH.data_vector]
+        /* extract_subtag(imm1, arg_y) */
+        ldrb    w1, [arg_y, #misc_subtag_offset]
+        add     arg_z, arg_z, imm0
+        cmp     imm1, #subtag_vectorH
+        b.eq    aref3_follow
+        cmp     imm1, #subtag_arrayH
+        b.eq    aref3_follow
+        /* Contract: arg_y=vector, arg_z=index(boxed), imm1=subtag */
+        b       misc_ref_common
+aref3_not_arrayH:
+        uuo_error_reg_not_xtype temp0, xtype_array3d /* ppc uuo_interr -> xtype trap */
+endsp aref3
+
+/* ===== aset2 ===== */
+/* ported from ppc-spentry.s:7127-7156 (PPC64 branch) */
+/* ABI inputs: temp0=array, arg_x=i, arg_y=j, arg_z=newval
+ * Computes row-major index, follows displaced-array chain, then branches to
+ * misc_set_common with: arg_x=underlying-vector, arg_y=row-major-index(boxed),
+ * arg_z=newval, imm1=subtag. */
+spentry aset2
+        /* extract_typecode(imm2, temp0) */
+        and     imm2, temp0, #fulltagmask
+        cmp     imm2, #fulltag_misc
+        b.ne    aset2_not_arrayH
+        ldrb    w2, [temp0, #misc_subtag_offset]
+        /* trap_unless_lisptag_equal(arg_x, tag_fixnum) */
+        tst     arg_x, #fixnummask
+        b.ne    aset2_not_arrayH
+        /* trap_unless_lisptag_equal(arg_y, tag_fixnum) */
+        tst     arg_y, #fixnummask
+        b.ne    aset2_not_arrayH
+        /* Now test subtag == subtag_arrayH (PPC64 cmpri cr2 + bne cr2) */
+        cmp     imm2, #subtag_arrayH
+        b.ne    aset2_not_arrayH
+        /* Check rank == 2 */
+        ldr     imm1, [temp0, #arrayH.rank]
+        cmp     imm1, #(2 << fixnumshift)
+        b.ne    aset2_not_arrayH
+        /* Bounds check dim0: trlge(arg_x, dim0[0]) */
+        ldr     imm0, [temp0, #arrayH.dim0]
+        cmp     arg_x, imm0
+        b.hs    aset2_not_arrayH
+        /* Bounds check dim1: trlge(arg_y, dim0[1]) */
+        ldr     imm0, [temp0, #(arrayH.dim0 + node_size)]
+        cmp     arg_y, imm0
+        b.hs    aset2_not_arrayH
+        /* Row-major: arg_y = arg_y + arg_x * unbox(dim1) */
+        asr     imm0, imm0, #fixnumshift
+        mul     arg_x, arg_x, imm0
+        add     arg_y, arg_y, arg_x
+        /* Follow displaced-array chain: arg_x = temp0 (the arrayH) */
+        mov     arg_x, temp0
+aset2_follow:
+        ldr     imm0, [arg_x, #arrayH.displacement]
+        ldr     arg_x, [arg_x, #arrayH.data_vector]
+        /* extract_subtag(imm1, arg_x) */
+        ldrb    w1, [arg_x, #misc_subtag_offset]
+        add     arg_y, arg_y, imm0
+        cmp     imm1, #subtag_vectorH
+        b.eq    aset2_follow
+        cmp     imm1, #subtag_arrayH
+        b.eq    aset2_follow
+        /* Contract: arg_x=vector, arg_y=index(boxed), arg_z=newval, imm1=subtag */
+        b       misc_set_common
+aset2_not_arrayH:
+        uuo_error_reg_not_xtype temp0, xtype_array2d /* ppc uuo_interr -> xtype trap */
+endsp aset2
+
+/* ===== aset3 ===== */
+/* ported from ppc-spentry.s:7160-7196 (PPC64 branch) */
+/* ABI inputs: temp1=array, temp0=i, arg_x=j, arg_y=k, arg_z=new
+ * Computes row-major index, follows displaced-array chain, then branches to
+ * misc_set_common with: arg_x=underlying-vector, arg_y=row-major-index(boxed),
+ * arg_z=newval, imm1=subtag. */
+spentry aset3
+        /* extract_typecode(imm2, temp1) */
+        and     imm2, temp1, #fulltagmask
+        cmp     imm2, #fulltag_misc
+        b.ne    aset3_not_arrayH
+        ldrb    w2, [temp1, #misc_subtag_offset]
+        /* trap_unless_lisptag_equal(temp0, tag_fixnum) */
+        tst     temp0, #fixnummask
+        b.ne    aset3_not_arrayH
+        /* trap_unless_lisptag_equal(arg_x, tag_fixnum) */
+        tst     arg_x, #fixnummask
+        b.ne    aset3_not_arrayH
+        /* trap_unless_lisptag_equal(arg_y, tag_fixnum) */
+        tst     arg_y, #fixnummask
+        b.ne    aset3_not_arrayH
+        /* Now test subtag == subtag_arrayH (PPC64 cmpri cr2 + bne cr2) */
+        cmp     imm2, #subtag_arrayH
+        b.ne    aset3_not_arrayH
+        /* Check rank == 3 */
+        ldr     imm1, [temp1, #arrayH.rank]
+        cmp     imm1, #(3 << fixnumshift)
+        b.ne    aset3_not_arrayH
+        /* Load dims: dim2, dim1, dim0 */
+        ldr     imm2, [temp1, #(arrayH.dim0 + (node_size * 2))]
+        ldr     imm1, [temp1, #(arrayH.dim0 + node_size)]
+        ldr     imm0, [temp1, #arrayH.dim0]
+        /* Bounds: trlge(arg_y, imm2) */
+        cmp     arg_y, imm2
+        b.hs    aset3_not_arrayH
+        asr     imm2, imm2, #fixnumshift    /* unbox dim2 */
+        /* Bounds: trlge(arg_x, imm1) */
+        cmp     arg_x, imm1
+        b.hs    aset3_not_arrayH
+        asr     imm1, imm1, #fixnumshift    /* unbox dim1 */
+        /* Bounds: trlge(temp0, imm0) */
+        cmp     temp0, imm0
+        b.hs    aset3_not_arrayH
+        /* Row-major: arg_y = k + j*dim2 + i*(dim1*dim2)
+         * PPC64: mullr(arg_x,arg_x,imm2); mullr(imm1,imm2,imm1);
+         *        mullr(temp0,imm1,temp0); add arg_y,arg_y,arg_x;
+         *        add arg_y,arg_y,temp0 */
+        mul     arg_x, arg_x, imm2
+        mul     imm1, imm2, imm1
+        mul     temp0, imm1, temp0
+        add     arg_y, arg_y, arg_x
+        add     arg_y, arg_y, temp0
+        /* Follow displaced-array chain: arg_x = temp1 (the arrayH) */
+        mov     arg_x, temp1
+aset3_follow:
+        ldr     temp0, [arg_x, #arrayH.displacement]
+        ldr     arg_x, [arg_x, #arrayH.data_vector]
+        /* extract_subtag(imm1, arg_x) */
+        ldrb    w1, [arg_x, #misc_subtag_offset]
+        add     arg_y, arg_y, temp0
+        cmp     imm1, #subtag_vectorH
+        b.eq    aset3_follow
+        cmp     imm1, #subtag_arrayH
+        b.eq    aset3_follow
+        /* Contract: arg_x=vector, arg_y=index(boxed), arg_z=newval, imm1=subtag */
+        b       misc_set_common
+aset3_not_arrayH:
+        uuo_error_reg_not_xtype temp1, xtype_array3d /* ppc uuo_interr -> xtype trap */
+endsp aset3
+
+/* ===== COMPLETION STATUS & MISSING CONSTANTS ===== */
+/*
+ * ALL 22 SUBPRIMS PORTED (logic complete, awaiting constant definitions):
+ *   ✓ aref2 (2d array ref) - COMPLETE, exits via misc_ref_common
+ *   ✓ aref3 (3d array ref) - COMPLETE, exits via misc_ref_common
+ *   ✓ aset2 (2d array set) - COMPLETE, exits via misc_set_common
+ *   ✓ aset3 (3d array set) - COMPLETE, exits via misc_set_common
+ *   ✓ conslist, conslist_star (heap cons) - COMPLETE
+ *   ✓ stkconslist, stkconslist_star (tstack cons) - needs tsp_frame offsets
+ *   ✓ mkstackv (tstack vector) - needs tsp_frame offsets
+ *   ✓ gvector (heap vector) - COMPLETE except dnode_align macro
+ *   ✓ misc_ref (vector read) - COMPLETE: integer/node/string/bit + float and
+ *     complex-float vectors (16m37/16m41)
+ *   ✓ subtag_misc_ref (explicit subtag) - COMPLETE
+ *   ✓ misc_set (vector write) - COMPLETE: same coverage as misc_ref above
+ *   ✓ subtag_misc_set (explicit subtag) - COMPLETE
+ *   ✓ gvset (GC write barrier) - LOGIC COMPLETE, needs GC globals
+ *   ✓ set_hash_key (hash-table write) - LOGIC COMPLETE, needs GC globals
+ *   ✓ store_node_conditional (atomic store+barrier) - LOGIC COMPLETE, needs GC globals
+ *   ✓ set_hash_key_conditional (atomic hash store) - LOGIC COMPLETE, needs GC globals
+ *   ✓ stkconsyz (tstack cons from Y/Z) - COMPLETE
+ *   ✓ progvsave (special bindings) - LOGIC COMPLETE (~70 lines), needs tcr/tsp_frame/symbol offsets
+ *   ✓ progvrestore (restore bindings) - LOGIC COMPLETE
+ *   ✓ stkgvector (tstack general vector) - LOGIC COMPLETE (~30 lines), needs tsp_frame offsets
+ *
+ * MISSING CONSTANTS (must be defined in arm64-constants.h or arm64-macros.s):
+ *
+ * 1. GC write barrier (gvset, set_hash_key, store/set_*_conditional):
+ *    - ref_base (global: base of reference bitmap)
+ *    - refbits (global: pointer to refbits array)
+ *    - ephemeral_refidx (global: pointer to ephemeral index array)
+ *    - oldspace_dnode_count (global: size of oldspace in dnodes)
+ *    - dnode_shift (constant: 4 for 16-byte dnodes)
+ *    - bitmap_shift (constant: 9 for 512-entry bitmap chunks)
+ *
+ * 2. Symbolic values:
+ *    - nil_value (address of NIL object; low-tag design unclear if static)
+ *    - t_value (address of T object)
+ *    - RESERVATION_DISCHARGE (address for clearing ldxr reservation)
+ *
+ * 3. Error codes:
+ *    - XBADVEC (bad vector type/index error)
+ *    - XNOTELT (bad element type error)
+ *    - XSETBADVEC (bad vector for set operation)
+ *
+ * 4. TSP frame structure (for stkconslist*, mkstackv, stkgvector, progvsave/restore):
+ *    - tsp_frame.fixed_overhead (frame header size, likely 8-16 bytes)
+ *    - tsp_frame.data_offset (offset to data area, likely 8)
+ *    - tsp_frame.backlink (offset to previous frame link)
+ *    - tstack_alloc_limit (global or tcr field for overflow check)
+ *
+ * 5. TCR offsets (already in constants.h but needs verification):
+ *    - tcr.ts_area (offset to tstack area pointer) - VERIFIED at tcr struct definition
+ *    - tcr.db_link (special binding chain, for progvsave)
+ *    - tcr.tlb_limit, tcr.tlb_pointer (thread-local binding array, for progvsave)
+ *
+ * 6. Alignment macros (referenced but not expanded):
+ *    - dnode_align(dest, src, add) - align to 16-byte boundary
+ *
+ * 7. Float/complex support -- CLOSED (16m37 real floats, 16m41 complex): the
+ *    constants and Misc_Alloc_Fixed all exist; misc_ref/misc_set dispatch every
+ *    float and complex-float vector subtag.  Kept for the register/allocation
+ *    notes below.
+ *    - subtag_double_float, subtag_single_float, subtag_complex_single_float, etc.
+ *    - Allocation macros: Misc_Alloc_Fixed for boxed float returns
+ *    - Bignum header constants: one/two/three_digit_bignum_header
+ *
+ * 8. progvsave-specific:
+ *    - symbol.binding_index (offset within symbol struct)
+ *    - XIMPROPERLIST (error code for improper list)
+ *    - Binding trap mechanism (PPC64 trlle → ARM64 conditional brk or bounds check)
+ *
+ * DESIGN NOTES:
+ *   - ARM64 low-tag: fixnumshift=3, misc_data_offset=+4, misc_header_offset=-4
+ *   - Bit vectors: ARM64 LSB0 bit order (bit 0 is rightmost)
+ *   - Atomics: PPC64 ldarx/stdcx. → ARM64 ldxr/stxr + dmb ish (isync → dmb)
+ *   - cons.size = 16 (2*node_size from struct definition)
+ *   - _rplaca/_rplacd macros expanded inline as str to cons.car/cons.cdr offsets
+ *   - Node vectors delegate to _SPgvset for write-barrier handling
+ *   - Float/complex handlers marked #error due to missing constants (not design issues)
+ */

--- a/lisp-kernel/spentry-C-bind-catch-throw.s
+++ b/lisp-kernel/spentry-C-bind-catch-throw.s
@@ -1,0 +1,1860 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * C-bind-catch-throw cluster: 41 subprims ported from PPC64 to ARM64 low-tag
+ *
+ * Source: vendor/ccl/lisp-kernel/ppc-spentry.s (PPC64 branch)
+ * Target: Matt Emerson's upstream ARM64 low-tag design
+ *
+ * Register map (ARM64 low-tag):
+ *   imm0-4 = x0-x4
+ *   imm5 = nargs = x6 (TAGGED fixnum)
+ *   fn = x7 (VOLATILE in calls)
+ *   arg_w = x8, arg_x = x9, arg_y = x10, arg_z = x11
+ *   temp0-5 = x12-x17   (authoritative: arm64-constants.h .req block)
+ *   save0-3 = x19-x22
+ *   rnil = x23
+ *   tsp = x24 (REAL tsp register, PPC-style)
+ *   vsp = x25
+ *   allocptr = x26, allocbase = x27
+ *   rcontext = x28
+ *   lr = x30
+ *
+ * Low tags (bottom 4 bits):
+ *   fulltag_cons = 0b0011
+ *   fulltag_misc = 0b0100
+ *   fulltag_nil = 0b1011
+ *   tag_fixnum = 0b000 (even fixnums 0b0000, odd 0b1000)
+ *   fixnumshift = 3
+ *
+ * Object layout:
+ *   misc_header_offset = -4
+ *   misc_data_offset = 0
+ *   cons.cdr, cons.car per arm64-constants.s _struct cons
+ *
+ * STATUS: all 41 subprims carry real ported bodies (0 stubs).  Sites that
+ * depend on constants/conventions Matt has not yet defined are guarded with
+ * #error + the intended instruction in a comment (see PROPOSED-CONSTANTS
+ * below and upstream-port/MISSING-CONSTANTS-RATIFY.md).
+ */
+
+#include "arm64-constants.h"
+#include "arm64-macros.s"
+#include "arm64-globals-proposed.s"
+
+/*
+ * ===========================================================================
+ * PROPOSED-CONSTANTS (ratify with Matt)
+ * ---------------------------------------------------------------------------
+ * These are NOT in arm64-constants.h.  Values are DERIVED from the cited
+ * sources; the C runtime (arm64-exceptions.c, gc) MUST agree on the struct
+ * layouts and the uuo/udf encodings below.
+ * ===========================================================================
+ */
+
+/* Function argument-descriptor word bits (in nargs on entry to
+   destructuring_bind_inner/macro_bind).  PROPOSED: adopt the ARM32
+   layout (vendor/ccl/lisp-kernel/arm-constants.s:561-567) -- counts in
+   value bytes 0/1/2, flag bits high -- NOT the PPC bit numbering
+   (ppc-constants.s:114-117 uses big-endian bit indices 4-7).
+   MUST match the compiler's doadlword emission when Matt defines it. */
+.set mask_keyp,     (1<<25)
+.set mask_aok,      (1<<26)
+.set mask_restp,    (1<<27)
+.set mask_initopt,  (1<<29)
+
+/* Lisp error selectors.  vendor/ccl/lisp-kernel/errors.s: deferr(NAME,N)
+   expands to  NAME = N<<fixnumshift  (a boxed fixnum passed to .SPksignalerr). */
+.set XVUNBND,       (1<<fixnumshift)     /* errors.s:176 deferr(XVUNBND,1)      */
+.set XCONST,        (115<<fixnumshift)   /* errors.s:201 deferr(XCONST,115)     */
+.set XBADKEYS,      (153<<fixnumshift)   /* errors.s:214 deferr(XBADKEYS,153)   */
+.set XCALLTOOMANY,  (167<<fixnumshift)   /* errors.s:220 deferr(XCALLTOOMANY,167)*/
+.set XCALLTOOFEW,   (168<<fixnumshift)   /* errors.s:221 deferr(XCALLTOOFEW,168) */
+.set XCALLNOMATCH,  (169<<fixnumshift)   /* errors.s:222 deferr(XCALLNOMATCH,169)*/
+.set XIMPROPERLIST, (170<<fixnumshift)   /* errors.s:223 deferr(XIMPROPERLIST,170)*/
+.set XSYMNOBIND,    (178<<fixnumshift)   /* errors.s:231 deferr(XSYMNOBIND,178) */
+
+/* Kernel (uuo_interr) error codes - raw small integers, NOT shifted.
+   vendor/ccl/lisp-kernel/errors.s top block. */
+.set error_throw_tag_missing, 3          /* errors.s:23  */
+.set error_propagate_suspend, 10         /* errors.s:28  */
+
+/* fixnum 1, and the *INTERRUPT-LEVEL* special's tlb byte-index.
+   x86-constants64.s:414 fixnumone=(1<<fixnumshift); :867 = fixnumone. */
+.set fixnumone, (1<<fixnumshift)
+.set fixnum_one, fixnumone
+.set INTERRUPT_LEVEL_BINDING_INDEX, fixnumone
+
+/* tcr.flags bit for a suspend that arrived while interrupts were disabled.
+   ppc-constants64.h / x86-constants64.s TCR_FLAG_BIT_PENDING_SUSPEND. */
+.set TCR_FLAG_BIT_PENDING_SUSPEND, 7
+
+/* value-cell header: def_header(value_cell_header,1,subtag_value_cell),
+   ppc-constants64.s:368 -- same (count<<num_subtag_bits)|subtag formula as
+   arm64-constants.h's own two_digit_bignum_header; subtag_value_cell is
+   already real there (SUBTAG(fulltag_nodeheader_1,5)). */
+.set value_cell_header, (1 << num_subtag_bits) | subtag_value_cell
+
+/* T = rnil + t_offset.  DERIVED from Matt's arm64-arch.lisp:184-188
+   (canonical-nil-value #x13000+fulltag_nil, canonical-t-value
+   #x13020+fulltag_symbol); the absolute addresses are provisional but the
+   OFFSET is the ratified geometry.  Same equate as spentry-B/-D. */
+.set t_offset, ((0x13020 + fulltag_symbol) - (0x13000 + fulltag_nil))
+
+/* log2(dnode_size=16): ppc-constants64.s:37 dnode_shift = dnode_align_bits. */
+.set dnode_shift, 4
+
+/* Function codevector lives in slot 0 (CLAUDE.md "codevector @ slot 0"; PPC
+   _function.entrypoint).  Referenced through a fulltag_misc function pointer. */
+.set function.codevector, misc_data_offset
+
+/* symbol.flags bits (x86-constants64.s:707-710; low-tag => +fixnum_shift). */
+.set sym_vbit_bound,      (0+fixnumshift)
+.set sym_vbit_bound_mask, (1<<sym_vbit_bound)
+.set sym_vbit_const,      (1+fixnumshift)
+.set sym_vbit_const_mask, (1<<sym_vbit_const)
+
+/*
+ * ---------------------------------------------------------------------------
+ * PROPOSED struct layouts (ratify with Matt; C side must match)
+ * Defined with the _struct/_node/_field/_ends macros from arm64-constants.h.
+ * ---------------------------------------------------------------------------
+ */
+
+/* symbol: referenced through a fulltag_symbol pointer (see spentry-D funcall,
+   x86-constants64.s:616 `_structf(symbol,-fulltag_symbol)`).  Field order is
+   the CCL-universal pname,vcell,fcell,...,binding_index. */
+_structf symbol, -fulltag_symbol
+  _node pname
+  _node vcell
+  _node fcell
+  _node package_predicate
+  _node flags
+  _node plist
+  _node binding_index
+_endstructf
+
+/* binding frame (vstack-consed): ppc-constants64.s _struct(binding,0). */
+_struct binding, 0
+  _node link
+  _node sym
+  _node val
+_ends
+
+/* lisp_frame on the control stack: Matt's ARM-family MARKER frame, NOT
+   PPC's backlink frame (ground truth: his popj vinsn, compiler/ARM64/
+   arm64-vinsns.lisp:61-67, + subtag_lisp_frame_marker).  Same layout as
+   spentry-A/-D/-E.  Frame builds store #lisp_frame_marker at slot 0; no
+   backlink word.  fn is VOLATILE (x7) in this design, so it is saved
+   here across catch. */
+.set lisp_frame.marker, 0
+.set lisp_frame.savevsp, 8
+.set lisp_frame.savefn, 16
+.set lisp_frame.savelr, 24
+.set lisp_frame.size, 32
+
+/* temp-stack frame header: ppc-constants64.s _struct(tsp_frame,0).
+   backlink+type = 2 nodes of fixed overhead; data follows. */
+_struct tsp_frame, 0
+  _node backlink
+  _node type
+_ends
+.set tsp_frame.fixed_overhead, tsp_frame.size
+.set tsp_frame.data_offset, tsp_frame.size
+
+/* catch_frame: PPC64 layout (ppc-constants64.s _structf(catch_frame);
+   ppc-constants64.h:213), but with regs sized to this design's nsaveregs=4
+   (save0..save3) instead of PPC's 8. */
+_structf catch_frame
+  _node catch_tag           /* unbound_marker => unwind-protect, else catch */
+  _node link                /* previous catch frame                         */
+  _node mvflag              /* 0 => single value, fixnum 1 => multiple       */
+  _node csp                 /* saved control-stack lisp_frame pointer        */
+  _node db_link             /* special-binding chain head                    */
+  _field regs, (nsaveregs*node_size)  /* save0..save3                        */
+  _node xframe              /* exception-frame chain                         */
+  _node nfp                 /* numeric/foreign frame pointer                 */
+_endstructf
+
+/*
+ * ---------------------------------------------------------------------------
+ * Local helper macros (this design has no ppc-macros.s / arm64-uuo.s in scope)
+ * ---------------------------------------------------------------------------
+ */
+
+/* vstack push/pop (grows toward lower addresses). */
+.macro vpush1 reg
+        str \reg, [vsp, #-node_size]!
+.endm
+.macro vpop1 reg
+        ldr \reg, [vsp], #node_size
+.endm
+
+/* nargs is a BOXED fixnum (== byte count of value block on the vstack). */
+.macro set_nargs n
+        mov nargs, #((\n)<<fixnumshift)
+.endm
+
+/* GPR numbers, for encoding a register operand into a udf immediate. */
+
+/* UUO / trap encodings.  CANONICAL: arm64-asm.lisp:435-450 (Matt's active
+   layer) = `udf #imm16`, low 3 bits = format (7 nullary, 1 unary
+   arg-count, 2 binary).  PROPOSED extensions (full namespace doc:
+   spentry-A's trap block, BINDING): fmt 3 = unary-misc, reg in 7:3, sub
+   in 15:8 (0 not_callable, 1 no_throw_tag, 2 tlb_too_small, 3 unbound,
+   >= 4 = the errors.s errnum: stack_overflow/too_many_values/
+   propagate_suspend here); nullary sub 4 = take-deferred-interrupt.
+   arm64-exceptions.c must decode these.  \gpr is a gpr_* number. */
+/* kernel trap error codes (errors.s:25/27) */
+.set error_stack_overflow,   5
+.set error_too_many_values,  7
+/* signal a deferred/pending suspend (ppc-macros.s suspend_now).
+   unary-misc sub = error_propagate_suspend (10); reg field unused (x0). */
+
+/* control-stack lisp_frame build/discard (MARKER frame: \tmp carries the
+   marker constant, not a backlink).  savelr gets \clpc (catch cleanup
+   PC), savefn gets the volatile fn. */
+.macro build_catch_lisp_frame tmp, clpc
+        sub sp, sp, #lisp_frame.size
+        mov \tmp, #lisp_frame_marker
+        str \tmp, [sp, #lisp_frame.marker]
+        str vsp, [sp, #lisp_frame.savevsp]
+        str fn, [sp, #lisp_frame.savefn]
+        str \clpc, [sp, #lisp_frame.savelr]
+.endm
+.macro discard_lisp_frame
+        add sp, sp, #lisp_frame.size
+.endm
+
+/* temp-stack allocation (real tsp register, PPC discipline).
+   ppc-macros.s TSP_Alloc_Fixed_Unboxed / Set_TSP_Frame_{Un,}boxed. */
+.macro tsp_alloc_fixed_unboxed nbytes, tmp
+        mov \tmp, tsp
+        sub tsp, tsp, #((\nbytes) + tsp_frame.data_offset)
+        str \tmp, [tsp, #tsp_frame.backlink]
+        str tsp, [tsp, #tsp_frame.type]         /* non-zero => unboxed */
+.endm
+.macro set_tsp_frame_boxed
+        str xzr, [tsp, #tsp_frame.type]         /* zero => boxed (GC-scanned) */
+.endm
+/* pop one tsp frame (ppc-macros.s unlink(tsp)). */
+.macro tsp_unlink
+        ldr tsp, [tsp, #tsp_frame.backlink]
+.endm
+
+/* save/restore the boxed NVRs into/from a catch frame's regs[] (save0..save3).
+   catch_frame is a fulltag_misc-biased _structf, so .regs = 44 is only
+   4-aligned -- stp/ldp (which need an 8-scaled imm7) cannot be used; single
+   str/ldr take any byte offset. */
+.macro save_catch_regs cf
+        str save0, [\cf, #(catch_frame.regs + 0*node_size)]
+        str save1, [\cf, #(catch_frame.regs + 1*node_size)]
+        str save2, [\cf, #(catch_frame.regs + 2*node_size)]
+        str save3, [\cf, #(catch_frame.regs + 3*node_size)]
+.endm
+.macro restore_catch_regs cf
+        ldr save0, [\cf, #(catch_frame.regs + 0*node_size)]
+        ldr save1, [\cf, #(catch_frame.regs + 1*node_size)]
+        ldr save2, [\cf, #(catch_frame.regs + 2*node_size)]
+        ldr save3, [\cf, #(catch_frame.regs + 3*node_size)]
+.endm
+
+/* Poll for a deferred interrupt (ppc-macros.s check_pending_interrupt).
+   Clobbers nargs; callers that must preserve it save/restore around this. */
+.macro check_pending_interrupt
+        ldr nargs, [rcontext, #tcr.tlb_pointer]
+        ldr nargs, [nargs, #INTERRUPT_LEVEL_BINDING_INDEX]
+        cmp nargs, #0
+        b.lt 8887f                       /* interrupts disabled: done */
+        b.gt 8886f                       /* level>0: cannot be pending here */
+        ldr nargs, [rcontext, #tcr.interrupt_pending]
+        cbz nargs, 8887f
+8886:   uuo_interrupt_now                /* uuo_misc 4 at pin 9c61574 (was 3 @115b7aa, before he
+                                            inserted uuo_debug_trap at 3) */
+8887:
+.endm
+
+/*
+ * ===========================================================================
+ * CATCH/THROW/UNWIND SUBPRIMS
+ * ===========================================================================
+ */
+
+/* mkcatch (ppc-macros.s:481-517).  Build a catch/unwind frame on the temp
+   stack, with the caller's continuation saved in a control-stack lisp_frame.
+   In: arg_z = catch tag, imm2 = mvflag (0 or fixnum 1).  Clobbers imm0-5 and
+   nargs ONLY; preserves save0..save3 (stored into the frame) and ALL temp
+   regs -- PPC parity: ppc-macros.s mkcatch scratches imm0-4/loc_pc/nargs,
+   and callers (toplevel_loop, compiled catch) keep the funcall target in
+   temp0 across the _SPmkcatch* call (16j boot: temp0-as-scratch clobbered
+   the toplevel function -> udf #49 in _SPfuncall).
+   PROPOSED: the cleanup-PC recovery assumes Matt's arm64 compiler emits a
+   forward `b <cleanup>` immediately after the `bl _SPmkcatch*`, exactly as the
+   PPC backend does. */
+        .macro mkcatch
+        ldr w5, [lr]                   /* imm5: the forward branch insn       */
+        ldr imm0, [rcontext, #tcr.catch_top]
+        sbfx imm5, imm5, #0, #26       /* B imm26, sign-extended              */
+        add imm5, lr, imm5, lsl #2     /* cleanup PC = lr + imm26*4           */
+        add lr, lr, #4                 /* normal return addr: skip the branch */
+        build_catch_lisp_frame imm4, imm5     /* csp frame: fn,cleanupPC,vsp  */
+        ldr imm3, [rcontext, #tcr.xframe]
+        ldr imm1, [rcontext, #tcr.db_link]
+        tsp_alloc_fixed_unboxed catch_frame.size, imm4
+        add nargs, tsp, #(tsp_frame.data_offset + fulltag_misc)  /* tagged cf
+                                          (PPC uses nargs for this too)       */
+        mov imm4, #((catch_frame.element_count<<num_subtag_bits) | subtag_catch_frame)
+        str imm4, [nargs, #catch_frame.header]
+        str arg_z, [nargs, #catch_frame.catch_tag]
+        str imm0, [nargs, #catch_frame.link]    /* previous catch_top          */
+        str imm2, [nargs, #catch_frame.mvflag]
+        mov imm4, sp
+        str imm4, [nargs, #catch_frame.csp]
+        str imm1, [nargs, #catch_frame.db_link]
+        save_catch_regs nargs
+        str imm3, [nargs, #catch_frame.xframe]
+        ldr imm0, [rcontext, #tcr.nfp]
+        str imm0, [nargs, #catch_frame.nfp]
+        set_tsp_frame_boxed
+        str nargs, [rcontext, #tcr.catch_top]
+        set_nargs 0
+        .endm
+
+/* ported from ppc-spentry.s:61-64.  Single-value catch; tag in arg_z. */
+spentry mkcatch1v
+        mov imm2, #0
+        mkcatch
+        ret
+endsp mkcatch1v
+
+/* ported from ppc-spentry.s:72-75.  Multiple-value catch; tag in arg_z. */
+spentry mkcatchmv
+        mov imm2, #fixnum_one
+        mkcatch
+        ret
+endsp mkcatchmv
+
+/* ported from ppc-spentry.s:66-70.  Unwind-protect frame: tag = unbound_marker,
+   mvflag = fixnum 1. */
+spentry mkunwind
+        mov arg_z, #unbound_marker
+        mov imm2, #fixnum_one
+        mkcatch
+        ret
+endsp mkunwind
+
+/* ported from ppc-spentry.s:80-162 (PPC64 branch) */
+/* Throw to a catch tag. Caller has pushed tag and 0 or more values; nargs = nvalues */
+spentry throw
+        /* ppc-spentry.s:80-162.  Caller pushed tag then 0+ values; nargs=nvalues. */
+        ldr imm1, [rcontext, #tcr.catch_top]
+        mov imm0, #0                    /* fixnum count of intervening frames  */
+        ldr temp0, [vsp, nargs]         /* the throw tag (above the values)     */
+        cbz imm1, 9f                    /* no catch frames -> tag not found     */
+1:      /* _throw_loop */
+        ldr temp1, [imm1, #catch_frame.catch_tag]
+        mov imm2, imm1                  /* imm2 = candidate target frame        */
+        ldr imm1, [imm1, #catch_frame.link]
+        cmp temp0, temp1
+        b.eq 2f                         /* _throw_found                         */
+        add imm0, imm0, #fixnum_one
+        cbnz imm1, 1b
+        b 9f                            /* end of chain -> tag not found        */
+2:      /* _throw_found: imm2 = target frame, imm0 = intervening count          */
+        mov fn, #0                      /* GC-safe fn across the nthrow call     */
+        add imm1, vsp, nargs
+        sub imm1, imm1, #node_size      /* imm1 -> top (last) value slot        */
+        ldr temp1, [imm2, #catch_frame.mvflag]
+        cbnz temp1, 4f                  /* multiple-value receiver              */
+        cmp nargs, #0                   /* single-value receiver                */
+        set_nargs 1
+        b.eq 3f                         /* no values thrown -> default NIL      */
+        mov vsp, imm1                   /* keep only the top value              */
+        b 4f
+3:      /* _throw_default_1_val */
+        vpush1 rnil
+4:      /* _throw_all_values */
+        bl _SPnthrowvalues
+        ldr imm3, [rcontext, #tcr.catch_top]
+        ldr imm1, [rcontext, #tcr.db_link]
+        ldr imm0, [imm3, #catch_frame.db_link]
+        sub tsp, imm3, #(tsp_frame.fixed_overhead + fulltag_misc)
+        cmp imm0, imm1
+        b.eq 5f                         /* _throw_dont_unbind                   */
+        bl _SPunbind_to                 /* imm0 = target db_link; keeps nargs   */
+5:      /* _throw_dont_unbind */
+        ldr imm4, [imm3, #catch_frame.mvflag]
+        add imm0, vsp, nargs
+        ldr imm1, [imm3, #catch_frame.csp]
+        ldr imm1, [imm1, #lisp_frame.savevsp]
+        cbnz imm4, 6f                   /* _throw_multiple                      */
+        ldr arg_z, [imm0, #-node_size]  /* single value into arg_z             */
+        b 8f
+6:      /* _throw_multiple */
+        cmp nargs, #0
+        b.eq 8f
+        mov imm2, nargs
+7:      /* _throw_mvloop: copy nargs values down onto the catcher's vsp        */
+        sub imm2, imm2, #fixnum_one
+        ldr temp0, [imm0, #-node_size]!
+        str temp0, [imm1, #-node_size]!
+        cmp imm2, #0
+        b.gt 7b
+8:      /* _throw_pushed_values */
+        mov vsp, imm1
+        ldr imm1, [imm3, #catch_frame.xframe]
+        str imm1, [rcontext, #tcr.xframe]
+        ldr imm1, [imm3, #catch_frame.nfp]
+        str imm1, [rcontext, #tcr.nfp]
+        ldr temp0, [imm3, #catch_frame.csp]
+        mov sp, temp0
+        ldr fn, [sp, #lisp_frame.savefn]
+        ldr temp4, [sp, #lisp_frame.savelr]  /* catch exit / cleanup PC        */
+        discard_lisp_frame
+        mov lr, temp4
+        restore_catch_regs imm3
+        ldr imm3, [imm3, #catch_frame.link]
+        str imm3, [rcontext, #tcr.catch_top]
+        tsp_unlink
+        ret
+9:      /* _throw_tag_not_found */
+        uuo_error_no_throw_tag temp0
+        str temp0, [vsp, nargs]         /* restore tag; retry after handler     */
+        b _SPthrow
+endsp throw
+
+/* ported from ppc-spentry.s:166-284 (PPC64 branch) */
+/* Unwind N frames (imm0 = count), processing unwind-protects */
+/* N multiple values atop vstack, nargs = count */
+/* Variable-size boxed tsp frame (ppc-macros.s TSP_Alloc_Var_Boxed_nz).
+   \size = 16-aligned data byte count (in a reg).  \p,\e scratch. */
+        .macro tsp_alloc_var_boxed_nz size, p, e
+        mov \p, tsp
+        sub tsp, tsp, \size
+        str \p, [tsp, #tsp_frame.backlink]
+        /* zero data words [data_offset .. backlink) so GC sees clean slots */
+        add \e, tsp, \size                    /* end = old tsp                */
+        add \p, tsp, #tsp_frame.data_offset
+        /* \@-unique labels: a bare 1:/2: inside a macro CAPTURES callers'
+           1f/2f branches that cross the expansion (the 16m5t makes128/
+           Misc_Alloc_Fixed class, patch 0011) */
+.Ltavb\@:
+        cmp \p, \e
+        b.hs .Ltavbdone\@
+        str xzr, [\p], #node_size
+        b .Ltavb\@
+.Ltavbdone\@:
+        str xzr, [tsp, #tsp_frame.type]       /* boxed                        */
+        .endm
+
+spentry nthrowvalues
+        /* ppc-spentry.s:166-284.  N values atop the vstack, nargs=count. */
+        mov imm1, #1
+        mov imm4, imm0                  /* imm4 = frame countdown (fixnum)      */
+        str imm1, [rcontext, #tcr.unwinding]
+1:      /* _nthrowv_nextframe */
+        subs imm4, imm4, #fixnum_one
+        ldr temp0, [rcontext, #tcr.catch_top]
+        ldr imm1, [rcontext, #tcr.db_link]
+        b.lt 8f                         /* countdown < 0 -> done                */
+        ldr imm0, [temp0, #catch_frame.db_link]
+        ldr imm3, [temp0, #catch_frame.link]
+        str imm3, [rcontext, #tcr.catch_top]
+        ldr temp1, [temp0, #catch_frame.catch_tag]
+        ldr imm3, [temp0, #catch_frame.xframe]
+        str imm3, [rcontext, #tcr.xframe]
+        ldr imm3, [temp0, #catch_frame.nfp]
+        str imm3, [rcontext, #tcr.nfp]
+        ldr imm2, [temp0, #catch_frame.csp]
+        mov sp, imm2                    /* sp = the frame's saved lisp_frame    */
+        cmp imm0, imm1                  /* special bindings to undo?            */
+        b.eq 2f
+        mov temp4, lr
+        bl _SPunbind_to                 /* imm0 = target db_link                */
+        mov lr, temp4
+2:      /* _nthrowv_dont_unbind */
+        cmp temp1, #unbound_marker      /* unwind-protect frame?                */
+        b.eq 4f
+        /* --- catch frame --- */
+        cmp imm4, #0
+        b.ne 3f                         /* not the last frame -> just discard   */
+        ldr imm0, [sp, #lisp_frame.savevsp]
+        str xzr, [sp, #lisp_frame.savevsp]  /* stack-overflow marker            */
+        add imm1, vsp, nargs
+        mov imm2, nargs
+        b 32f
+31:     /* _nthrowv_push_loop: move values down onto catcher's vstack           */
+        ldr temp1, [imm1, #-node_size]!
+        str temp1, [imm0, #-node_size]!
+32:     cmp imm2, #0
+        sub imm2, imm2, #fixnum_one
+        b.ne 31b
+        mov vsp, imm0
+        restore_catch_regs temp0
+3:      /* _nthrowv_skip */
+        sub tsp, temp0, #(tsp_frame.fixed_overhead + fulltag_misc)
+        tsp_unlink
+        discard_lisp_frame
+        b 1b
+4:      /* _nthrowv_do_unwind: run the cleanup form with values preserved      */
+        ldr imm3, [temp0, #catch_frame.xframe]
+        str imm3, [rcontext, #tcr.xframe]
+        ldr imm3, [temp0, #catch_frame.nfp]
+        str imm3, [rcontext, #tcr.nfp]
+        restore_catch_regs temp0
+        sub tsp, temp0, #(tsp_frame.fixed_overhead + fulltag_misc)
+        tsp_unlink
+        ldr temp4, [sp, #lisp_frame.savelr]   /* cleanup code address          */
+        ldr nfn, [sp, #lisp_frame.savefn]     /* cleanup's own fn              */
+        str fn, [sp, #lisp_frame.savefn]      /* stash caller fn in the frame  */
+        mov fn, nfn
+        str lr, [sp, #lisp_frame.savelr]      /* stash our return in the frame */
+        /* allocate a boxed tsp frame: overhead + nargs bytes + 2 nodes        */
+        add imm0, nargs, #(tsp_frame.fixed_overhead + (2*node_size) + (dnode_size-1))
+        and imm0, imm0, #~(dnode_size-1)
+        tsp_alloc_var_boxed_nz imm0, imm1, imm2
+        mov imm2, nargs
+        add imm1, vsp, nargs            /* imm1 = top of value block            */
+        add imm0, tsp, #tsp_frame.data_offset
+        str nargs, [imm0]               /* data[0] = value count                */
+        b 42f
+41:     /* _nthrowv_tpushloop: stash values into the tsp frame                  */
+        ldr temp0, [imm1, #-node_size]!
+        str temp0, [imm0, #node_size]!
+        sub imm2, imm2, #fixnum_one
+42:     cmp imm2, #0
+        b.ne 41b
+        str imm4, [imm0, #node_size]!   /* stash throw count after the values   */
+        ldr vsp, [sp, #lisp_frame.savevsp]
+        str xzr, [rcontext, #tcr.unwinding]
+        blr temp4                       /* call the cleanup form                */
+        mov imm1, #1
+        add imm0, tsp, #tsp_frame.data_offset
+        str imm1, [rcontext, #tcr.unwinding]
+        ldr fn, [sp, #lisp_frame.savefn]
+        ldr temp4, [sp, #lisp_frame.savelr]
+        discard_lisp_frame
+        mov lr, temp4
+        ldr nargs, [imm0]               /* restore value count                  */
+        mov imm2, nargs
+        b 44f
+43:     /* _nthrowv_tpoploop: restore values onto the vstack                    */
+        ldr temp0, [imm0, #node_size]!
+        vpush1 temp0
+        sub imm2, imm2, #fixnum_one
+44:     cmp imm2, #0
+        b.ne 43b
+        ldr imm4, [imm0, #node_size]    /* restore throw count                  */
+        tsp_unlink
+        b 1b
+8:      /* _nthrowv_done */
+        str xzr, [rcontext, #tcr.unwinding]
+        mov imm4, nargs                 /* preserve nargs across the poll       */
+        check_pending_interrupt
+        mov nargs, imm4
+        ret
+endsp nthrowvalues
+
+/* ported from ppc-spentry.s:289-363 (PPC64 branch) */
+/* Single-value version of nthrowvalues. Value in arg_z */
+spentry nthrow1value
+        /* ppc-spentry.s:289-363.  Single value in arg_z; nargs unused. */
+        mov imm1, #1                    /* ppc:290 */
+        mov imm4, imm0                  /* ppc:291  imm4 = frame countdown       */
+        str imm1, [rcontext, #tcr.unwinding]  /* ppc:292 */
+1:      /* ppc:293 _nthrow1v_nextframe */
+        subs imm4, imm4, #fixnum_one    /* ppc:294-295 (cr1)                     */
+        ldr temp0, [rcontext, #tcr.catch_top]  /* ppc:296 */
+        ldr imm1, [rcontext, #tcr.db_link]     /* ppc:297 */
+        set_nargs 1                     /* ppc:298 (flag-preserving)             */
+        b.lt 8f                         /* ppc:299 blt cr1 -> done               */
+        ldr imm3, [temp0, #catch_frame.link]      /* ppc:300 */
+        ldr imm0, [temp0, #catch_frame.db_link]   /* ppc:301 */
+        str imm3, [rcontext, #tcr.catch_top]      /* ppc:303 */
+        ldr imm3, [temp0, #catch_frame.xframe]    /* ppc:304 */
+        ldr temp1, [temp0, #catch_frame.catch_tag]/* ppc:305 */
+        ldr temp2, [temp0, #catch_frame.nfp]      /* ppc:306 */
+        str imm3, [rcontext, #tcr.xframe]         /* ppc:308 */
+        str temp2, [rcontext, #tcr.nfp]           /* ppc:309 */
+        ldr imm2, [temp0, #catch_frame.csp]       /* ppc:310 (sp via scratch)    */
+        mov sp, imm2
+        cmp imm0, imm1                  /* ppc:302 cr0, at its branch            */
+        b.eq 2f                         /* ppc:311 beq cr0 -> dont_unbind        */
+        mov temp4, lr                   /* ppc:312 mflr                          */
+        bl _SPunbind_to                 /* ppc:313 (clobbers flags)              */
+        mov lr, temp4                   /* ppc:314 mtlr                          */
+2:      /* ppc:315 _nthrow1v_dont_unbind */
+        cmp temp1, #unbound_marker      /* ppc:307 cr7, recomputed post-unbind   */
+        b.eq 4f                         /* ppc:316 beq cr7 -> do_unwind          */
+        cmp imm4, #0                    /* ppc:295 cr1, recomputed               */
+        b.ne 3f                         /* ppc:318 bne cr1 -> skip               */
+        ldr vsp, [sp, #lisp_frame.savevsp]  /* ppc:319 */
+        restore_catch_regs temp0        /* ppc:320 */
+3:      /* ppc:321 _nthrow1v_skip */
+        sub tsp, temp0, #(tsp_frame.fixed_overhead + fulltag_misc)  /* ppc:322 */
+        tsp_unlink                      /* ppc:323 */
+        discard_lisp_frame              /* ppc:324 */
+        b 1b                            /* ppc:325 */
+4:      /* ppc:326 _nthrow1v_do_unwind */
+        restore_catch_regs temp0        /* ppc:332 */
+        sub tsp, temp0, #(tsp_frame.fixed_overhead + fulltag_misc)  /* ppc:333 */
+        tsp_unlink                      /* ppc:334 */
+        ldr temp4, [sp, #lisp_frame.savelr]  /* ppc:335,337 cleanup PC -> temp4  */
+        ldr nfn, [sp, #lisp_frame.savefn]    /* ppc:336 cleanup's own fn         */
+        str fn, [sp, #lisp_frame.savefn]     /* ppc:338 stash caller fn          */
+        mov fn, nfn                     /* ppc:340 */
+        str lr, [sp, #lisp_frame.savelr]     /* ppc:339,341 stash our return     */
+        /* fixed boxed tsp frame: value + throw count = 2 nodes (ppc:342)        */
+        tsp_alloc_fixed_unboxed 2*node_size, imm0
+        set_tsp_frame_boxed
+        str arg_z, [tsp, #tsp_frame.data_offset]                /* ppc:343 */
+        str imm4, [tsp, #(tsp_frame.data_offset + node_size)]   /* ppc:344 */
+        ldr vsp, [sp, #lisp_frame.savevsp]   /* ppc:345 */
+        str xzr, [rcontext, #tcr.unwinding]  /* ppc:346 */
+        blr temp4                       /* ppc:347 bctrl -> cleanup form         */
+        mov imm1, #1                    /* ppc:348 */
+        ldr arg_z, [tsp, #tsp_frame.data_offset]                /* ppc:349 */
+        str imm1, [rcontext, #tcr.unwinding] /* ppc:350 */
+        ldr imm4, [tsp, #(tsp_frame.data_offset + node_size)]   /* ppc:351 */
+        ldr fn, [sp, #lisp_frame.savefn]     /* ppc:352 */
+        ldr temp4, [sp, #lisp_frame.savelr]  /* ppc:353 */
+        discard_lisp_frame              /* ppc:354 */
+        mov lr, temp4                   /* ppc:355 */
+        tsp_unlink                      /* ppc:356 */
+        b 1b                            /* ppc:357 */
+8:      /* ppc:358 _nthrow1v_done.  nargs is dead here, so the poll may clobber it. */
+        str xzr, [rcontext, #tcr.unwinding]  /* ppc:359 */
+        check_pending_interrupt         /* ppc:362 */
+        ret                             /* ppc:363 */
+endsp nthrow1value
+
+/*
+ * ===========================================================================
+ * SPECIAL BINDING SUBPRIMS
+ * ===========================================================================
+ */
+
+/* ported from ppc-spentry.s:367-386 (PPC64 branch) */
+/* Bind symbol arg_y to value arg_z */
+spentry bind
+        ldr imm1, [arg_y, #symbol.binding_index]
+        ldr imm0, [rcontext, #tcr.tlb_limit]
+        cmp imm0, imm1                 /* trlle: trap unless limit > index */
+        b.hi 1f
+        uuo_error_tlb_too_small imm1
+1:
+        cmp imm1, #0                   /* binding_index 0 => not special */
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+        ldr imm0, [rcontext, #tcr.db_link]
+        ldr temp1, [imm2, imm1]        /* old value at tlb[index] */
+        b.eq 9f
+        vpush1 temp1                   /* binding frame: old value */
+        vpush1 imm1                    /*               tlb index  */
+        vpush1 imm0                    /*               prev db_link */
+        str arg_z, [imm2, imm1]        /* tlb[index] = new value */
+        str vsp, [rcontext, #tcr.db_link]
+        ret
+9:
+        mov arg_z, arg_y
+        mov arg_y, #XSYMNOBIND
+        set_nargs 2
+        b _SPksignalerr
+endsp bind
+
+/* ported from ppc-spentry.s:389-411 (PPC64 branch) */
+/* Bind symbol arg_z to its current value */
+spentry bind_self
+        ldr imm1, [arg_z, #symbol.binding_index]
+        ldr imm0, [rcontext, #tcr.tlb_limit]
+        cmp imm1, #0
+        b.eq 9f
+        cmp imm0, imm1                 /* trlle: trap unless limit > index */
+        b.hi 1f
+        uuo_error_tlb_too_small imm1
+1:
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+        ldr imm0, [rcontext, #tcr.db_link]
+        ldr temp1, [imm2, imm1]        /* current tlb value */
+        mov temp0, temp1
+        cmp temp1, #no_thread_local_binding_marker
+        b.ne 2f
+        ldr temp0, [arg_z, #symbol.vcell]  /* no per-thread value: use vcell */
+2:
+        vpush1 temp1                   /* old tlb contents */
+        vpush1 imm1                    /* tlb index */
+        vpush1 imm0                    /* prev db_link */
+        str temp0, [imm2, imm1]
+        str vsp, [rcontext, #tcr.db_link]
+        ret
+9:
+        mov arg_y, #XSYMNOBIND
+        set_nargs 2
+        b _SPksignalerr
+endsp bind_self
+
+/* ported from ppc-spentry.s:414-432 (PPC64 branch) */
+/* Bind symbol arg_z to NIL */
+spentry bind_nil
+        /* symbol in arg_z; bind it to NIL by reusing .SPbind
+           (symbol->arg_y, value(nil)->arg_z). */
+        mov arg_y, arg_z
+        mov arg_z, rnil
+        b _SPbind
+endsp bind_nil
+
+/* ported from ppc-spentry.s:436-458 (PPC64 branch) */
+/* Bind symbol arg_z to its current value; trap if unbound */
+spentry bind_self_boundp_check
+        ldr imm1, [arg_z, #symbol.binding_index]
+        ldr imm0, [rcontext, #tcr.tlb_limit]
+        cmp imm1, #0
+        b.eq 9f
+        cmp imm0, imm1                 /* trlle: trap unless limit > index */
+        b.hi 1f
+        uuo_error_tlb_too_small imm1
+1:
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+        ldr imm0, [rcontext, #tcr.db_link]
+        ldr temp1, [imm2, imm1]
+        mov temp0, temp1
+        cmp temp1, #no_thread_local_binding_marker
+        b.ne 2f
+        ldr temp0, [arg_z, #symbol.vcell]
+2:
+        cmp temp0, #unbound_marker      /* treqi: trap if still unbound */
+        b.ne 3f
+        uuo_error_unbound arg_z         /* macro fixed upstream @ c9e7ffb */
+3:
+        vpush1 temp1                   /* old tlb contents */
+        vpush1 imm1                    /* tlb index */
+        vpush1 imm0                    /* prev db_link */
+        str temp0, [imm2, imm1]
+        str vsp, [rcontext, #tcr.db_link]
+        ret
+9:
+        mov arg_y, #XSYMNOBIND
+        set_nargs 2
+        b _SPksignalerr
+endsp bind_self_boundp_check
+
+/* ported from ppc-spentry.s:938-953 (PPC64 branch) */
+/* Set symbol value. Non-null symbol in arg_y, new value in arg_z */
+/* NOTE: Line number search for setqsym in ppc-spentry.s */
+spentry setqsym
+        /* ppc-spentry.s:938-945.  Non-null symbol in arg_y, new value in arg_z.
+           Constant symbol => error; otherwise the real work is in .SPspecset. */
+        ldr imm0, [arg_y, #symbol.flags]
+        tst imm0, #sym_vbit_const_mask
+        b.eq _SPspecset
+        mov arg_z, arg_y
+        mov arg_y, #XCONST
+        set_nargs 2
+        b _SPksignalerr
+endsp setqsym
+
+/*
+ * ===========================================================================
+ * UNBINDING SUBPRIMS
+ * ===========================================================================
+ */
+
+/* ported from ppc-spentry.s:6902-6910 (PPC64 branch) */
+/* Unbind one binding frame */
+spentry unbind
+        ldr imm1, [rcontext, #tcr.db_link]
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+        ldr imm3, [imm1, #binding.sym]
+        ldr temp1, [imm1, #binding.val]
+        ldr imm1, [imm1, #binding.link]
+        str temp1, [imm2, imm3]
+        str imm1, [rcontext, #tcr.db_link]
+        ret
+endsp unbind
+
+/* ported from ppc-spentry.s:6912-6923 (PPC64 branch) */
+/* Unbind imm0 binding frames (imm0 is unboxed count, NOT a fixnum) */
+spentry unbind_n
+        ldr imm1, [rcontext, #tcr.db_link]
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+1:
+        sub imm0, imm0, #1
+        ldr imm3, [imm1, #binding.sym]
+        ldr temp1, [imm1, #binding.val]
+        cmp imm0, #0
+        ldr imm1, [imm1, #binding.link]
+        str temp1, [imm2, imm3]
+        b.ne 1b
+        str imm1, [rcontext, #tcr.db_link]
+        ret
+endsp unbind_n
+
+/* ported from ppc-spentry.s:6928-6938 (PPC64 branch) */
+/* Unbind back to db_link value in imm0. Clobbers imm1, imm2, imm5, arg_x, arg_y */
+spentry unbind_to
+        /* Unbind until db_link == imm0.  Clobbers imm1,imm2,arg_x,arg_y.
+           NOTE: unlike PPC (imm5 scratch), we must NOT touch imm5==nargs,
+           because .SPthrow relies on nargs surviving this call. */
+        ldr imm1, [rcontext, #tcr.db_link]
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+1:
+        ldr arg_x, [imm1, #binding.sym]
+        ldr arg_y, [imm1, #binding.val]
+        ldr imm1, [imm1, #binding.link]
+        cmp imm0, imm1
+        str arg_y, [imm2, arg_x]
+        b.ne 1b
+        str imm1, [rcontext, #tcr.db_link]
+        ret
+endsp unbind_to
+
+/* ported from ppc-spentry.s:6963-6979 (PPC64 branch) */
+/* Bind *INTERRUPT-LEVEL* to 0; check for pending interrupt if old value was negative */
+spentry bind_interrupt_level_0
+        /* ppc:6964-6979.  Bind *INTERRUPT-LEVEL* to 0; poll for a deferred
+           interrupt if the old level was negative. */
+        ldr imm4, [rcontext, #tcr.tlb_pointer]              /* ppc:6964 */
+        ldr temp0, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:6965 old level */
+        ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:6966 */
+        mov imm3, #INTERRUPT_LEVEL_BINDING_INDEX            /* ppc:6968 */
+        vpush1 temp0                    /* ppc:6969 binding frame: old value */
+        vpush1 imm3                     /* ppc:6970               tlb index   */
+        vpush1 imm1                     /* ppc:6971               prev db_link*/
+        str xzr, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]     /* ppc:6972 tlb[il]=0 */
+        str vsp, [rcontext, #tcr.db_link]                   /* ppc:6973 */
+        cmp temp0, #0                   /* ppc:6967 cmpri(temp0,0) */
+        b.eq 2f                         /* ppc:6974 beqlr -> old level 0, return */
+        mov nargs, temp0                /* ppc:6975 mr nargs,temp0 */
+        cmp temp0, #0                   /* recompute (ARM64 single NZCV) for bgt */
+        b.gt 1f                         /* ppc:6976 bgt 1f -> old level>0, skip load */
+        ldr nargs, [rcontext, #tcr.interrupt_pending]       /* ppc:6977 */
+1:      cmp nargs, #0                   /* ppc:6978 trgti(nargs,0): trap if nargs>0 */
+        b.le 2f
+        uuo_interrupt_now                /* uuo_misc 4 at pin 9c61574 (was 3 @115b7aa, before he
+                                            inserted uuo_debug_trap at 3) */
+2:      ret                             /* ppc:6979 blr */
+endsp bind_interrupt_level_0
+
+/* ported from ppc-spentry.s:6983-6994 (PPC64 branch) */
+/* Bind *INTERRUPT-LEVEL* to -1 (disable interrupts) */
+spentry bind_interrupt_level_m1
+        /* ppc:6984-6994.  Bind *INTERRUPT-LEVEL* to -1 (disable interrupts). */
+        mov imm2, #(-fixnumone)         /* ppc:6984 li imm2,-fixnumone */
+        mov imm3, #INTERRUPT_LEVEL_BINDING_INDEX            /* ppc:6985 */
+        ldr imm4, [rcontext, #tcr.tlb_pointer]              /* ppc:6986 */
+        ldr temp0, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:6987 old level */
+        ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:6988 */
+        vpush1 temp0                    /* ppc:6989 binding frame: old value */
+        vpush1 imm3                     /* ppc:6990               tlb index   */
+        vpush1 imm1                     /* ppc:6991               prev db_link*/
+        str imm2, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]    /* ppc:6992 tlb[il]=-1 */
+        str vsp, [rcontext, #tcr.db_link]                   /* ppc:6993 */
+        ret                             /* ppc:6994 blr */
+endsp bind_interrupt_level_m1
+
+/* ported from ppc-spentry.s:6999-7011 (PPC64 branch) */
+/* Bind *INTERRUPT-LEVEL* to value in arg_z */
+spentry bind_interrupt_level
+        /* ppc:7000-7011.  Bind *INTERRUPT-LEVEL* to arg_z; if arg_z==0, tail to
+           _SPbind_interrupt_level_0. */
+        cmp arg_z, #0                   /* ppc:7000 cmpri(arg_z,0) */
+        mov imm3, #INTERRUPT_LEVEL_BINDING_INDEX            /* ppc:7001 */
+        ldr imm4, [rcontext, #tcr.tlb_pointer]              /* ppc:7002 */
+        ldr temp0, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7003 old level */
+        ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:7004 */
+        b.eq _SPbind_interrupt_level_0  /* ppc:7005 beq -> bind to 0 */
+        vpush1 temp0                    /* ppc:7006 binding frame: old value */
+        vpush1 imm3                     /* ppc:7007               tlb index   */
+        vpush1 imm1                     /* ppc:7008               prev db_link*/
+        str arg_z, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7009 tlb[il]=arg_z */
+        str vsp, [rcontext, #tcr.db_link]                   /* ppc:7010 */
+        ret                             /* ppc:7011 blr */
+endsp bind_interrupt_level
+
+/* ported from ppc-spentry.s:7018-7047 (PPC64 branch) */
+/* Unbind *INTERRUPT-LEVEL*; check for pending interrupt if transitioning negative->non-negative */
+spentry unbind_interrupt_level
+        /* ppc:7019-7047.  Unbind *INTERRUPT-LEVEL*; poll for a pending interrupt
+           if the level goes from negative to non-negative.  nargs is often live,
+           so save/restore it around any poll. */
+        ldr imm0, [rcontext, #tcr.flags]                    /* ppc:7019 */
+        ldr imm2, [rcontext, #tcr.tlb_pointer]              /* ppc:7020 */
+        tst imm0, #(1<<TCR_FLAG_BIT_PENDING_SUSPEND)        /* ppc:7021 andi. cr0 */
+        ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:7022 */
+        ldr temp1, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7023 old level */
+        b.ne 3f                         /* ppc:7024 bne -> missed-suspend path */
+1:      /* ppc:7025 (PPC label 0).  temp1=old level, imm1=binding, imm2=tlb_ptr. */
+        mov temp0, temp1                /* preserve old level for the cr1 test  */
+        ldr temp1, [imm1, #binding.val] /* ppc:7026 restored (new) level         */
+        ldr imm1, [imm1, #binding.link] /* ppc:7027 new db_link                  */
+        str temp1, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7029 */
+        str imm1, [rcontext, #tcr.db_link]                  /* ppc:7030 */
+        cmp temp0, #0                   /* ppc:7025 cmpri(cr1,old,0), adjacent    */
+        b.ge 2f                         /* ppc:7031 bgelr cr1: old>=0 -> return   */
+        cmp temp1, #0                   /* ppc:7028 cmpri(cr0,new,0), adjacent    */
+        b.lt 2f                         /* ppc:7032 bltlr cr0: new<0 -> return     */
+        mov imm2, nargs                 /* ppc:7033 save nargs across the poll     */
+        check_pending_interrupt         /* ppc:7034 check_pending_interrupt(cr1)   */
+        mov nargs, imm2                 /* ppc:7035 restore nargs                  */
+2:      ret                             /* ppc:7036 blr                            */
+3:      /* ppc:7037 (PPC label 5).  Missed a suspend; force suspend now if we are
+           restoring interrupt level to -1 or greater. */
+        cmp temp1, #(-2<<fixnumshift)   /* ppc:7039 cmpri(old,-2<<fixnumshift)     */
+        b.ne 1b                         /* ppc:7040 bne 0b                          */
+        ldr imm0, [imm1, #binding.val]  /* ppc:7041 restored value                 */
+        cmp imm0, temp1                 /* ppc:7042 cmpr(restored,old)              */
+        b.eq 1b                         /* ppc:7043 beq 0b                          */
+        mov imm0, #(1<<fixnumshift)     /* ppc:7044 li imm0,1<<fixnumshift          */
+        str imm0, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]    /* ppc:7045 */
+        uuo_suspend_now                 /* ppc:7046 (his misc 4) */
+        b 1b                            /* ppc:7047 b 0b                            */
+endsp unbind_interrupt_level
+
+/*
+ * ===========================================================================
+ * VALUES / MULTIPLE-VALUE SUBPRIMS
+ * ===========================================================================
+ */
+
+/* ret1valn returns "1 multiple value" when a called function does not
+   return multiple values.  Its presence on the stack (as a return
+   address) identifies the frame to multiple-value-returning code.
+   ppc-spentry.s:1167-1179; pmcl-kernel.c:2109 takes &ret1valn for
+   lisp_global(RET1VALN).  Marker-frame restore order per this file's
+   frame idiom (lr from savelr, vsp, fn, discard).
+
+   ORDERING (16m5t root cause): in PPC this is a STANDALONE _exportfn
+   defined BEFORE _spentry(values) (ppc:1171), and `values' falls
+   straight through `mflr loc_pc' into local_label(return_values)
+   (ppc:1214-1216).  A prior port mis-inserted this block BETWEEN
+   `values' `mov temp4,lr' and `return_values', so `values' fell into
+   ret1valn and ALWAYS delivered 1 value (set_nargs 1) -- the mv-return
+   branch logic at return_values was only reachable via nvalret's
+   explicit `b'.  Kept here, ABOVE `spentry values', so the fall-through
+   values -> return_values is intact. */
+        .globl C(ret1valn)
+C(ret1valn):
+        ldr lr, [sp, #lisp_frame.savelr]        /* ppc:1172 ldr loc_pc  */
+        ldr vsp, [sp, #lisp_frame.savevsp]      /* ppc:1173             */
+        ldr fn, [sp, #lisp_frame.savefn]        /* ppc:1175             */
+        add sp, sp, #lisp_frame.size            /* ppc:1176 discard     */
+        vpush1 arg_z                            /* ppc:1177             */
+        set_nargs 1                             /* ppc:1178             */
+        ret                                     /* ppc:1179 blr         */
+
+/* ported from ppc-spentry.s:1214-1248 (PPC64 branch) */
+/* Return multiple values. nargs = count (fixnum), values on stack */
+spentry values
+        /* ppc-spentry.s:1214-1265 (PPC64 branch).  temp0 = entry vsp (VERIFIED
+           cont-71); nargs = boxed value count.  No loc_pc register in this
+           design -- lr(x30) carries the return pc, stashed in temp4. */
+        mov temp4, lr                   /* ppc:1215 mflr loc_pc (->temp4)        */
+        /* FALL THROUGH to return_values (ppc:1216 local_label). */
+
+        .globl return_values
+return_values:                          /* ppc:1216 shared entry; spentry-D nvalret must `b return_values' */
+        /* ppc:1217 ref_global(imm0,ret1val_addr): load the ret1val_addr global.
+           No ref_global / lisp_globals idiom exists for ARM64 in this file or
+           its includes (see spentry-A-alloc-numbers.s:25-26 and the open
+           PORT-TODO at spentry-D-call-builtins.s:112-113). */
+        ref_global imm0, ret1val_addr   /* ppc:1217 (idiom: arm64-globals-proposed.s) */
+        mov arg_z, rnil                 /* ppc:1218 li arg_z,nil_value           */
+        cmp nargs, #(4096-(dnode_size+dnode_size))  /* ppc:1221 cmpri cr2        */
+        b.ge 2f                         /* ppc:1224 bge cr2 -> too many values   */
+        cmp imm0, temp4                 /* ppc:1222 cmpr cr1 (imm0==ret1val_addr?)*/
+        b.eq 3f                         /* ppc:1225 beq cr1 -> return to real caller*/
+        mov lr, temp4                   /* ppc:1226 mtlr loc_pc                   */
+        add imm0, vsp, nargs            /* ppc:1227 add imm0,nargs,vsp            */
+        cmp nargs, #fixnum_one          /* ppc:1223 cmpri cr0, recomputed here    */
+        b.lt 1f                         /* ppc:1228 blt cr0 -> no values, keep nil*/
+        ldr arg_z, [imm0, #-node_size]  /* ppc:1229 top value                     */
+1:      /* ppc:1230 */
+        mov vsp, temp0                  /* ppc:1231 restore entry vsp             */
+        ret                             /* ppc:1232 blr                           */
+2:      /* ppc:1234 */
+        /* ppc:1235 uuo_interr(error_too_many_values,nargs) -- udf
+           unary-misc, sub = errnum 7 (namespace: spentry-A trap block). */
+        uuo_interr error_too_many_values, nargs /* PROPOSED ext (globals-proposed.s) */
+        b 2b                            /* ppc:1236 */
+3:      /* ppc:1239 return multiple values to real caller */
+        ldr temp4, [sp, #lisp_frame.savelr]   /* ppc:1240 ldr loc_pc            */
+        add imm1, vsp, nargs            /* ppc:1241 add imm1,nargs,vsp            */
+        ldr imm0, [sp, #lisp_frame.savevsp]   /* ppc:1242                        */
+        ldr fn, [sp, #lisp_frame.savefn]      /* ppc:1243                        */
+        mov lr, temp4                   /* ppc:1245 mtlr loc_pc                   */
+        discard_lisp_frame              /* ppc:1247                              */
+        cmp imm1, imm0                  /* ppc:1244 cmpr cr0, recomputed post-discard*/
+        b.eq 7f                         /* ppc:1248 beqlr cr0 -> already in place */
+        cmp nargs, #fixnum_one          /* ppc:1246 cmpri cr1                     */
+        b.ne 4f                         /* ppc:1249 bne cr1                       */
+        ldr arg_z, [vsp]                /* ppc:1250 ldr arg_z,0(vsp)              */
+        mov vsp, imm0                   /* ppc:1251                              */
+        vpush1 arg_z                    /* ppc:1252                              */
+        ret                             /* ppc:1253 blr                           */
+4:      /* ppc:1254 */
+        cmp nargs, #fixnum_one          /* ppc:1246 cr1 recomputed                */
+        b.lt 6f                         /* ppc:1255 blt cr1                       */
+        mov imm2, #fixnum_one           /* ppc:1256                              */
+5:      /* ppc:1257 */
+        cmp imm2, nargs                 /* ppc:1258 cmpr cr0                       */
+        add imm2, imm2, #fixnum_one     /* ppc:1259                              */
+        ldr arg_z, [imm1, #-node_size]! /* ppc:1260 ldru pre-decrement            */
+        str arg_z, [imm0, #-node_size]! /* ppc:1261 push pre-decrement            */
+        b.ne 5b                         /* ppc:1262 bne cr0                        */
+6:      /* ppc:1263 */
+        mov vsp, imm0                   /* ppc:1264                              */
+        ret                             /* ppc:1265 blr                           */
+7:      /* ppc:1248 beqlr cr0 target: values already in place                     */
+        ret
+endsp values
+
+/* ported from ppc-spentry.s:1424-1579 (PPC64 branch)
+ *
+ * keyword_bind: Function-entry keyword processor.
+ *
+ * Entry conditions (PPC convention, mapped to ARM64):
+ *   nargs          = actual arg count (boxed fixnum)
+ *   imm0           = canonical required+optional count (boxed fixnum)
+ *   keyword_count  = number of defined keyword args (boxed fixnum, imm3/x3)
+ *   keyword_vector = vector of keyword specifier symbols (temp3/x16)
+ *   keyword_flags  = flag word, pre-seeded by caller (imm2/x2)
+ *   nfn            = the function being entered (temp2/x15)
+ *   fn             = caller's fn, to be saved (VOLATILE x7)
+ *   lr             = return pc to record in the new frame
+ *
+ * DEVIATIONS from literal PPC transcription (forced by ISA):
+ *   [D1] PPC keeps up to four CR results live simultaneously.  AArch64 has ONE
+ *        NZCV.  Where PPC relies on a stale CR, we recompute the comparison or
+ *        stash a boolean with `cset` into a free scratch.
+ *   [D2] PPC pushes NILs via imm5 (=nargs).  Here nargs is still live, so we
+ *        push the dedicated NIL register (rnil) instead.
+ *   [D3] `loc_pc` -> lr.  keyword_bind saves lr into lisp_frame.savelr and
+ *        returns with `ret`.
+ */
+
+/* Register aliases for keyword_bind (PPC ppc-spentry.s:1414-1422 mapping;
+   temp3 = x15 on Matt's map -- an earlier revision mis-aliased the vector
+   to x16/temp4, 16m5o).  nfn (= temp2 = x14) comes from the register map. */
+keyword_flags  .req x2    /* imm2 */
+keyword_count  .req x3    /* imm3 */
+keyword_vector .req x15   /* temp3 (= fname; dead by keyword-entry time)  */
+varptr         .req x19   /* save0 */
+valptr         .req x20   /* save1 */
+limit          .req x21   /* save2 */
+
+spentry keyword_bind
+        /* ARM64-DEVIATION (16m5o): PPC's keyword_bind built the fn's ONLY
+           lisp frame here (ppc:1432-1438) because PPC2 emits just save-lr
+           before it -- LR survives in loc_pc.  This design has no loc_pc:
+           the blr that reaches us already clobbered lr, so the compiled
+           prologue (save-lisp-context-variable) saved the caller's
+           fn/lr/vsp in ITS frame -- with identical savevsp arithmetic
+           (vsp + stack-arg bytes = caller's vsp).  Building a second
+           frame here recorded a bogus savelr (mid-prologue pc) that
+           poisoned unwinds and leaked cstack.  Entry contract now:
+           compiled prologue owns the frame; fn already = nfn. */
+        /* ppc:1445-1450: prime the pair-of-NILs loop. */
+        mov arg_z, #0                           /* ppc:1446 li arg_z,0             */
+        sub imm1, nargs, imm0                   /* ppc:1447 sub imm1,nargs,imm0   */
+        mov imm4, vsp                           /* ppc:1448 mr imm4,vsp (for odd-keywords error) */
+        cmp arg_z, imm3                         /* ppc:1444 cmpri(cr0,imm3,0) [D1]: arg_z==0 here, so this == keycount-vs-0, same predicate the in-loop cmp at 2: recomputes */
+        b 3f                                    /* ppc:1450                        */
+2:                                              /* ppc:1451-1456                   */
+        add arg_z, arg_z, #fixnumone            /* ppc:1452 addi arg_z,fixnum_one  */
+        cmp arg_z, imm3                         /* ppc:1453 cmplr(cr0,arg_z,imm3)  */
+        vpush1 rnil                             /* ppc:1454-1455 vpush NIL [D2]    */
+        vpush1 rnil
+3:
+        b.ne 2b                                 /* ppc:1458 bne cr0,2b             */
+        /* ppc:1459-1461: if no pairs, done; if odd count, error. */
+        cmp imm1, #0                            /* ppc:1449 cmpri(cr1,imm1,0)      */
+        b.le kbind_ret                          /* ppc:1460 blelr cr1 (imm1<=0)    */
+        tst imm1, #fixnumone                    /* ppc:1459 andi. arg_z,imm1,fixnum_one */
+        b.ne kbind_odd_keywords                 /* ppc:1461 bne cr0,odd_keywords   */
+
+        /* ppc:1465-1467: save the non-volatile ptr regs we are about to use. */
+        vpush1 limit                            /* ppc:1465 vpush(limit)           */
+        vpush1 valptr                           /* ppc:1466 vpush(valptr)          */
+        vpush1 varptr                           /* ppc:1467 vpush(varptr)          */
+        /* ppc:1469-1476: recompute user-arg pointer (stack may have moved).
+           imm3 is a boxed fixnum == keycount*node_size. */
+        add imm4, vsp, imm3                     /* ppc:1469 add imm4,vsp,imm3     */
+        add imm4, imm4, imm3                    /* ppc:1470 add imm4,imm4,imm3    */
+        add imm4, imm4, #3*node_size            /* ppc:1471 addi imm4,3*node_size  */
+        mov varptr, imm4                        /* ppc:1473 mr varptr,imm4         */
+        add limit, vsp, #3*node_size            /* ppc:1474 la limit,3*node_size(vsp) */
+        mov valptr, limit                       /* ppc:1475 mr valptr,limit        */
+        mov arg_z, imm1                         /* ppc:1476 mr arg_z,imm1          */
+4:                                              /* ppc:1477-1489: slide pairs up, NIL sources */
+        subs arg_z, arg_z, #(2<<fixnumshift)    /* ppc:1479 subi + cmpri(cr0,0)    */
+        ldr arg_x, [varptr, #node_size*0]       /* ppc:1481 ldr(arg_x,0(varptr))   */
+        ldr arg_y, [varptr, #node_size*1]       /* ppc:1482 ldr(arg_y,8(varptr))   */
+        str rnil, [varptr, #node_size*0]        /* ppc:1483 str(nil,0(varptr)) [D2]*/
+        str rnil, [varptr, #node_size*1]        /* ppc:1484 str(nil,8(varptr)) [D2]*/
+        add varptr, varptr, #node_size*2        /* ppc:1485 la varptr,16(varptr)   */
+        str arg_x, [valptr, #node_size*0]       /* ppc:1486 str(arg_x,0(valptr))   */
+        str arg_y, [valptr, #node_size*1]       /* ppc:1487 str(arg_y,8(valptr))   */
+        add valptr, valptr, #node_size*2        /* ppc:1488 la valptr,16(valptr)   */
+        b.ne 4b                                 /* ppc:1489 bne cr0,4b             */
+
+        /* ppc:1501: remember top-of-values for the badkeys conslist. */
+        mov imm4, valptr                        /* ppc:1501 mr imm4,valptr         */
+5:                                              /* ppc:1502-1515: per supplied pair */
+        /* load key/value with pre-decrement (PPC ldru). */
+        ldr arg_z, [valptr, #-node_size]!       /* ppc:1504 ldru(arg_z,-8(valptr)) */
+        ldr arg_y, [valptr, #-node_size]!       /* ppc:1505 ldru(arg_y,-8(valptr)) */
+        ref_nrs_symbol arg_x, kallowotherkeys   /* ppc:1507 */
+        cmp arg_x, arg_z                        /* ppc:1509 cmpr(cr6,arg_x,arg_z)  */
+        cset temp0, eq                          /* [D1] stash cr6 (is-aok) into temp0 */
+        b.ne 6f                                 /* ppc:1511 bne cr6,6f             */
+        tst keyword_flags, #(16<<fixnumshift)   /* ppc:1503 cmpri(cr0,keyword_flags,16<<fixnumshift) already seen? */
+        b.ne 6f                                 /* ppc:1512 bge cr0,6f             */
+        orr keyword_flags, keyword_flags, #(16<<fixnumshift) /* ppc:1513 ori      */
+        cmp arg_y, rnil                         /* ppc:1506/1514 cmpri(cr1,arg_y,nil_value) */
+        b.eq 6f                                 /* ppc:1514 beq cr1,6f             */
+        orr keyword_flags, keyword_flags, #fixnumone /* ppc:1515 ori: note aok active */
+6:                                              /* ppc:1516-1520                   */
+        mov imm1, #misc_data_offset             /* ppc:1518 li imm1,misc_data_offset */
+        mov imm0, #0                            /* ppc:1519 li imm0,0              */
+        b 8f                                    /* ppc:1520 b 8f                   */
+7:                                              /* ppc:1521-1536: scan keyword vector */
+        add imm0, imm0, #fixnumone              /* ppc:1522 addi imm0,fixnum_one   */
+        ldr arg_x, [keyword_vector, imm1]       /* ppc:1524 ldrx(arg_x,keyword_vector,imm1) */
+        add imm1, imm1, #fixnumone              /* ppc:1526 addi imm1,fixnum_one (==node_size) */
+        cmp arg_x, arg_z                        /* ppc:1525 cmpr(cr0,arg_x,arg_z)  */
+        b.ne 8f                                 /* ppc:1527 bne cr0,8f (no match)  */
+        /* matched this defined keyword */
+        add imm0, imm0, imm0                    /* ppc:1528 add imm0,imm0,imm0 (pair stride) */
+        sub imm0, varptr, imm0                  /* ppc:1529 sub imm0,varptr,imm0   */
+        ldr arg_x, [imm0, #0]                   /* ppc:1530 ldr(arg_x,0(imm0)) current supplied-p */
+        cmp arg_x, rnil                         /* ppc:1531 cmpri(cr0,arg_x,nil_value) */
+        b.ne 9f                                 /* ppc:1533 bne cr0,9f already supplied */
+        add arg_z, rnil, #t_offset              /* ppc:1532 li arg_z,t_value       */
+        str arg_y, [imm0, #node_size]           /* ppc:1534 str(arg_y,node_size(imm0)) store value */
+        str arg_z, [imm0, #0]                   /* ppc:1535 str(arg_z,0(imm0)) supplied-p = T */
+        b 9f                                    /* ppc:1536 b 9f                   */
+8:                                              /* ppc:1537-1542                   */
+        cmp imm0, imm3                          /* ppc:1523/1538 [D1] recompute cr1 (idx==keycount) */
+        b.ne 7b                                 /* ppc:1538 bne cr1,7b more keywords to try */
+        /* unknown keyword */
+        cbnz temp0, 9f                          /* ppc:1541 beq cr6,9f (it was :aok) [D1] */
+        orr keyword_flags, keyword_flags, #(2<<fixnumshift) /* ppc:1542 ori: note unknown seen */
+9:                                              /* ppc:1543-1544                   */
+        cmp valptr, limit                       /* ppc:1544 [D1] recompute cr7 (valptr==limit?) */
+        b.ne 5b                                 /* ppc:1544 bne cr7,5b             */
+        /* ppc:1545-1558: restore ptr regs, then act on the flags. */
+        vpop1 varptr                            /* ppc:1545 vpop(varptr)           */
+        vpop1 valptr                            /* ppc:1546 vpop(valptr)           */
+        vpop1 limit                             /* ppc:1547 vpop(limit)            */
+        /* All keyword/value pairs have been processed.
+           If we saw an unknown keyword and did not expect to, error.
+           Unless bit 2 is set in keyword_flags, discard the pairs. */
+        and imm0, keyword_flags, #((fixnumone)|(2<<fixnumshift)) /* ppc:1552 andi. */
+        cmp imm0, #(2<<fixnumshift)             /* ppc:1553 cmpri(cr0,imm0,2<<fixnumshift) unknown+not-allowed? */
+        b.eq kbind_badkeys                      /* ppc:1554 beq- cr0,badkeys       */
+        tst keyword_flags, #(4<<fixnumshift)    /* ppc:1555 andi. imm2,keyword_flags,4<<fixnumshift keep pairs? */
+        b.ne kbind_ret                          /* ppc:1556 bnelr cr0              */
+        mov vsp, imm4                           /* ppc:1557 mr vsp,imm4 (discard key/value pairs) */
+kbind_ret:
+        ret                                     /* ppc:1558 blr; the fn's frame is the
+                                                   compiled prologue's (see entry note) */
+
+        /* ppc:1569-1579: error tails. */
+kbind_odd_keywords:
+        mov vsp, imm4                           /* ppc:1570 mr vsp,imm4            */
+        mov nargs, imm1                         /* ppc:1571 mr nargs,imm1          */
+        b kbind_signal                          /* ppc:1572 b 1f                   */
+kbind_badkeys:
+        sub nargs, imm4, vsp                    /* ppc:1574 sub nargs,imm4,vsp     */
+kbind_signal:
+        bl _SPconslist                          /* ppc:1576 bl _SPconslist          */
+        mov arg_y, #XBADKEYS                    /* ppc:1577 li arg_y,XBADKEYS      */
+        set_nargs 2                             /* ppc:1578 set_nargs(2)           */
+        b _SPksignalerr                         /* ppc:1579 b _SPksignalerr        */
+endsp keyword_bind
+
+.unreq keyword_flags
+.unreq keyword_count
+.unreq keyword_vector
+.unreq varptr
+.unreq valptr
+.unreq limit
+
+/* ported from ppc-spentry.s:2025-2029 (PPC64 branch) */
+/* Allocate &rest arg list on stack */
+spentry stack_rest_arg
+        /* ppc:2025-2028.  As in the heap-consed cases, only stack-cons the &rest
+           arg.  No required args consumed -> subtract 0. */
+        mov imm0, #0                    /* ppc:2026 li imm0,0 */
+        /* vpush_argregs() (ppc-macros.s:329) inlined; cmplri -> unsigned.
+           nargs is a boxed fixnum, one arg == node_size bytes (set_nargs). */
+        cmp nargs, #0                   /* cmplri(cr0,nargs,0) */
+        b.eq 3f                         /* nargs==0 -> push nothing */
+        cmp nargs, #(node_size*2)       /* cmplri(cr1,nargs,node_size*2) */
+        b.lo 2f                         /* nargs<2 -> only arg_z */
+        b.eq 1f                         /* nargs==2 -> arg_y,arg_z */
+        vpush1 arg_x                    /* nargs>=3 */
+1:      vpush1 arg_y
+2:      vpush1 arg_z
+3:
+        b _SPstack_cons_rest_arg        /* ppc:2028 */
+endsp stack_rest_arg
+
+/* ported from ppc-spentry.s:2031-2033 (PPC64 branch) */
+/* Required stack rest arg variant */
+spentry req_stack_rest_arg
+        /* ppc:2031-2033.  imm0 (count of required args already consumed) is
+           supplied by the caller; just vpush the arg regs and cons. */
+        /* vpush_argregs() (ppc-macros.s:329) inlined; own labels. */
+        cmp nargs, #0                   /* cmplri(cr0,nargs,0) */
+        b.eq 3f                         /* nargs==0 -> push nothing */
+        cmp nargs, #(node_size*2)       /* cmplri(cr1,nargs,node_size*2) */
+        b.lo 2f                         /* nargs<2 -> only arg_z */
+        b.eq 1f                         /* nargs==2 -> arg_y,arg_z */
+        vpush1 arg_x                    /* nargs>=3 */
+1:      vpush1 arg_y
+2:      vpush1 arg_z
+3:
+        b _SPstack_cons_rest_arg        /* ppc:2033 */
+endsp req_stack_rest_arg
+
+/* ported from ppc-spentry.s:2035-2069 (PPC64 branch) */
+/* Cons up &rest arg list on stack */
+spentry stack_cons_rest_arg
+        /* ppc:2035-2063.  imm0 = required args already consumed; nargs = total.
+           Cons the rest args into a list on the temp stack (heap-cons if the
+           block would be too large).  arg_z accumulates the list. */
+        /* Labels 8/9 for the ble/bge targets (not 2/3): the inlined
+           tsp_alloc_var_boxed_nz macro emits its own local 1:/2:, so a forward
+           `2f` here would bind to the macro's label.  Matches throw/nthrowvalues
+           high-label convention. */
+        sub imm1, nargs, imm0           /* ppc:2036 imm1 = rest count (bytes)   */
+        mov arg_z, rnil                 /* ppc:2039 li arg_z,nil_value          */
+        cmp imm1, #0                    /* ppc:2037 cmpri(cr0,imm1,0), signed   */
+        b.le 8f                         /* ppc:2040 ble cr0 -> always push cell */
+        cmp imm1, #((4096-dnode_size)/2)/* ppc:2038 cmpri(cr1,...), signed      */
+        b.ge 9f                         /* ppc:2041 bge cr1 -> too big, heap    */
+        add imm1, imm1, imm1            /* ppc:2042 imm1 *= 2 -> cons byte count */
+        /* dnode_align(imm2,imm1,tsp_frame.fixed_overhead) (ppc:2043), inlined
+           per spentry-A:447-448. */
+        add imm2, imm1, #(tsp_frame.fixed_overhead + dnode_size - 1)
+        and imm2, imm2, #0xfffffffffffffff0
+        tsp_alloc_var_boxed_nz imm2, imm3, imm4   /* ppc:2044 TSP_Alloc_Var_Boxed */
+        add imm0, tsp, #(tsp_frame.data_offset + fulltag_cons)  /* ppc:2045     */
+1:      /* ppc:2046 */
+        cmp imm1, #cons.size            /* ppc:2047 cmpri(cr0,imm1,cons.size)   */
+        sub imm1, imm1, #cons.size      /* ppc:2048 subi (plain sub: keep flags)*/
+        vpop1 arg_x                     /* ppc:2049 vpop(arg_x)                 */
+        str arg_z, [imm0, #cons.cdr]    /* ppc:2050 _rplacd(imm0,arg_z)         */
+        str arg_x, [imm0, #cons.car]    /* ppc:2051 _rplaca(imm0,arg_x)         */
+        mov arg_z, imm0                 /* ppc:2052 mr arg_z,imm0               */
+        add imm0, imm0, #cons.size      /* ppc:2053 la imm0,cons.size(imm0)     */
+        b.ne 1b                         /* ppc:2054 bne cr0 (pre-decr test)     */
+        vpush1 arg_z                    /* ppc:2055 vpush(arg_z)                */
+        ret                             /* ppc:2056 blr                         */
+8:      /* ppc:2057 */
+        tsp_alloc_fixed_unboxed 0, imm3 /* ppc:2058 TSP_Alloc_Fixed_Unboxed(0)  */
+        vpush1 arg_z                    /* ppc:2059 vpush(arg_z)                */
+        ret                             /* ppc:2060 blr                         */
+9:      /* ppc:2061 */
+        tsp_alloc_fixed_unboxed 0, imm3 /* ppc:2062 TSP_Alloc_Fixed_Unboxed(0)  */
+        b _SPheap_cons_rest_arg         /* ppc:2063                             */
+endsp stack_cons_rest_arg
+
+/* ported from ppc-spentry.s:2300-2357 (PPC64 branch) */
+/* Tail-call function with vsp args */
+spentry tfuncallvsp
+        /* ppc:2300-2306.  No args vpushed: recover saved context from the
+           lisp_frame, discard it, tail-dispatch on temp0.  lr IS x30, so the
+           savelr load replaces PPC's loc_pc load + mtlr.  All three loads read
+           the current sp-relative frame and MUST precede discard_lisp_frame. */
+        ldr lr, [sp, #lisp_frame.savelr]        /* ppc:2301+2304 loc_pc/mtlr */
+        ldr fn, [sp, #lisp_frame.savefn]        /* ppc:2302 */
+        ldr vsp, [sp, #lisp_frame.savevsp]      /* ppc:2303 */
+        discard_lisp_frame                      /* ppc:2305 */
+        b _SPfuncall                            /* ppc:2306 do_funcall() (temp0) */
+endsp tfuncallvsp
+
+/* ported from ppc-spentry.s:2359-2369 (PPC64 branch) */
+/* Tail-call symbol with vsp args */
+spentry tcallsymvsp
+        /* ppc:2359-2366.  No args vpushed: recover saved context, discard the
+           frame, tail-dispatch via fname's fcell.  Loads precede the discard. */
+        ldr lr, [sp, #lisp_frame.savelr]        /* ppc:2360+2364 loc_pc/mtlr */
+        ldr fn, [sp, #lisp_frame.savefn]        /* ppc:2361 */
+        ldr vsp, [sp, #lisp_frame.savevsp]      /* ppc:2362 */
+        discard_lisp_frame                      /* ppc:2363 */
+        b _SPjmpsym                             /* ppc:2365 jump_fname (fname) */
+endsp tcallsymvsp
+
+/* ported from ppc-spentry.s:2393-2412 (PPC64 branch) */
+/* Tail-call nfn with vsp args */
+spentry tcallnfnvsp
+        /* ppc:2393-2399.  No args vpushed: recover saved context, discard the
+           frame, tail-dispatch to nfn's code.  Loads precede the discard. */
+        ldr lr, [sp, #lisp_frame.savelr]        /* ppc:2394+2398 loc_pc/mtlr */
+        ldr fn, [sp, #lisp_frame.savefn]        /* ppc:2395 */
+        ldr vsp, [sp, #lisp_frame.savevsp]      /* ppc:2396 */
+        discard_lisp_frame                      /* ppc:2397 */
+        b _SPjmpnfn                             /* ppc:2399 jump_nfn() (nfn) */
+endsp tcallnfnvsp
+
+/* ported from ppc-spentry.s:3271-3285 (PPC64 branch) */
+/* Get vcell address on stack */
+spentry stkvcellvsp
+        /* ppc-spentry.s:3271-3292.  Push 3 NILs, then overlay a stack-allocated
+           value-cell on two of them, placement chosen by (oddp vsp). */
+        mov arg_z, rnil                 /* ppc:3272 li arg_z,nil_value          */
+        vpush1 arg_z                    /* ppc:3273 vpush(arg_z)                */
+        vpush1 arg_z                    /* ppc:3274 vpush(arg_z)                */
+        vpush1 arg_z                    /* ppc:3275 vpush(arg_z)                */
+        mov imm1, #(node_size*3)        /* ppc:3276 li imm1,node_size*3         */
+        add imm0, vsp, imm1             /* ppc:3277 imm0 = old vsp (pre-push)   */
+        tst vsp, #(1<<3)                /* ppc:3278 andi. (oddp vsp)? flag-only;
+                                           1<<word_shift, word_shift==3 (spentry-B) */
+        mov imm1, #value_cell_header    /* ppc:3279 (flag-neutral)              */
+        ldr arg_z, [imm0]               /* ppc:3280 reload value at old vsp (flag-neutral) */
+        b.eq 1f                         /* ppc:3281 beq cr0 -> even-vsp layout  */
+        str arg_z, [vsp, #(node_size*2)]/* ppc:3282                             */
+        str imm1, [vsp, #node_size]     /* ppc:3283                             */
+        add arg_z, vsp, #(fulltag_misc+node_size) /* ppc:3284 la                */
+        str arg_z, [imm0]               /* ppc:3285                             */
+        ret                             /* ppc:3286 blr                         */
+1:      /* ppc:3287 */
+        str arg_z, [vsp, #node_size]    /* ppc:3288                             */
+        str imm1, [vsp]                 /* ppc:3289                             */
+        add arg_z, vsp, #fulltag_misc   /* ppc:3290 la                          */
+        str arg_z, [imm0]               /* ppc:3291                             */
+        ret                             /* ppc:3292 blr                         */
+endsp stkvcellvsp
+
+/* Register aliases for the destructuring trio (ppc-spentry.s:3538-3541 mapping).
+   whole_reg = temp1 (x14); arg_reg = temp3/fname (x16); keyvect_reg = temp2/nfn (x15).
+   keyword_bind's .unreq freed x16/x15 above; these re-alias the same physical regs. */
+whole_reg   .req x14   /* temp1 */
+arg_reg     .req x16   /* temp3 = fname */
+keyvect_reg .req x15   /* temp2 = nfn */
+
+/* ported from ppc-spentry.s:3545-3568 (PPC64 branch) */
+/* Macro lambda-list binding.  Discard the macro name (car of the whole form),
+   then fall into the shared destructuring machinery at destbind1. */
+spentry macro_bind
+        mov whole_reg, arg_reg              /* ppc:3547 mr whole_reg,arg_reg       */
+        and imm0, arg_reg, #fulltagmask     /* ppc:3548 extract_fulltag            */
+        cmp arg_reg, rnil                   /* ppc:3549 cmpri(cr1,arg_reg,nil_value)*/
+        b.eq 0f                             /* ppc:3551 beq cr1,0f (nil form ok)   */
+        cmp imm0, #fulltag_cons             /* ppc:3550 cmpri(cr0,imm0,fulltag_cons)*/
+        b.ne 1f                             /* ppc:3552 bne- cr0,1f (not a list)   */
+0:
+        ldr arg_reg, [arg_reg, #cons.cdr]   /* ppc:3554 _cdr: drop the macro name  */
+        b destbind1
+1:                                          /* ppc:3564-3568 */
+        mov arg_y, #XCALLNOMATCH            /* ppc:3565 li arg_y,XCALLNOMATCH      */
+        mov arg_z, whole_reg                /* ppc:3566 mr arg_z,whole_reg         */
+        set_nargs 2                         /* ppc:3567 set_nargs(2)               */
+        b _SPksignalerr                     /* ppc:3568 b _SPksignalerr            */
+endsp macro_bind
+
+/* ported from ppc-spentry.s:3571-3573 (PPC64 branch) */
+/* Destructuring bind entry.  Saves whole form and branches to shared body. */
+spentry destructuring_bind
+        mov whole_reg, arg_reg              /* ppc:3572 mr whole_reg,arg_reg       */
+        b destbind1                         /* ppc:3573 b destbind1                */
+endsp destructuring_bind
+
+/* ported from ppc-spentry.s:3575-3814 (PPC64 branch)
+ *
+ * destructuring_bind_inner: tree-walking argument destructuring.
+ *
+ * nargs holds the argument-descriptor longword (NOT a boxed count):
+ *   bits 0-7   required count      bits 8-15  optional count
+ *   bits 16-23 keyword count       bit  mask_initopt  hard (supplied-p) opts
+ *   bit mask_keyp  &key present    bit mask_aok  &allow-other-keys
+ *   bit mask_restp &rest present
+ * arg_reg = the list being destructured ; keyvect_reg = keyword vector ;
+ * whole_reg = whole form (for errors) ; imm4 = saved entry vsp.
+ * No lisp frame is built (runs in caller's frame); returns with `ret'.
+ */
+spentry destructuring_bind_inner
+        mov whole_reg, arg_z                /* ppc:3576 mr whole_reg,arg_z         */
+destbind1:
+        /* ppc:3580-3585: pull required & optional counts. */
+        ands imm0, nargs, #0xff             /* ppc:3580-3583 req count; sets Z if 0*/
+        ubfx imm1, nargs, #8, #8            /* ppc:3585 opt count                  */
+        /* ppc:3593-3595: save entry vsp; branch past req loop if none. */
+        mov imm4, vsp                       /* ppc:3594 mr imm4,vsp                */
+        b.eq 2f                             /* ppc:3595 beq cr0,2f                 */
+1:                                          /* ppc:3596-3612: bind required args   */
+        cmp arg_reg, rnil                   /* ppc:3597 cmpri(cr7,arg_reg,nil)     */
+        b.eq db_toofew                      /* ppc:3607 beq cr7,toofew             */
+        and imm3, arg_reg, #fulltagmask     /* ppc:3598-3599 extract_fulltag       */
+        cmp imm3, #fulltag_cons             /* ppc:3600                            */
+        b.ne db_badlist                     /* ppc:3608 bne cr3,badlist            */
+        subs imm0, imm0, #1                 /* ppc:3605-3606 subi + cmpri cr0      */
+        ldr arg_x, [arg_reg, #cons.car]     /* ppc:3609 ldr(arg_x,cons.car)        */
+        ldr arg_reg, [arg_reg, #cons.cdr]   /* ppc:3610 ldr(arg_reg,cons.cdr)      */
+        vpush1 arg_x                        /* ppc:3611 vpush(arg_x)               */
+        b.ne 1b                             /* ppc:3612 bne cr0,1b                 */
+2:                                          /* ppc:3613-3615                       */
+        cbz imm1, db_rest_keys              /* ppc:3614 beq cr1,rest_keys (no opts)*/
+        tst nargs, #mask_initopt            /* ppc:3615 cmpri(cr2,imm2,0)          */
+        b.ne db_opt_supp                    /* ppc:3615 bne cr2,opt_supp           */
+
+        /* ppc:3616-3642: 'simple' &optionals -- no supplied-p, default NIL. */
+db_simple_opt_loop:
+        cmp arg_reg, rnil                   /* ppc:3618 cmpri(cr0,arg_reg,nil)     */
+        b.eq db_default_simple_opt          /* ppc:3629 beq cr0,default_simple_opt */
+        and imm3, arg_reg, #fulltagmask     /* ppc:3619-3621 extract_fulltag       */
+        cmp imm3, #fulltag_cons             /* ppc:3621                            */
+        b.ne db_badlist                     /* ppc:3630 bne cr3,badlist            */
+        subs imm1, imm1, #1                 /* ppc:3626-3627 subi + cmpri cr1      */
+        ldr arg_x, [arg_reg, #cons.car]     /* ppc:3631 ldr(arg_x,cons.car)        */
+        ldr arg_reg, [arg_reg, #cons.cdr]   /* ppc:3632 ldr(arg_reg,cons.cdr)      */
+        vpush1 arg_x                        /* ppc:3633 vpush(arg_x)               */
+        b.ne db_simple_opt_loop             /* ppc:3634 bne cr1,simple_opt_loop    */
+        b db_rest_keys                      /* ppc:3635 b rest_keys                */
+db_default_simple_opt:                      /* ppc:3639-3642                       */
+        subs imm1, imm1, #1                 /* ppc:3637 subi + cmpri cr1 [D1]      */
+        vpush1 rnil                         /* ppc:3640 vpush(imm5/nil) [D2]       */
+        b.ne db_default_simple_opt          /* ppc:3641 bne cr1                    */
+        b db_rest_keys                      /* ppc:3642 b rest_keys                */
+
+        /* ppc:3643-3671: &optionals WITH supplied-p vars. */
+db_opt_supp:                                /* ppc:3644-3645                       */
+        add arg_y, rnil, #t_offset          /* ppc:3645 li arg_y,t_value           */
+db_opt_supp_loop:                           /* ppc:3646-3663                       */
+        cmp arg_reg, rnil                   /* ppc:3647 cmpri(cr0,arg_reg,nil)     */
+        b.eq db_default_hard_opt            /* ppc:3657 beq cr0,default_hard_opt   */
+        and imm3, arg_reg, #fulltagmask     /* ppc:3648-3650 extract_fulltag       */
+        cmp imm3, #fulltag_cons             /* ppc:3650                            */
+        b.ne db_badlist                     /* ppc:3658 bne cr3,badlist            */
+        subs imm1, imm1, #1                 /* ppc:3655-3656 subi + cmpri cr1      */
+        ldr arg_x, [arg_reg, #cons.car]     /* ppc:3659 ldr(arg_x,cons.car)        */
+        ldr arg_reg, [arg_reg, #cons.cdr]   /* ppc:3660 ldr(arg_reg,cons.cdr)      */
+        vpush1 arg_x                        /* ppc:3661 vpush(arg_x)               */
+        vpush1 arg_y                        /* ppc:3662 vpush(arg_y) supplied-p=T  */
+        b.ne db_opt_supp_loop               /* ppc:3663 bne cr1,opt_supp_loop      */
+        b db_rest_keys                      /* ppc:3664 b rest_keys                */
+db_default_hard_opt:                        /* ppc:3668-3671                       */
+        subs imm1, imm1, #1                 /* ppc:3666 subi + cmpri cr1 [D1]      */
+        vpush1 rnil                         /* ppc:3669 vpush(nil) value [D2]      */
+        vpush1 rnil                         /* ppc:3670 vpush(nil) supplied-p      */
+        b.ne db_default_hard_opt            /* ppc:3671 bne cr1                    */
+
+db_rest_keys:                               /* ppc:3672-3677                       */
+        tst nargs, #mask_restp              /* ppc:3674 bne cr5,have_rest          */
+        b.ne db_have_rest
+        tst nargs, #mask_keyp               /* ppc:3675 bne cr4,have_keys          */
+        b.ne db_have_keys
+        cmp arg_reg, rnil                   /* ppc:3673 cmpri(cr0,arg_reg,nil)     */
+        b.ne db_toomany                     /* ppc:3676 bne cr0,toomany            */
+        ret                                 /* ppc:3677 blr                        */
+db_have_rest:                               /* ppc:3678-3680                       */
+        vpush1 arg_reg                      /* ppc:3678 vpush(arg_reg)             */
+        tst nargs, #mask_keyp               /* ppc:3679 beqlr cr4 (not keyp)       */
+        b.eq db_ret                         /* ppc:3680 beqlr                      */
+db_have_keys:                               /* ppc:3681-3685                       */
+        /* Ensure arg_reg contains a proper, even-length list; length <= 512.
+           imm0 is a plain 256-countdown budget (cheap circularity check). */
+        mov imm0, #256                      /* ppc:3684 li imm0,256                */
+        mov arg_x, arg_reg                  /* ppc:3685 mr arg_x,arg_reg           */
+db_count_keys_loop:                         /* ppc:3686-3712                       */
+        cmp arg_x, rnil                     /* ppc:3694 cmpri(cr0,arg_x,nil)       */
+        b.eq db_counted_keys                /* ppc:3697 beq cr0,counted_keys       */
+        and imm3, arg_x, #fulltagmask       /* ppc:3687-3689 extract_fulltag       */
+        cmp imm3, #fulltag_cons             /* ppc:3689                            */
+        b.ne db_badlist                     /* ppc:3698 bne cr3,badlist            */
+        subs imm0, imm0, #1                 /* ppc:3695-3696 subi + cmpri cr4      */
+        b.mi db_toomany                     /* ppc:3707 blt cr4,toomany            */
+        ldr arg_x, [arg_x, #cons.cdr]      /* ppc:3699 ldr(arg_x,cons.cdr)        */
+        cmp arg_x, rnil                     /* ppc:3708 cmpri(cr0,arg_x,nil)       */
+        b.eq db_badkeys                     /* ppc:3709 beq cr0,db_badkeys (odd)   */
+        and imm3, arg_x, #fulltagmask       /* ppc:3700-3702 extract_fulltag       */
+        cmp imm3, #fulltag_cons             /* ppc:3702                            */
+        b.ne db_badlist                     /* ppc:3710 bne cr3,badlist            */
+        ldr arg_x, [arg_x, #cons.cdr]      /* ppc:3711 ldr(arg_x,cons.cdr)        */
+        b db_count_keys_loop                /* ppc:3712 b count_keys_loop          */
+db_counted_keys:                            /* ppc:3713-3732                       */
+        /* For each defined keyword var push a (value,supplied-p)=(NIL,NIL). */
+        ubfx imm0, nargs, #16, #8           /* ppc:3717 keyword count              */
+        mov imm2, imm0                      /* ppc:3718 save keycount              */
+        cbz imm0, db_push_pair_done         /* ppc:3717/3727 extrwi. + bne [D1]    */
+db_push_pair_loop:                          /* ppc:3721-3725                       */
+        subs imm0, imm0, #1                 /* ppc:3722-3723 subi + cmpri cr0      */
+        vpush1 rnil                         /* ppc:3724 vpush(nil) [D2]            */
+        vpush1 rnil                         /* ppc:3725 vpush(nil)                 */
+        b.ne db_push_pair_loop              /* ppc:3727 bne cr0,push_pair_loop     */
+db_push_pair_done:
+        lsl imm2, imm2, #dnode_shift        /* ppc:3728 slwi pairs -> bytes        */
+        add imm2, vsp, imm2                 /* ppc:3729 add imm2,vsp,imm2          */
+        /* imm1 accumulates flags: bit0 = unknown-keywords-allowed (seed from
+           mask_aok), bit1 = seen-:aok, unknown-keyword count in bits >= 2. */
+        mov imm0, #0                        /* ppc:3730 li imm0,0                  */
+        tst nargs, #mask_aok                /* ppc:3731 extrwi imm1,nargs,1,mask_aok*/
+        cset imm1, ne                       /* imm1 = aok-allowed ? 1 : 0          */
+        ubfx nargs, nargs, #16, #8          /* ppc:3732 nargs = keyword count (raw)*/
+
+db_match_keys_loop:                         /* ppc:3747-3759                       */
+        cmp arg_reg, rnil                   /* ppc:3748 cmpri(cr0,arg_reg,nil)     */
+        mov imm0, #0                        /* ppc:3749 li imm0,0                  */
+        mov imm3, #misc_data_offset         /* ppc:3750 li imm3,misc_data_offset   */
+        b.eq db_matched_keys                /* ppc:3751 beq cr0,matched_keys       */
+        ldr arg_x, [arg_reg, #cons.car]     /* ppc:3752 ldr(arg_x,cons.car)        */
+        ref_nrs_symbol arg_y, kallowotherkeys   /* ppc:3753 */
+        cmp arg_x, arg_y                    /* ppc:3754 cmpr(cr3,arg_x,arg_y)      */
+        cset temp4, eq                      /* [D1] stash cr3 (is-aok) into temp4  */
+        ldr arg_reg, [arg_reg, #cons.cdr]   /* ppc:3755 ldr(arg_reg,cons.cdr)      */
+        ldr arg_y, [arg_reg, #cons.car]     /* ppc:3756 ldr(arg_y,cons.car)        */
+        ldr arg_reg, [arg_reg, #cons.cdr]   /* ppc:3758 ldr(arg_reg,cons.cdr)      */
+        b db_match_test                     /* ppc:3759 b match_test               */
+db_match_loop:                              /* ppc:3760-3766                       */
+        ldr temp0, [keyvect_reg, imm3]      /* ppc:3761 ldrx(temp0,keyvect_reg,imm3)*/
+        add imm3, imm3, #node_size          /* ppc:3765 addi imm3,node_size        */
+        add imm0, imm0, #1                  /* ppc:3763 addi imm0,1 (raw 1-based)  */
+        cmp arg_x, temp0                    /* ppc:3762 cmpr(cr0,arg_x,temp0)      */
+        b.eq db_match_hit                   /* ppc:3766 beq cr0 (hit)              */
+db_match_test:                              /* ppc:3778-3782                       */
+        cmp imm0, nargs                     /* ppc:3764/3779 [D1] recompute cr4    */
+        b.ne db_match_loop                  /* ppc:3779 bne cr4,match_loop         */
+        cbnz temp4, db_match_keys_check_aok /* ppc:3780 beq cr3,check_aok          */
+        add imm1, imm1, #node_size          /* ppc:3781 addi imm1,node_size (count)*/
+        b db_match_keys_loop                /* ppc:3782 b match_keys_loop          */
+db_match_hit:                               /* ppc:3767-3777                       */
+        lsl imm0, imm0, #dnode_shift        /* ppc:3768 slwi imm0,dnode_shift      */
+        sub imm0, imm2, imm0                /* ppc:3769 subf imm0,imm0,imm2       */
+        ldr temp0, [imm0, #0]               /* ppc:3770 ldr(temp0,0(imm0))         */
+        cmp temp0, rnil                     /* ppc:3771 cmpri(cr0,temp0,nil)       */
+        b.ne db_match_keys_loop             /* ppc:3773 bne cr0,match_keys_loop    */
+        add temp0, rnil, #t_offset          /* ppc:3772 li temp0,t_value           */
+        str arg_y, [imm0, #node_size*1]     /* ppc:3774 str(arg_y,node_size*1(imm0))*/
+        str temp0, [imm0, #node_size*0]     /* ppc:3775 str(temp0,node_size*0(imm0))*/
+        cbz temp4, db_match_keys_loop       /* ppc:3776 bne cr3,match_keys_loop    */
+db_match_keys_check_aok:                    /* ppc:3783-3790                       */
+        tst imm1, #2                        /* ppc:3784 andi. imm0,imm1,2 (seen-aok?)*/
+        orr imm1, imm1, #2                  /* ppc:3786 ori imm1,imm1,2 (mark seen)*/
+        b.ne db_match_keys_loop             /* ppc:3787 bne cr0,match_keys_loop    */
+        cmp arg_y, rnil                     /* ppc:3785 cmpri(cr1,arg_y,nil)       */
+        b.eq db_match_keys_loop             /* ppc:3788 beq cr1,match_keys_loop    */
+        orr imm1, imm1, #1                  /* ppc:3789 ori imm1,imm1,1 (allow)    */
+        b db_match_keys_loop                /* ppc:3790 b match_keys_loop          */
+db_matched_keys:                            /* ppc:3791-3795                       */
+        bic imm0, imm1, #3                  /* ppc:3792 clrrwi. imm0,imm1,2        */
+        cbz imm0, db_ret                    /* ppc:3793 beqlr (none unknown)       */
+        tst imm1, #1                        /* ppc:3794 andi. imm1,imm1,1          */
+        b.ne db_ret                         /* ppc:3795 bnelr (allowed)            */
+        /* fall through to db_badkeys */
+db_badkeys:                                 /* ppc:3798-3800                       */
+        mov arg_y, #XBADKEYS               /* ppc:3799 li arg_y,XBADKEYS          */
+        b db_destructure_error              /* ppc:3800 b destructure_error        */
+db_toomany:                                 /* ppc:3801-3803                       */
+        mov arg_y, #XCALLTOOMANY            /* ppc:3802 li arg_y,XCALLTOOMANY      */
+        b db_destructure_error              /* ppc:3803 b destructure_error        */
+db_toofew:                                  /* ppc:3804-3806                       */
+        mov arg_y, #XCALLTOOFEW             /* ppc:3805 li arg_y,XCALLTOOFEW       */
+        b db_destructure_error              /* ppc:3806 b destructure_error        */
+db_badlist:                                 /* ppc:3807-3809                       */
+        mov arg_y, #XCALLNOMATCH            /* ppc:3808 li arg_y,XCALLNOMATCH      */
+db_destructure_error:                       /* ppc:3810-3814                       */
+        mov vsp, imm4                       /* ppc:3811 mr vsp,imm4 (undo vstack) */
+        mov arg_z, whole_reg                /* ppc:3812 mr arg_z,whole_reg         */
+        set_nargs 2                         /* ppc:3813 set_nargs(2)               */
+        b _SPksignalerr                     /* ppc:3814 b _SPksignalerr            */
+db_ret:
+        ret                                 /* ppc:3677/3680 blr                   */
+endsp destructuring_bind_inner
+
+.unreq whole_reg
+.unreq arg_reg
+.unreq keyvect_reg
+
+/* ported from ppc-spentry.s:3819-3878 (PPC64 branch) */
+/* Recover multiple values from stack */
+spentry recover_values
+        /* ppc:3819-3854.  vpush the saved value set atop the vstack, bumping
+           nargs, then discard the tsp frame.  Two loops share NZCV, so each
+           cmp is recomputed at its consuming branch. */
+        /* First, walk the segments reversing the previous-segment pointers.
+           The chain ends when the previous pointer equals the prev tsp. */
+        ldr imm0, [tsp, #tsp_frame.backlink]        /* ppc:3823 previous tsp     */
+        mov imm1, tsp                               /* ppc:3824 current segment  */
+        mov imm2, tsp                               /* ppc:3825 last segment     */
+1:      /* ppc:3826 walkloop */
+        ldr imm3, [imm1, #(tsp_frame.fixed_overhead+node_size)] /* ppc:3827 next  */
+        str imm2, [imm1, #(tsp_frame.fixed_overhead+node_size)] /* ppc:3829 rev   */
+        mov imm2, imm1                              /* ppc:3830 last<-current     */
+        mov imm1, imm3                              /* ppc:3831 current<-next     */
+        cmp imm0, imm3                              /* ppc:3828 last segment?     */
+        b.ne 1b                                     /* ppc:3832 bne cr0           */
+        /* final segment ptr now in imm2 (ppc:3834); walk backwards pushing
+           values onto the vstack and incrementing nargs. */
+2:      /* ppc:3836 pushloop */
+        ldr imm0, [imm2, #tsp_frame.data_offset]    /* ppc:3837 count in segment  */
+        add imm3, imm2, #(tsp_frame.data_offset+(2*node_size)) /* ppc:3840 la     */
+        add imm3, imm3, imm0                        /* ppc:3841                   */
+        add nargs, nargs, imm0                      /* ppc:3842                   */
+        cmp imm0, #0                                /* ppc:3838 cr0 entry test    */
+        b 4f                                        /* ppc:3843                   */
+3:      /* ppc:3844 inner push body */
+        ldr arg_z, [imm3, #-node_size]!             /* ppc:3845 ldru              */
+        cmp imm0, #fixnum_one                       /* ppc:3846 cr0 (pre-decr)    */
+        sub imm0, imm0, #fixnum_one                 /* ppc:3847                   */
+        vpush1 arg_z                                /* ppc:3848 vpush (flag-neut) */
+4:      /* ppc:3849 inner entry/continue test */
+        b.ne 3b                                     /* ppc:3850 bne cr0           */
+        cmp imm2, tsp                               /* ppc:3839 cr1 (test old imm2)*/
+        ldr imm2, [imm2, #(tsp_frame.data_offset+node_size)] /* ppc:3851 prev seg */
+        b.ne 2b                                     /* ppc:3852 bne cr1 (ldr flag-neut)*/
+        tsp_unlink                                  /* ppc:3853 unlink(tsp)       */
+        ret                                         /* ppc:3854 blr               */
+endsp recover_values
+
+/* ported from ppc-spentry.s:4987-5011 (PPC64 branch) */
+/* Save multiple values to stack */
+spentry save_values
+        /* ppc:4987-5011.  nargs values atop the vstack -> a boxed tsp frame,
+           popping them off the vstack.  save_values_to_tsp is the common exit
+           shared with add_values (a REAL named file-local label, since a
+           numeric local will not resolve across the separate add_values body). */
+        mov imm1, tsp                               /* ppc:4988                   */
+        /* common exit: nargs = values in this set, imm1 = tsp before the call. */
+save_values_to_tsp:                                 /* ppc:4992 (named label)     */
+        mov imm2, tsp                               /* ppc:4993 previous tsp      */
+        /* dnode_align(imm0,nargs,tsp_frame.fixed_overhead+2*node_size) ppc:4994,
+           inlined per spentry-A:447-448. */
+        add imm0, nargs, #(tsp_frame.fixed_overhead+(2*node_size)+dnode_size-1)
+        and imm0, imm0, #0xfffffffffffffff0
+        tsp_alloc_var_boxed_nz imm0, imm3, imm4     /* ppc:4995 (imm3+scratch)    */
+        str imm1, [tsp, #tsp_frame.backlink]        /* ppc:4996 one tsp "frame"   */
+        str nargs, [tsp, #tsp_frame.data_offset]    /* ppc:4997 value count       */
+        str imm2, [tsp, #(tsp_frame.data_offset+node_size)] /* ppc:4998 prev tsp  */
+        add imm3, tsp, #(tsp_frame.data_offset+node_size*2) /* ppc:4999 la        */
+        add imm3, imm3, nargs                       /* ppc:5000                   */
+        add imm0, vsp, nargs                        /* ppc:5001 top of value block*/
+        cmp imm0, vsp                               /* ppc:5002 cr0 entry test    */
+        b 2f                                        /* ppc:5003                   */
+1:      /* ppc:5004 */
+        ldr arg_z, [imm0, #-node_size]!             /* ppc:5005 ldru              */
+        cmp imm0, vsp                               /* ppc:5006 cr0 (pre-decr)    */
+        str arg_z, [imm3, #-node_size]!             /* ppc:5007 stru (flag-neut)  */
+2:      /* ppc:5008 */
+        b.ne 1b                                     /* ppc:5009 bne cr0           */
+        add vsp, vsp, nargs                         /* ppc:5010 discard values    */
+        ret                                         /* ppc:5011 blr               */
+endsp save_values
+
+/* ported from ppc-spentry.s:5022-5026 (PPC64 branch) */
+/* Add saved values to current values */
+spentry add_values
+        /* ppc:5022-5026.  Add the nargs values atop the vstack to the set saved
+           in the top tsp frame; a fresh linked tsp element is built by falling
+           into save_values_to_tsp (imm1 = current top-tsp backlink). */
+        ldr imm1, [tsp, #tsp_frame.backlink]        /* ppc:5024 ldr imm1,0(tsp)   */
+        cmp nargs, #0                               /* ppc:5023 cr0               */
+        b.ne save_values_to_tsp                     /* ppc:5025 bne cr0           */
+        ret                                         /* ppc:5026 blr               */
+endsp add_values
+
+/* ported from ppc-spentry.s:5330-5334 (PPC64 branch) */
+/* Save context and vsp */
+spentry savecontextvsp
+        /* ppc-spentry.s:5330-5334.  Save fn, return-pc, vsp into a control-stack
+           lisp_frame, install nfn as the current fn, trap on stack overflow.
+           No generic build_lisp_frame macro here; inline it (mirrors
+           build_catch_lisp_frame but stores lr as savelr).  loc_pc == lr == x30.
+           temp0 is a free scratch (not a live input; mkcatch uses it likewise). */
+        ldr imm0, [rcontext, #tcr.cs_limit]     /* ppc:5331 cs_limit            */
+        sub sp, sp, #lisp_frame.size            /* ppc:5332 build_lisp_frame:   */
+        mov temp0, #lisp_frame_marker           /*   MARKER frame               */
+        str temp0, [sp, #lisp_frame.marker]
+        str vsp, [sp, #lisp_frame.savevsp]
+        str fn, [sp, #lisp_frame.savefn]
+        str lr, [sp, #lisp_frame.savelr]        /* loc_pc == return pc          */
+        mov fn, nfn                             /* ppc:5333 mr fn,nfn           */
+        cmp sp, imm0                            /* ppc:5334 trllt(sp,imm0)      */
+        b.hs 1f                                 /* sp>=cs_limit: no overflow    */
+        uuo_interr error_stack_overflow, sp /* ppc:5334 trllt (PROPOSED ext) */
+1:      ret                                     /* ppc:5335 blr                 */
+endsp savecontextvsp
+
+/* ported from ppc-spentry.s:7200-7230 (PPC64 branch) */
+/* Make an unwind marker (for %unwind-protect) */
+spentry nmkunwind
+        /* ppc-spentry.s:7200-7230.  Unwind-protect frame that first disables
+           interrupts.  Bind *INTERRUPT-LEVEL* to -1 (saving the old level in
+           arg_y, which mkcatch preserves), build the unwind-protect catch frame
+           (tag=unbound_marker, mvflag=fixnum 1, exactly as .SPmkunwind), then
+           tail into .SPbind_interrupt_level with arg_z = old level to re-bind it.
+           The interrupt-level binding mirrors .SPbind_interrupt_level_m1; the
+           frame build mirrors .SPmkunwind. */
+        mov imm2, #(-fixnumone)         /* ppc:7201 li imm2,-fixnumone          */
+        mov imm3, #INTERRUPT_LEVEL_BINDING_INDEX            /* ppc:7202         */
+        ldr imm4, [rcontext, #tcr.tlb_pointer]              /* ppc:7203         */
+        ldr arg_y, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7204 old lvl */
+        ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:7205         */
+        vpush1 arg_y                    /* ppc:7206 binding frame: old value    */
+        vpush1 imm3                     /* ppc:7207               tlb index     */
+        vpush1 imm1                     /* ppc:7208               prev db_link   */
+        str imm2, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]    /* ppc:7209 il=-1   */
+        str vsp, [rcontext, #tcr.db_link]                   /* ppc:7210         */
+        mov arg_z, #unbound_marker      /* ppc:7211 lwi(arg_z,unbound_marker)   */
+        mov imm2, #fixnum_one           /* ppc:7212 li imm2,fixnum_one          */
+        mkcatch                         /* ppc:7213 mkcatch() (preserves arg_y) */
+        mov arg_z, arg_y                /* ppc:7214 mr arg_z,arg_y (old level)  */
+        b _SPbind_interrupt_level       /* ppc:7215 b _SPbind_interrupt_level   */
+endsp nmkunwind
+
+/* ported from ppc-spentry.s:5337-5343 (PPC64 branch) */
+/* Save context with vsp+imm0 as the stored vsp (callee-save setup variant). */
+spentry savecontext0
+        /* ppc-spentry.s:5337-5343.  Like savecontextvsp, but the stored vsp is
+           (vsp + imm0), and cs_limit is loaded AFTER building the frame (the PPC
+           ordering differs from savecontextvsp).  imm0 is an unboxed byte delta. */
+        add imm0, vsp, imm0             /* ppc:5338 add imm0,vsp,imm0           */
+        sub sp, sp, #lisp_frame.size    /* ppc:5339 build_lisp_frame: MARKER    */
+        mov temp0, #lisp_frame_marker
+        str temp0, [sp, #lisp_frame.marker]
+        str imm0, [sp, #lisp_frame.savevsp] /* stored vsp = vsp+delta           */
+        str fn, [sp, #lisp_frame.savefn]
+        str lr, [sp, #lisp_frame.savelr]
+        ldr imm0, [rcontext, #tcr.cs_limit] /* ppc:5340 ldr(imm0,tcr.cs_limit)  */
+        mov fn, nfn                     /* ppc:5341 mr fn,nfn                   */
+        cmp sp, imm0                    /* ppc:5342 trllt(sp,imm0)              */
+        b.hs 1f                         /* sp>=cs_limit: no overflow            */
+        uuo_interr error_stack_overflow, sp /* ppc:5342 trllt (PROPOSED ext) */
+1:      ret                             /* ppc:5343 blr                         */
+endsp savecontext0
+
+/* ported from ppc-spentry.s:5348-5353 (PPC64 branch) */
+/* Like restorefullcontext, only the saved return address winds up in
+   loc-pc (lr) instead of getting thrashed around.  I.e. a normal restore
+   and return. */
+spentry restorecontext
+        /* ppc-spentry.s:5348-5353.  Restore fn, vsp, lr from lisp_frame on sp,
+           discard the frame, and return normally (saved lr → lr → ret). */
+        ldr lr, [sp, #lisp_frame.savelr]    /* ppc:5349 ldr(loc_pc,savelr); mtlr */
+        ldr vsp, [sp, #lisp_frame.savevsp]  /* ppc:5350                          */
+        ldr fn, [sp, #lisp_frame.savefn]    /* ppc:5351                          */
+        discard_lisp_frame                  /* ppc:5352                          */
+        ret                                 /* ppc:5353 blr                      */
+endsp restorecontext
+
+/* ported from ppc-spentry.s:5320-5328 (PPC64 branch) */
+/* Restore full context: jump to the CALLER's return address while restoring
+   the frame's saved lr (i.e. the frame's savelr goes into lr, but execution
+   resumes at what lr was on entry — the PPC ctr trick). */
+spentry restorefullcontext
+        /* ppc-spentry.s:5320-5328.  PPC idiom: mflr->mtctr, restore lr from
+           frame, bctr.  ARM64 equivalent: save lr in scratch, restore lr from
+           frame (so the "saved" return address lives in lr for its eventual
+           caller), then branch to the original lr via the scratch.  imm0 is
+           free (no live inputs besides the frame on sp). */
+        mov imm0, lr                        /* ppc:5321-5322 mflr+mtctr (save lr)*/
+        ldr lr, [sp, #lisp_frame.savelr]    /* ppc:5323-5324 restore saved lr    */
+        ldr vsp, [sp, #lisp_frame.savevsp]  /* ppc:5325                          */
+        ldr fn, [sp, #lisp_frame.savefn]    /* ppc:5326                          */
+        discard_lisp_frame                  /* ppc:5327                          */
+        br imm0                             /* ppc:5328 bctr                     */
+endsp restorefullcontext
+
+/* ported from ppc-spentry.s:6743-6756 (PPC64 branch) */
+/* Restore current thread's interrupt level to arg_z, noting whether the
+   tcr's interrupt_pending flag was set.  If level is being restored to 0
+   and an interrupt was pending, signal it now. */
+spentry restoreintlevel
+        /* ppc-spentry.s:6743-6756.  Two conditions checked:
+           1) arg_z != 0 (not restoring to level-0) → just store
+           2) tcr.interrupt_pending == 0 → just store
+           Both false → clear pending flag, trap (deferred interrupt). */
+        cmp arg_z, #0                       /* ppc:6744 cmpri(cr1,arg_z,0)       */
+        ldr imm0, [rcontext, #tcr.interrupt_pending] /* ppc:6745                 */
+        b.ne 1f                             /* ppc:6747 bne cr1,1f (not level-0) */
+        cbz imm0, 1f                        /* ppc:6748 beq cr0,1f (nothing pending) */
+        str xzr, [rcontext, #tcr.interrupt_pending] /* ppc:6749 str(rzero,...)   */
+        mov nargs, #fixnum_one              /* ppc:6750 li nargs,fixnum_one      */
+        uuo_interrupt_now               /* ppc:6751 trgti: deferred-interrupt (uuo_misc 4 at the pin) */
+        /* intended: trap if nargs>0, i.e. always — signals deferred interrupt   */
+        ret                                 /* ppc:6752 blr (unreachable past trap) */
+1:
+        ldr nargs, [rcontext, #tcr.tlb_pointer]  /* ppc:6754                     */
+        str arg_z, [nargs, #INTERRUPT_LEVEL_BINDING_INDEX] /* ppc:6755           */
+        ret                                 /* ppc:6756 blr                      */
+endsp restoreintlevel
+
+/* ported from ppc-spentry.s:6726-6739 (PPC64 branch) */
+/* arg_y = special symbol, arg_z = new value.  Set the thread-local binding
+   if one exists; otherwise fall through to gvset on the symbol's vcell. */
+spentry specset
+        /* ppc-spentry.s:6726-6739.  Sibling of specref/specrefcheck (getters):
+           same tlb_pointer/tlb_limit access pattern, but STORES instead of
+           loading; on no_thread_local_binding_marker hit, stores to
+           symbol.vcell via _SPgvset. */
+        ldr imm3, [arg_y, #symbol.binding_index]   /* ppc:6727                  */
+        ldr imm0, [rcontext, #tcr.tlb_limit]       /* ppc:6728                  */
+        ldr imm2, [rcontext, #tcr.tlb_pointer]     /* ppc:6729                  */
+        cmp imm3, imm0                      /* ppc:6730 cmpr(imm3,imm0)          */
+        b.hs 1f                             /* ppc:6731 bge 1f (index>=limit)    */
+        ldr temp1, [imm2, imm3]             /* ppc:6732 ldrx(temp1,imm2,imm3)   */
+        cmp temp1, #no_thread_local_binding_marker /* ppc:6733                   */
+        b.eq 1f                             /* ppc:6734 beq 1f (no local binding)*/
+        str arg_z, [imm2, imm3]             /* ppc:6735 strx(arg_z,imm2,imm3)   */
+        ret                                 /* ppc:6736 blr                      */
+1:      /* No thread-local binding: store to symbol.vcell via _SPgvset.
+           ppc:6737-6739: arg_x=symbol, arg_y=byte-offset, tail to _SPgvset. */
+        mov arg_x, arg_y                    /* ppc:6737 mr arg_x,arg_y           */
+        mov arg_y, #(symbol.vcell - misc_data_offset) /* ppc:6738                */
+        b _SPgvset                          /* ppc:6739 b _SPgvset               */
+endsp specset
+
+/* ported from ppc-spentry.s:3246-3268 (PPC64 branch) */
+/* Make a stack-consed value cell.  imm0 points to the closed-over value
+   (already vpushed as a locative offset from vsp).  Replace that locative
+   with the newly-minted vcell.  Sibling of stkvcellvsp (which is the same
+   but assumes imm0 == vsp on entry). */
+spentry stkvcell0
+        /* ppc-spentry.s:3246-3268.  Like stkvcellvsp but imm0 is a locative
+           pointing INTO the vstack (not necessarily vsp): compute delta first,
+           then push 3 NILs, recompute, and overlay exactly as stkvcellvsp. */
+        sub imm1, imm0, vsp             /* ppc:3247 sub imm1,imm0,vsp (delta)   */
+        mov arg_z, rnil                 /* ppc:3248 li arg_z,nil_value           */
+        vpush1 arg_z                    /* ppc:3249 vpush(arg_z)                 */
+        vpush1 arg_z                    /* ppc:3250 vpush(arg_z)                 */
+        vpush1 arg_z                    /* ppc:3251 vpush(arg_z)                 */
+        add imm1, imm1, #(node_size*3)  /* ppc:3252 addi imm1,imm1,node_size*3  */
+        add imm0, vsp, imm1             /* ppc:3253 add imm0,vsp,imm1 (recompute)*/
+        tst vsp, #(1<<3)                /* ppc:3254 andi. imm1,vsp,1<<word_shift */
+        mov imm1, #value_cell_header    /* ppc:3255 li imm1,value_cell_header    */
+        ldr arg_z, [imm0]              /* ppc:3256 ldr(arg_z,0(imm0))           */
+        b.eq 1f                         /* ppc:3257 beq cr0 -> even-vsp layout   */
+        str arg_z, [vsp, #(node_size*2)]/* ppc:3258                              */
+        str imm1, [vsp, #node_size]     /* ppc:3259                              */
+        add arg_z, vsp, #(fulltag_misc+node_size) /* ppc:3260 la                 */
+        str arg_z, [imm0]              /* ppc:3261                              */
+        ret                             /* ppc:3262 blr                          */
+1:      /* ppc:3263 even-vsp layout */
+        str arg_z, [vsp, #node_size]    /* ppc:3264                              */
+        str imm1, [vsp]                /* ppc:3265                              */
+        add arg_z, vsp, #fulltag_misc   /* ppc:3266 la                           */
+        str arg_z, [imm0]              /* ppc:3267                              */
+        ret                             /* ppc:3268 blr                          */
+endsp stkvcell0
+
+/* NOTES
+ *
+ * All 41 subprims in this cluster carry real ported bodies (0 stubs).
+ * Every site that depends on a constant/convention Matt has not yet defined
+ * is guarded with #error + the intended instruction in a comment; the deduped
+ * union lives in upstream-port/MISSING-CONSTANTS-RATIFY.md.  Open #error
+ * classes in this file:
+ *   - ret1val_addr ref-global idiom (values, ppc:1217)
+ *   - error_too_many_values uuo_interr trap convention (values, ppc:1235)
+ *   - nrs.kallowotherkeys rnil-relative ref (keyword_bind ppc:1507,
+ *     destructuring_bind_inner ppc:3753)
+ *   - stack-overflow (trllt) trap convention (savecontextvsp ppc:5333;
+ *     savecontext0 ppc:5342)
+ *   - deferred-interrupt trap trgti (restoreintlevel ppc:6751)
+ * PROPOSED (ratify): mask_initopt/keyp/aok/restp adopt the ARM32 bit layout
+ * (arm-constants.s:561-567), NOT the PPC big-endian bit indices; must match
+ * the compiler's doadlword emission when Matt defines it.
+ * Struct layouts (catch_frame with nsaveregs=4, lisp_frame, tsp_frame,
+ * binding, symbol) are PROPOSED in this file's header blocks; the C runtime
+ * and GC must agree.
+ */

--- a/lisp-kernel/spentry-D-call-builtins.s
+++ b/lisp-kernel/spentry-D-call-builtins.s
@@ -1,0 +1,1717 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * ARM64 subprim implementations: call/arglist/builtin operations (59 subprims)
+ * Ported from PPC64 to ARM64 for upstream low-tag design
+ */
+
+#include "arm64-constants.h"
+#include "arm64-macros.s"
+#include "arm64-globals-proposed.s"
+
+/* ========== BUILTIN FUNCTION VECTOR INDICES ========== */
+/* From vendor/ccl/lisp-kernel/ppc-constants.s:128-151.
+ * These are lisp-level vector indices into %builtin-functions% --
+ * arch-independent, safe to define here. */
+.set _builtin_plus,     0
+.set _builtin_minus,    1
+.set _builtin_times,    2
+.set _builtin_div,      3
+.set _builtin_eq,       4
+.set _builtin_ne,       5
+.set _builtin_gt,       6
+.set _builtin_ge,       7
+.set _builtin_lt,       8
+.set _builtin_le,       9
+.set _builtin_eql,      10
+.set _builtin_length,   11
+.set _builtin_seqtype,  12
+.set _builtin_assq,     13
+.set _builtin_memq,     14
+.set _builtin_logbitp,  15
+.set _builtin_logior,   16
+.set _builtin_logand,   17
+.set _builtin_ash,      18
+.set _builtin_negate,   19
+.set _builtin_logxor,   20
+.set _builtin_aref1,    21
+.set _builtin_aset1,    22
+
+/* ========== LOCAL HELPER MACROS ========== */
+
+/* vstack push/pop (grows toward lower addresses). */
+.macro vpush1 reg
+        str \reg, [vsp, #-node_size]!
+.endm
+.macro vpop1 reg
+        ldr \reg, [vsp], #node_size
+.endm
+
+/* nargs is a BOXED fixnum (== byte count of value block on the vstack). */
+.macro set_nargs n
+        mov nargs, #((\n)<<fixnumshift)
+.endm
+
+/* lisp_frame: Matt's ARM-family MARKER frame, NOT PPC's backlink frame
+ * (ground truth: his popj vinsn, compiler/ARM64/arm64-vinsns.lisp:61-67,
+ * + subtag_lisp_frame_marker, arm64-constants.h:177).  Same equates as
+ * spentry-A:55-59 / spentry-E.  Frame builds store #lisp_frame_marker at
+ * slot 0; there is NO backlink word. */
+.set lisp_frame.marker, 0
+.set lisp_frame.savevsp, 8
+.set lisp_frame.savefn, 16
+.set lisp_frame.savelr, 24
+.set lisp_frame.size, 32
+
+/* symbol.fcell / function codevector: slot order from ppc-constants64.s
+ * :237-245/:223-226.  Symbols keep their dedicated pointer tag; a function
+ * is an ordinary miscobj (fulltag_function removed, patch 0055), so its
+ * codevector slot sits at misc_data_offset (-4). */
+.set symbol.fcell, (3*node_size - fulltag_symbol)
+.set _function.codevector, misc_data_offset
+
+/* fixnum 1 (x86-constants64.s:414). */
+.set fixnumone, (1<<fixnumshift)
+
+/* T = rnil + t_offset.  Derived from Matt's arm64-arch.lisp:184-188:
+ * canonical-nil-value = #x13000+fulltag_nil, canonical-t-value =
+ * #x13020+fulltag_symbol, t-offset = their difference (= 0x1c).  The
+ * absolute addresses are provisional ("xxx nil can't be a constant") but
+ * the OFFSET is the ratified geometry: T is the symbol after NIL's
+ * cons/symbol pun cell. */
+.set t_offset, ((0x13020 + fulltag_symbol) - (0x13000 + fulltag_nil))
+
+/* vectorH.logsize: slot 0 of a (misc-tagged) vector header,
+ * ppc-constants64.s:259-265 _structf(vectorH). */
+.set vectorH.logsize, misc_data_offset
+
+/* Lisp error selectors: errors.s deferr(NAME,N) = boxed fixnum N. */
+.set XSTKOVER,  (75<<fixnumshift)       /* errors.s:196  */
+.set XNOSPREAD, (120<<fixnumshift)      /* errors.s:202  */
+
+/* Kernel (uuo) error codes - raw, NOT boxed.  errors.s top block. */
+.set error_object_not_list, 133         /* errors.s:38-48 def_type_error
+                                           counter: 128=array +5 => list */
+
+/* GC write-barrier shift constants (same derivations as spentry-B). */
+.set dnode_shift, 4
+.set bitmap_shift, 6
+
+/* UUO / trap encodings.  CANONICAL: arm64-asm.lisp:435-450 (Matt's active
+ * layer) = `udf #imm16`, low 3 bits = format.  fmt 3 = unary-misc is a
+ * PROPOSED extension (reg in 7:3, sub in 15:8: 0 not_callable,
+ * 1 no_throw_tag, 2 tlb_too_small, 3 unbound, >= 4 = errors.s errnum —
+ * not_list below; full namespace doc: spentry-A's trap block).
+ * arm64-exceptions.c must decode.  gpr numbers for the registers here. */
+/* trap_unless_list's trap (ppc-macros.s): object in \gpr is not a list. */
+
+/* discard_lisp_frame: pop one lisp frame from sp. */
+.macro discard_lisp_frame
+        add sp, sp, #lisp_frame.size
+.endm
+
+/* jump_builtin: dispatch to Lisp builtin handler via %builtin-functions%
+ * vector.  Macro equivalent of PPC64 jump_builtin (ppc-spentry.s:37-42);
+ * nrs/globals idiom per arm64-globals-proposed.s. */
+.macro jump_builtin idx, nargs_count
+        ref_nrs_value fname, builtin_functions
+        set_nargs \nargs_count
+        ldr fname, [fname, #(misc_data_offset + (\idx) * node_size)]
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+.endm
+
+/* ========== BASIC CALL/JUMP OPERATIONS ========== */
+
+/* ported from ppc-spentry.s:44-45 (PPC64 branch: jump_fname macro) */
+spentry jmpsym
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp jmpsym
+
+/* ported from ppc-spentry.s:47-48 (PPC64 branch: jump_nfn macro) */
+spentry jmpnfn
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp jmpnfn
+
+/* ported from ppc-spentry.s:51-52 (PPC64 branch: do_funcall macro,
+ * ppc-macros.s).  Call temp0 if it is a symbol or a function, else trap.
+ * PPC dispatches on the TYPECODE (subtag_symbol / subtag_function);
+ * here symbols keep a dedicated pointer fulltag, while a function is an
+ * ordinary miscobj (fulltag_function removed, patch 0055), so: symbol
+ * fulltag -> fcell, misc fulltag + header subtag_function -> call, else
+ * trap.  The SYMBOL path jumps through the fcell object's slot 0
+ * UNCHECKED, exactly like PPC64: a real function's slot 0 is its
+ * codevector, and the macro/special-op/udf fcell simple-vectors carry
+ * %macro-code%/%udf-code% at slot 0, which signal. */
+spentry funcall
+        and imm0, temp0, #fulltagmask
+        cmp imm0, #fulltag_symbol
+        b.eq 2f
+        cmp imm0, #fulltag_misc
+        b.ne 3f
+        ldrb w1, [temp0, #misc_subtag_offset]  /* imm1 = header subtag (ldurb form) */
+        cmp imm1, #subtag_function
+        b.ne 3f
+        mov nfn, temp0
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+2:      /* symbol: call its function cell (unchecked slot-0 jump) */
+        mov fname, temp0
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+3:      /* ppc-macros.s do_funcall: uuo_interr(error_cant_call, temp0) */
+        uuo_error_reg_not_callable temp0 /* his macro name */
+endsp funcall
+
+/* ========== CONS MUTATION (with EGC write barrier) ========== */
+
+/* ported from ppc-spentry.s:482-520 (PPC64 branch).
+ * The store is real; the EGC write-barrier memoization (ppc:487-519:
+ * dnode math on (arg_y - ref_base), set bit in refbits + ephemeral_refidx
+ * with ldxr/stxr) needs the ref_base/oldspace_dnode_count/refbits/
+ * ephemeral_refidx GLOBALS, which have no ARM64 anchor yet - the same
+ * open idiom as the spentry-B barrier sites.  #error so a build cannot
+ * silently drop the memoization (young-object refs would be lost by the
+ * EGC). */
+/* pc_luser_xp window labels (ppc-spentry.s:480-486 places egc_rplaca at
+ * the subprim entry and did_store right after the str; NOTE: PPC's single
+ * contiguous [write_barrier_start, write_barrier_end) window does NOT
+ * exist on ARM64 — the barrier family is split between this file and
+ * spentry-B, so arm64-exceptions.c's pc_luser_xp checks per-family
+ * windows instead). */
+        .globl C(egc_rplaca)
+        .globl C(egc_rplaca_did_store)
+spentry rplaca
+C(egc_rplaca):
+        cmp arg_z, arg_y                /* ppc:484 cmplr(cr2,arg_z,arg_y)  */
+        str arg_z, [arg_y, #cons.car]   /* ppc:485 _rplaca                 */
+C(egc_rplaca_did_store):
+        b.ls 1f                         /* ppc:487 blelr cr2 (no barrier)  */
+        ref_global imm2, ref_base               /* ppc:488 ref_global      */
+        mov imm3, #0x8000000000000000           /* ppc:489 load_highbit    */
+        ref_global imm1, oldspace_dnode_count   /* ppc:493                 */
+        sub imm0, arg_y, imm2                   /* ppc:490                 */
+        lsr imm0, imm0, #dnode_shift            /* ppc:491                 */
+        cmp imm0, imm1                          /* ppc:495 cmplr           */
+        lsr imm2, imm0, #8                      /* ppc:492 refidx granule  */
+        and imm4, imm0, #0x3f                   /* ppc:494 bit shift count */
+        lsr imm0, imm0, #bitmap_shift           /* ppc:497                 */
+        lsr imm3, imm3, imm4                    /* ppc:496                 */
+        ref_global temp0, refbits               /* ppc:498                 */
+        b.hs 1f                                 /* ppc:499 bgelr (UNSIGNED)*/
+        lsl imm0, imm0, #3                      /* ppc:500 word_shift      */
+        ldr imm1, [temp0, imm0]                 /* ppc:501                 */
+        tst imm1, imm3                          /* ppc:502 and.            */
+        b.ne 1f                                 /* ppc:503 bnelr           */
+        add temp0, temp0, imm0                  /* ldxr/stxr take [Xn]     */
+2:      ldxr imm1, [temp0]                      /* ppc:504 lrarx           */
+        orr imm1, imm1, imm3                    /* ppc:505                 */
+        stxr w17, imm1, [temp0]                  /* ppc:506 strcx           */
+        cbnz w17, 2b                             /* ppc:507                 */
+        dmb ish                                 /* ppc:508 isync           */
+        and imm4, imm2, #0x3f                   /* ppc:509                 */
+        lsr imm2, imm2, #bitmap_shift           /* ppc:510                 */
+        mov imm3, #0x8000000000000000           /* ppc:511                 */
+        ref_global temp0, ephemeral_refidx      /* ppc:512                 */
+        lsl imm2, imm2, #3                      /* ppc:513                 */
+        lsr imm3, imm3, imm4                    /* ppc:514                 */
+        add temp0, temp0, imm2                  /* ldxr/stxr take [Xn]     */
+3:      ldxr imm1, [temp0]                      /* ppc:515 lrarx           */
+        orr imm1, imm1, imm3                    /* ppc:516                 */
+        stxr w17, imm1, [temp0]                  /* ppc:517 strcx           */
+        cbnz w17, 3b                             /* ppc:518                 */
+        dmb ish                                 /* ppc:519 isync           */
+1:      ret
+endsp rplaca
+
+/* ported from ppc-spentry.s:524-562 (PPC64 branch); see rplaca above. */
+/* pc_luser_xp window labels (ppc-spentry.s:522-528). */
+        .globl C(egc_rplacd)
+        .globl C(egc_rplacd_did_store)
+spentry rplacd
+C(egc_rplacd):
+        cmp arg_z, arg_y
+        str arg_z, [arg_y, #cons.cdr]
+C(egc_rplacd_did_store):
+        b.ls 1f
+        ref_global imm2, ref_base               /* ppc:528 ref_global      */
+        mov imm3, #0x8000000000000000           /* ppc:529 load_highbit    */
+        ref_global imm1, oldspace_dnode_count   /* ppc:533                 */
+        sub imm0, arg_y, imm2                   /* ppc:530                 */
+        lsr imm0, imm0, #dnode_shift            /* ppc:531                 */
+        cmp imm0, imm1                          /* ppc:535 cmplr           */
+        lsr imm2, imm0, #8                      /* ppc:532 refidx granule  */
+        and imm4, imm0, #0x3f                   /* ppc:534 bit shift count */
+        lsr imm0, imm0, #bitmap_shift           /* ppc:537                 */
+        lsr imm3, imm3, imm4                    /* ppc:536                 */
+        ref_global temp0, refbits               /* ppc:538                 */
+        b.hs 1f                                 /* ppc:539 bgelr (UNSIGNED)*/
+        lsl imm0, imm0, #3                      /* ppc:540 word_shift      */
+        ldr imm1, [temp0, imm0]                 /* ppc:541                 */
+        tst imm1, imm3                          /* ppc:542 and.            */
+        b.ne 1f                                 /* ppc:543 bnelr           */
+        add temp0, temp0, imm0                  /* ldxr/stxr take [Xn]     */
+2:      ldxr imm1, [temp0]                      /* ppc:544 lrarx           */
+        orr imm1, imm1, imm3                    /* ppc:545                 */
+        stxr w17, imm1, [temp0]                  /* ppc:546 strcx           */
+        cbnz w17, 2b                             /* ppc:547                 */
+        dmb ish                                 /* ppc:548 isync           */
+        and imm4, imm2, #0x3f                   /* ppc:549                 */
+        lsr imm2, imm2, #bitmap_shift           /* ppc:550                 */
+        mov imm3, #0x8000000000000000           /* ppc:551                 */
+        ref_global temp0, ephemeral_refidx      /* ppc:552                 */
+        lsl imm2, imm2, #3                      /* ppc:553                 */
+        lsr imm3, imm3, imm4                    /* ppc:554                 */
+        add temp0, temp0, imm2                  /* ldxr/stxr take [Xn]     */
+3:      ldxr imm1, [temp0]                      /* ppc:555 lrarx           */
+        orr imm1, imm1, imm3                    /* ppc:556                 */
+        stxr w17, imm1, [temp0]                  /* ppc:557 strcx           */
+        cbnz w17, 3b                             /* ppc:558                 */
+        dmb ish                                 /* ppc:559 isync           */
+1:      ret
+/* end of the rplaca/rplacd pc_luser_xp window (this file's half of the
+ * split barrier family; spentry-B holds the other four families). */
+        .globl C(egc_rplacd_end)
+C(egc_rplacd_end):
+endsp rplacd
+
+/* ========== MULTIPLE VALUES ========== */
+
+/* ported from ppc-spentry.s:1153-1165 (PPC64 branch).
+ * Funcall temp0, returning multiple values if it does. */
+spentry mvpass
+        cmp nargs, #(nargregs<<fixnumshift)     /* ppc:1154                */
+        mov imm0, vsp                           /* ppc:1156                */
+        b.le 1f                                 /* ppc:1157                */
+        sub imm0, imm0, #(nargregs<<fixnumshift) /* ppc:1158               */
+        add imm0, imm0, nargs                   /* ppc:1159                */
+1:
+        /* ppc:1161 build_lisp_frame(fn,loc_pc,imm0) - MARKER frame */
+        sub sp, sp, #lisp_frame.size
+        mov temp1, #lisp_frame_marker
+        str temp1, [sp, #lisp_frame.marker]
+        str imm0,  [sp, #lisp_frame.savevsp]
+        str fn,    [sp, #lisp_frame.savefn]
+        str lr,    [sp, #lisp_frame.savelr]
+        /* ppc:1162 ref_global(loc_pc,ret1val_addr); ppc:1164 mtlr */
+        ref_global lr, ret1val_addr             /* ppc:1162+1164           */
+        mov fn, xzr                             /* ppc:1163 li fn,0        */
+        b _SPfuncall                            /* ppc:1165 do_funcall     */
+endsp mvpass
+
+/* ported from ppc-spentry.s:1181-1193 (PPC64 branch) */
+spentry fitvals
+        /* Adjust value count: imm0 = desired count, nargs = actual count */
+        subs imm0, imm0, nargs
+        mov imm1, rnil
+        b.ge 2f
+        /* Too many values - discard extras */
+        sub vsp, vsp, imm0
+        ret
+1:      /* Push nils */
+        subs imm0, imm0, #node_size
+        str imm1, [vsp, #-node_size]!
+        add nargs, nargs, #node_size
+2:      b.ne 1b
+        ret
+endsp fitvals
+
+/* ported from ppc-spentry.s:1196-1207 (PPC64 branch) */
+spentry nthvalue
+        /* Get nth value: top of vstack is index (tagged fixnum) */
+        add imm0, vsp, nargs            /* ppc:1197                        */
+        ldr imm1, [imm0]                /* ppc:1198                        */
+        cmp imm1, nargs                 /* ppc:1199 cmplr = UNSIGNED, so a
+                                           negative index wraps high => nil */
+        mov arg_z, rnil                 /* ppc:1200                        */
+        neg imm1, imm1                  /* ppc:1201                        */
+        sub imm1, imm1, #node_size      /* ppc:1202                        */
+        b.hs 1f                         /* ppc:1203 bge on the UNSIGNED cmp */
+        ldr arg_z, [imm0, imm1]         /* ppc:1204 ldrx                   */
+1:      add vsp, imm0, #node_size       /* ppc:1206                        */
+        ret
+endsp nthvalue
+
+/* ported from ppc-spentry.s:1270-1276 (PPC64 branch).
+ * Come here with saved context on top of stack.  Tail into the shared
+ * return_values entry exported by spentry-C (_spentry(values):
+ * contract there is temp4 = return pc, temp0 = entry vsp). */
+/* pmcl-kernel.c:2110 takes &nvalret for lisp_global(LEXPR_RETURN)
+   (PPC exports it the same way, ppc-spentry.s:1267-1271). */
+        .globl C(nvalret)
+spentry nvalret
+C(nvalret):
+        ldr temp4, [sp, #lisp_frame.savelr]     /* ppc:1272 ldr loc_pc     */
+        ldr temp0, [sp, #lisp_frame.savevsp]    /* ppc:1273                */
+        ldr fn, [sp, #lisp_frame.savefn]        /* ppc:1274                */
+        discard_lisp_frame                      /* ppc:1275                */
+        b return_values                         /* ppc:1276 (.globl in C)  */
+endsp nvalret
+
+/* ========== OPTIONAL/REST/KEYWORD ARGUMENTS ========== */
+
+/* ported from ppc-spentry.s:1282-1293 (PPC64 branch).
+ * Provide nil defaults for missing &optional args; imm0 = (fixnum) upper
+ * limit on required + &optional count.  nargs preserved.
+ * ARM64-DEVIATION: PPC parks nil in imm5, but Matt's imm5 ALIASES nargs
+ * (arm64-constants.h:45-46, the ledger's imm5/x5-vs-x6 item) - use temp0.
+ * The nargs-vs-imm0 compare is redone AFTER the vpush block (whose cmp
+ * clobbers NZCV) and is UNSIGNED (ppc:1283 cmplr). */
+spentry default_optional_args
+        mov temp0, rnil                 /* ppc:1284 li imm5,nil_value      */
+        /* ppc:1285 vpush_argregs */
+        cbz nargs, 2f
+        cmp nargs, #(2<<fixnumshift)
+        b.lt 3f
+        b.eq 4f
+        str arg_x, [vsp, #-node_size]!
+4:      str arg_y, [vsp, #-node_size]!
+3:      str arg_z, [vsp, #-node_size]!
+2:
+        mov imm1, nargs                 /* ppc:1286                        */
+        cmp nargs, imm0                 /* ppc:1283 cmplr(cr7,nargs,imm0)  */
+        b.hs 1f                         /* ppc:1287 bgelr cr7 (unsigned)   */
+5:      add imm1, imm1, #fixnumone      /* ppc:1289                        */
+        cmp imm1, imm0                  /* ppc:1290                        */
+        str temp0, [vsp, #-node_size]!  /* ppc:1291 vpush(nil)             */
+        b.ne 5b                         /* ppc:1292                        */
+1:      ret
+endsp default_optional_args
+
+/* ported from ppc-spentry.s:1299-1315 (PPC64 branch).
+ * Push T/NIL supplied-p flags for each of the imm0 &optional args;
+ * supplied iff (< i nargs), computed branchlessly exactly as PPC64
+ * (xor/sradi/or/sub/srdi = sign-bit trick; both operands are nonnegative
+ * fixnums, then flag * t_offset + nil). */
+spentry opt_supplied_p
+        mov imm1, xzr                   /* ppc:1300                        */
+1:      eor imm2, imm1, nargs           /* ppc:1304                        */
+        asr imm2, imm2, #63             /* ppc:1305 sradi                  */
+        orr imm2, imm2, imm1            /* ppc:1306                        */
+        add imm1, imm1, #fixnumone      /* ppc:1307 addi fixnumone         */
+        cmp imm1, imm0                  /* ppc:1308                        */
+        sub imm2, imm2, nargs           /* ppc:1309 subf                   */
+        lsr imm2, imm2, #63             /* ppc:1310 srdi -> 1 iff supplied */
+        mov temp0, #t_offset            /* ppc:1311 mulli imm2,t_offset    */
+        mul imm2, imm2, temp0
+        add imm2, imm2, rnil            /* ppc:1312 addi imm2,nil_value    */
+        str imm2, [vsp, #-node_size]!   /* ppc:1313 vpush                  */
+        b.ne 1b                         /* ppc:1314                        */
+        ret
+endsp opt_supplied_p
+
+/* ported from ppc-spentry.s:1336-1352 (PPC64 branch).
+ * If nargs <= imm0(=0 here), vpush nil; else cons a list of the excess
+ * args and vpush it.
+ * ARM64-DEVIATION (all three rest-arg loops): PPC compares BEFORE Cons
+ * (PPC's Cons preserves CR); Matt's Cons macro does `cmp allocptr,
+ * allocbase` (arm64-macros.s:36-45) and CLOBBERS NZCV, so the loop test
+ * is a fresh `cmp imm1, #0` AFTER the decrement. */
+spentry heap_rest_arg
+        mov imm0, xzr                   /* ppc:1337                        */
+        /* ppc:1338 vpush_argregs */
+        cbz nargs, 2f
+        cmp nargs, #(2<<fixnumshift)
+        b.lt 3f
+        b.eq 4f
+        str arg_x, [vsp, #-node_size]!
+4:      str arg_y, [vsp, #-node_size]!
+3:      str arg_z, [vsp, #-node_size]!
+2:
+        sub imm1, nargs, imm0           /* ppc:1339                        */
+        mov arg_z, rnil                 /* ppc:1341                        */
+        b 6f
+5:      ldr temp0, [vsp]                /* ppc:1344                        */
+        add vsp, vsp, #node_size        /* ppc:1346                        */
+        Cons arg_z, temp0, arg_z        /* ppc:1347                        */
+        sub imm1, imm1, #fixnumone      /* ppc:1348                        */
+6:      cmp imm1, #0                    /* ppc:1340/1345 (post-Cons here)  */
+        b.gt 5b
+        str arg_z, [vsp, #-node_size]!  /* ppc:1350 vpush                  */
+        ret
+endsp heap_rest_arg
+
+/* ported from ppc-spentry.s:1358-1373 (PPC64 branch).
+ * Like heap_rest_arg, but imm0 = (fixnum) count of required args to
+ * leave on the vstack.  Flags note as heap_rest_arg. */
+spentry req_heap_rest_arg
+        /* vpush_argregs */
+        cbz nargs, 2f
+        cmp nargs, #(2<<fixnumshift)
+        b.lt 3f
+        b.eq 4f
+        str arg_x, [vsp, #-node_size]!
+4:      str arg_y, [vsp, #-node_size]!
+3:      str arg_z, [vsp, #-node_size]!
+2:
+        sub imm1, nargs, imm0
+        mov arg_z, rnil
+        b 6f
+5:      ldr temp0, [vsp]
+        add vsp, vsp, #node_size
+        Cons arg_z, temp0, arg_z
+        sub imm1, imm1, #fixnumone
+6:      cmp imm1, #0
+        b.gt 5b
+        str arg_z, [vsp, #-node_size]!
+        ret
+endsp req_heap_rest_arg
+
+/* ported from ppc-spentry.s:1376-1390 (PPC64 branch).
+ * As above, argregs already vpushed by caller.  Flags note as
+ * heap_rest_arg. */
+spentry heap_cons_rest_arg
+        sub imm1, nargs, imm0
+        mov arg_z, rnil
+        b 2f
+1:      ldr temp0, [vsp]
+        add vsp, vsp, #node_size
+        Cons arg_z, temp0, arg_z
+        sub imm1, imm1, #fixnumone
+2:      cmp imm1, #0
+        b.gt 1b
+        str arg_z, [vsp, #-node_size]!
+        ret
+endsp heap_cons_rest_arg
+
+/* ported from ppc-spentry.s:1393-1396 (PPC64 branch) */
+spentry simple_keywords
+        mov imm0, xzr
+        /* vpush argregs */
+        cbz nargs, 2f
+        cmp nargs, #(node_size * 2)
+        b.lt 3f
+        b.eq 4f
+        str arg_x, [vsp, #-node_size]!
+4:      str arg_y, [vsp, #-node_size]!
+3:      str arg_z, [vsp, #-node_size]!
+2:      b _SPkeyword_bind
+endsp simple_keywords
+
+/* ported from ppc-spentry.s:1398-1400 (PPC64 branch) */
+spentry keyword_args
+        /* vpush argregs */
+        cbz nargs, 2f
+        cmp nargs, #(node_size * 2)
+        b.lt 3f
+        b.eq 4f
+        str arg_x, [vsp, #-node_size]!
+4:      str arg_y, [vsp, #-node_size]!
+3:      str arg_z, [vsp, #-node_size]!
+2:      b _SPkeyword_bind
+endsp keyword_args
+
+/* ported from ppc-spentry.s:2020-2022 (PPC64 branch):
+ * li fname,nrs.errdisp; jump_fname. */
+spentry ksignalerr
+        ref_nrs_symbol fname, errdisp   /* ppc:2021 li fname,nrs.errdisp   */
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp ksignalerr
+
+/* ========== CLOSURE CALLS ========== */
+
+/* ported from ppc-spentry.s:2076-2166 (PPC64 branch).
+ * Prepend all but the first two (closure code, fn) and last two (name,
+ * lfbits) elements of nfn (the closure vector) to the arglist, then call
+ * the function in slot 1.  PPC keeps two condition registers live (cr0 =
+ * nargs vs nargregs, cr1 = nargs vs 1); flattened here with re-compares
+ * placed so no intervening instruction sets NZCV (ldr/str/add/sub/mov are
+ * all non-flag-setting).  Labels are .L-local to avoid numeric-label
+ * leaks across this long body. */
+spentry call_closure
+        /* The closure arrives misc-tagged (fulltag_function removed,
+         * patch 0055), and this body addresses it misc-relative (PPC
+         * shape) - no retag needed, exactly as on PPC. */
+        /* ppc:2079-2080 vector_length(imm0,nfn,imm0) - 4 slots overhead */
+        ldr imm0, [nfn, #misc_header_offset]
+        lsr imm0, imm0, #num_subtag_bits
+        lsl imm0, imm0, #fixnumshift
+        sub imm0, imm0, #(4<<fixnumshift)   /* imm0 = inherited arg count  */
+        mov imm1, #(misc_data_offset + (2<<fixnumshift)) /* ppc:2081 1st arg */
+        mov imm4, rnil                      /* ppc:2082                    */
+        cmp nargs, #(nargregs<<fixnumshift) /* ppc:2077 cmpri cr0          */
+        b.le .Lcc_no_insert                 /* ppc:2083 ble cr0            */
+        /* Args already vpushed: vpush imm0 NILs, slide the vpushed args
+           down, insert the inherited args (ppc:2084-2115). */
+        mov imm2, #0                        /* ppc:2088                    */
+.Lcc_push_nil_loop:
+        add imm2, imm2, #fixnumone          /* ppc:2090                    */
+        cmp imm2, imm0                      /* ppc:2091 cmpr cr2           */
+        str imm4, [vsp, #-node_size]!       /* ppc:2092 vpush              */
+        b.ne .Lcc_push_nil_loop             /* ppc:2093                    */
+        mov imm3, vsp                       /* ppc:2095                    */
+        add imm4, vsp, imm0                 /* ppc:2096                    */
+        sub imm2, nargs, #(nargregs<<fixnumshift) /* ppc:2097              */
+.Lcc_copy_already_loop:
+        cmp imm2, #fixnumone                /* ppc:2099 cmpri cr2          */
+        sub imm2, imm2, #fixnumone          /* ppc:2100                    */
+        ldr fname, [imm4]                   /* ppc:2101                    */
+        add imm4, imm4, #fixnumone          /* ppc:2102                    */
+        str fname, [imm3]                   /* ppc:2103                    */
+        add imm3, imm3, #fixnumone          /* ppc:2104                    */
+        b.ne .Lcc_copy_already_loop         /* ppc:2105                    */
+.Lcc_insert_loop:
+        cmp imm0, #fixnumone                /* ppc:2108 cmpri cr2          */
+        ldr fname, [nfn, imm1]              /* ppc:2109 ldrx               */
+        add imm1, imm1, #fixnumone          /* ppc:2110                    */
+        add nargs, nargs, #fixnumone        /* ppc:2111                    */
+        sub imm0, imm0, #fixnumone          /* ppc:2112                    */
+        str fname, [imm4, #-node_size]!     /* ppc:2113 push(fname,imm4)   */
+        b.ne .Lcc_insert_loop               /* ppc:2114                    */
+        b .Lcc_go                           /* ppc:2115                    */
+.Lcc_no_insert:
+        /* nargregs or fewer args vpushed (ppc:2116-2120); NZCV still holds
+           the nargs-vs-nargregs compare. */
+        add imm2, imm1, imm0                /* ppc:2119                    */
+        b.ne .Lcc_set_regs                  /* ppc:2120 bne cr0            */
+.Lcc_vpush_remaining:                       /* exactly nargregs args       */
+        cmp imm0, #fixnumone                /* ppc:2122 cmpri cr2          */
+        ldr fname, [nfn, imm1]              /* ppc:2123                    */
+        add imm1, imm1, #fixnumone          /* ppc:2124                    */
+        str fname, [vsp, #-node_size]!      /* ppc:2125 vpush              */
+        sub imm0, imm0, #fixnumone          /* ppc:2126                    */
+        add nargs, nargs, #fixnumone        /* ppc:2127                    */
+        b.ne .Lcc_vpush_remaining           /* ppc:2128                    */
+        b .Lcc_go                           /* ppc:2129                    */
+.Lcc_set_regs:
+        /* nargs < nargregs: fill arg regs from the inherited args'
+           HIGH end (imm2), possibly spilling the rest (ppc:2130-2160). */
+        cmp nargs, #fixnumone               /* ppc:2078 cmpri cr1          */
+        b.le .Lcc_set_y_z                   /* ppc:2133 ble cr1            */
+.Lcc_set_arg_x:                             /* nargs was 2                 */
+        sub imm0, imm0, #fixnumone          /* ppc:2135                    */
+        sub imm2, imm2, #fixnumone          /* ppc:2137                    */
+        ldr arg_x, [nfn, imm2]              /* ppc:2138 ldrx               */
+        add nargs, nargs, #fixnumone        /* ppc:2139                    */
+        cmp imm0, #0                        /* ppc:2136 cmpri cr0          */
+        b.ne .Lcc_vpush_remaining           /* ppc:2140                    */
+        b .Lcc_go                           /* ppc:2141                    */
+.Lcc_set_y_z:                               /* NZCV: nargs vs fixnumone    */
+        b.ne .Lcc_set_arg_z                 /* ppc:2144 bne cr1 (nargs=0)  */
+.Lcc_set_arg_y:                             /* nargs was 1                 */
+        sub imm0, imm0, #fixnumone          /* ppc:2147                    */
+        sub imm2, imm2, #fixnumone          /* ppc:2149                    */
+        ldr arg_y, [nfn, imm2]              /* ppc:2150                    */
+        add nargs, nargs, #fixnumone        /* ppc:2151                    */
+        cmp imm0, #0                        /* ppc:2148                    */
+        b.ne .Lcc_set_arg_x                 /* ppc:2152                    */
+        b .Lcc_go                           /* ppc:2153                    */
+.Lcc_set_arg_z:                             /* nargs was 0                 */
+        sub imm0, imm0, #fixnumone          /* ppc:2155                    */
+        sub imm2, imm2, #fixnumone          /* ppc:2157                    */
+        ldr arg_z, [nfn, imm2]              /* ppc:2158                    */
+        add nargs, nargs, #fixnumone        /* ppc:2159                    */
+        cmp imm0, #0                        /* ppc:2156                    */
+        b.ne .Lcc_set_arg_y                 /* ppc:2160                    */
+.Lcc_go:
+        ldr nfn, [nfn, #(misc_data_offset + node_size)] /* ppc:2163 slot 1 */
+        ldr temp0, [nfn, #_function.codevector]         /* ppc:2164        */
+        br temp0                            /* ppc:2165-2166 mtctr+bctr    */
+endsp call_closure
+
+/* ========== INTEGER/NATURAL CONVERSION ========== */
+
+/* ported from ppc-spentry.s:2173-2202: the PPC64 branch of getxlong is
+ * EMPTY (the __ifdef(`PPC64') arm has no code - only the PPC32 arm has a
+ * body), i.e. this subprim is unreferenced on 64-bit targets.  Ported as
+ * a loud trap, exactly like the trap-only PPC64 entries in spentry-E
+ * (ffcallX/callbackX). */
+spentry getxlong
+        brk #0
+endsp getxlong
+
+/* ========== ARGUMENT SPREADING ========== */
+
+/* ported from ppc-spentry.s:2209-2252 (PPC64 branch).
+ * Everything up to the last arg has been vpushed; nargs = boxed count of
+ * things already pushed.  Spread the list in arg_z, then set arg_x/y/z +
+ * nargs as for a normal call.  ppc2-invoke-fn assumes temp1 preserved.
+ * PPC keeps cr0 (nil check) and cr1 (cons check) live; flattened with
+ * the cons check at loop top and the nil check at loop bottom. */
+spentry spreadargz
+        and imm1, arg_z, #fulltagmask   /* ppc:2211 extract_fulltag        */
+        mov imm0, xzr                   /* ppc:2218 li imm0,0              */
+        mov arg_y, arg_z                /* ppc:2219 save for error case    */
+        cmp arg_z, rnil                 /* ppc:2217 cmpri cr0              */
+        b.eq 2f                         /* ppc:2220 beq cr0                */
+1:      cmp imm1, #fulltag_cons         /* ppc:2212/2228 cmpri cr1         */
+        b.ne 3f                         /* ppc:2222 bne cr1 -> error       */
+        ldr arg_x, [arg_z, #cons.car]   /* ppc:2223 _car                   */
+        ldr arg_z, [arg_z, #cons.cdr]   /* ppc:2224 _cdr                   */
+        and imm1, arg_z, #fulltagmask   /* ppc:2227                        */
+        str arg_x, [vsp, #-node_size]!  /* ppc:2233 vpush                  */
+        add imm0, imm0, #fixnumone      /* ppc:2234                        */
+        cmp arg_z, rnil                 /* ppc:2225 cmpri cr0              */
+        b.ne 1b                         /* ppc:2235                        */
+2:      adds nargs, nargs, imm0         /* ppc:2237 add. (sets Z)          */
+        b.eq 9f                         /* ppc:2239 beqlr- cr0             */
+        cmp nargs, #(2<<fixnumshift)    /* ppc:2238 cmpri cr2              */
+        ldr arg_z, [vsp], #node_size    /* ppc:2240 vpop                   */
+        b.lt 9f                         /* ppc:2241 bltlr cr2              */
+        ldr arg_y, [vsp], #node_size    /* ppc:2242 vpop                   */
+        b.eq 9f                         /* ppc:2243 beqlr cr2              */
+        ldr arg_x, [vsp], #node_size    /* ppc:2244 vpop                   */
+9:      ret                             /* ppc:2245 blr                    */
+        /* Improper tail: discard pushes, signal XNOSPREAD (ppc:2247-2252) */
+3:      add vsp, vsp, imm0              /* ppc:2248                        */
+        mov arg_z, arg_y                /* ppc:2249 recover original arg_z */
+        mov arg_y, #XNOSPREAD           /* ppc:2250                        */
+        set_nargs 2                     /* ppc:2251                        */
+        b _SPksignalerr                 /* ppc:2252                        */
+endsp spreadargz
+
+/* ========== TAIL CALLS ========== */
+
+/* ported from ppc-spentry.s:2256-2277 (PPC64 branch) */
+spentry tfuncallgen
+        /* PORT-TODO: fn-volatile protocol decision needed */
+        /* Tail funcall - general case */
+        cmp nargs, #(nargregs << fixnumshift)
+        ldr x30, [sp, #lisp_frame.savelr]
+        ldr fn, [sp, #lisp_frame.savefn]
+        b.le 2f
+
+        /* Some args vpushed - slide them down */
+        ldr imm0, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+
+        sub imm1, nargs, #(nargregs << fixnumshift)
+        add imm1, imm1, vsp
+1:      ldr temp2, [imm1, #-node_size]!
+        cmp imm1, vsp
+        str temp2, [imm0, #-node_size]!
+        b.ne 1b
+        mov vsp, imm0
+        b _SPfuncall
+
+2:      ldr vsp, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+        b _SPfuncall
+endsp tfuncallgen
+
+/* ported from ppc-spentry.s:2282-2297 (PPC64 branch) */
+spentry tfuncallslide
+        /* PORT-TODO: fn-volatile protocol decision needed */
+        /* Tail funcall - args were vpushed */
+        ldr x30, [sp, #lisp_frame.savelr]
+        ldr fn, [sp, #lisp_frame.savefn]
+        ldr imm0, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+
+        sub imm1, nargs, #(nargregs << fixnumshift)
+        add imm1, imm1, vsp
+1:      ldr temp2, [imm1, #-node_size]!
+        cmp imm1, vsp
+        str temp2, [imm0, #-node_size]!
+        b.ne 1b
+        mov vsp, imm0
+        b _SPfuncall
+endsp tfuncallslide
+
+/* tfuncallvsp (ppc:2299-2306) lives in spentry-C-bind-catch-throw.s
+   (the W4 gate-32 port); an earlier draft here duplicated the symbol. */
+
+/* ported from ppc-spentry.s:2313-2336 (PPC64 branch) */
+spentry tcallsymgen
+        /* PORT-TODO: fn-volatile protocol decision needed */
+        /* Tail call symbol - general case */
+        cmp nargs, #(nargregs << fixnumshift)
+        ldr x30, [sp, #lisp_frame.savelr]
+        ldr fn, [sp, #lisp_frame.savefn]
+        b.le 2f
+
+        ldr imm0, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+
+        sub imm1, nargs, #(nargregs << fixnumshift)
+        add imm1, imm1, vsp
+1:      ldr temp2, [imm1, #-node_size]!
+        cmp imm1, vsp
+        str temp2, [imm0, #-node_size]!
+        b.ne 1b
+        mov vsp, imm0
+        /* Jump to fname */
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+
+2:      ldr vsp, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp tcallsymgen
+
+/* ported from ppc-spentry.s:2341-2356 (PPC64 branch) */
+spentry tcallsymslide
+        /* PORT-TODO: fn-volatile protocol decision needed */
+        /* Tail call symbol - args vpushed */
+        ldr x30, [sp, #lisp_frame.savelr]
+        ldr fn, [sp, #lisp_frame.savefn]
+        ldr imm0, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+
+        sub imm1, nargs, #(nargregs << fixnumshift)
+        add imm1, imm1, vsp
+1:      ldr temp2, [imm1, #-node_size]!
+        cmp imm1, vsp
+        str temp2, [imm0, #-node_size]!
+        b.ne 1b
+        mov vsp, imm0
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp tcallsymslide
+
+/* ported from ppc-spentry.s:2369-2372 (PPC64 branch) */
+spentry tcallnfngen
+        /* Tail call nfn - general */
+        cmp nargs, #(nargregs << fixnumshift)
+        b.le _SPtcallnfnvsp
+        b _SPtcallnfnslide
+endsp tcallnfngen
+
+/* ported from ppc-spentry.s:2376-2391 (PPC64 branch) */
+spentry tcallnfnslide
+        /* PORT-TODO: fn-volatile protocol decision needed */
+        ldr x30, [sp, #lisp_frame.savelr]
+        ldr fn, [sp, #lisp_frame.savefn]
+        ldr imm0, [sp, #lisp_frame.savevsp]
+        add sp, sp, #lisp_frame.size
+
+        sub imm1, nargs, #(nargregs << fixnumshift)
+        add imm1, imm1, vsp
+1:      ldr fname, [imm1, #-node_size]!
+        cmp imm1, vsp
+        str fname, [imm0, #-node_size]!
+        b.ne 1b
+        mov vsp, imm0
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp tcallnfnslide
+
+/* ========== BUILTIN ARITHMETIC ========== */
+
+/* ported from ppc-spentry.s:5492-5517 (PPC64 branch) */
+spentry builtin_plus
+        /* Fixnum addition with overflow to bignum */
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+
+        adds arg_z, arg_y, arg_z
+        b.vc 2f  /* No overflow */
+
+        /* Overflow - make bignum */
+        asr imm0, arg_z, #fixnumshift
+        eor imm0, imm0, #0xe000000000000000
+        mov imm1, #two_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm1, aligned_bignum_size(2)
+        str imm0, [arg_z, #misc_data_offset]
+2:      ret
+
+1:      /* Not both fixnums - dispatch to Lisp */
+        jump_builtin _builtin_plus, 2  /* ppc:5517 */
+endsp builtin_plus
+
+/* ported from ppc-spentry.s:5518-5543 (PPC64 branch) */
+spentry builtin_minus
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+
+        subs arg_z, arg_y, arg_z
+        b.vc 2f
+
+        /* Overflow to bignum */
+        asr imm0, arg_z, #fixnumshift
+        eor imm0, imm0, #0xe000000000000000
+        mov imm1, #two_digit_bignum_header
+        Misc_Alloc_Fixed arg_z, imm1, aligned_bignum_size(2)
+        str imm0, [arg_z, #misc_data_offset]
+2:      ret
+
+1:      jump_builtin _builtin_minus, 2  /* ppc:5543 */
+endsp builtin_minus
+
+/* ported from ppc-spentry.s:5544-5576 (PPC64 branch) */
+spentry builtin_times
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+
+        asr imm2, arg_y, #fixnumshift
+        /* Multiply with overflow detection */
+        asr imm3, arg_z, #fixnumshift
+        mul imm1, imm3, imm2  /* low 64 bits */
+        smulh imm0, imm3, imm2  /* high 64 bits */
+
+        /* Check if result fits in fixnum.  GC SAFETY (Matt 2026-07-11):
+           imm scratch, never a node reg.
+           16m5t FIX: the old single test `asr imm1,#61 == smulh` accepted
+           s62 products; fixnums are s61 (value bits = 64-3).  2^60 then
+           boxed to 2^63 (= -2^60), and -2^61 boxed to EXACTLY 0 -- the
+           *base-power* doubling loop wedged at 0 (l0-int.lisp:155 spin).
+           PPC gets this free by multiplying BOXED*unboxed (mulldo. OV ==
+           fixnum overflow, ppc:5548); with both operands unboxed we need
+           BOTH: product fits s64 (smulh == sign of low) AND low fits s61
+           (sbfx round-trip, Matt's makes64 idiom). */
+        asr imm4, imm1, #63
+        cmp imm4, imm0
+        b.ne 2f
+        sbfx imm4, imm1, #0, #(nbits_in_word - nfixnumtagbits)
+        cmp imm4, imm1
+        b.ne 2f
+        lsl arg_z, imm1, #fixnumshift
+        ret
+
+2:      /* Result doesn't fit in fixnum - call makes128 */
+        b _SPmakes128
+
+1:      jump_builtin _builtin_times, 2  /* ppc:5576 */
+endsp builtin_times
+
+/* ========== BUILTIN COMPARISONS ========== */
+
+/* ported from ppc-spentry.s:5581-5594 (PPC64 branch) */
+spentry builtin_eq
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        cmp arg_y, arg_z
+        mov arg_z, rnil
+        b.ne 2f
+        /* PORT-TODO: load t_value constant */
+        add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+2:      ret
+1:      jump_builtin _builtin_eq, 2  /* ppc:5594 */
+endsp builtin_eq
+
+/* ported from ppc-spentry.s:5596-5609 (PPC64 branch) */
+spentry builtin_ne
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        cmp arg_y, arg_z
+        mov arg_z, rnil
+        b.eq 2f
+        add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+2:      ret
+1:      jump_builtin _builtin_ne, 2  /* ppc:5609 */
+endsp builtin_ne
+
+/* ported from ppc-spentry.s:5611-5624 (PPC64 branch) */
+spentry builtin_gt
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        cmp arg_y, arg_z
+        mov arg_z, rnil
+        b.le 2f
+        add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+2:      ret
+1:      jump_builtin _builtin_gt, 2  /* ppc:5624 */
+endsp builtin_gt
+
+/* ported from ppc-spentry.s:5626-5639 (PPC64 branch) */
+spentry builtin_ge
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        cmp arg_y, arg_z
+        mov arg_z, rnil
+        b.lt 2f
+        add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+2:      ret
+1:      jump_builtin _builtin_ge, 2  /* ppc:5639 */
+endsp builtin_ge
+
+/* ported from ppc-spentry.s:5641-5654 (PPC64 branch) */
+spentry builtin_lt
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        cmp arg_y, arg_z
+        mov arg_z, rnil
+        b.ge 2f
+        add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+2:      ret
+1:      jump_builtin _builtin_lt, 2  /* ppc:5654 */
+endsp builtin_lt
+
+/* ported from ppc-spentry.s:5656-5669 (PPC64 branch) */
+spentry builtin_le
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        cmp arg_y, arg_z
+        mov arg_z, rnil
+        b.gt 2f
+        add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+2:      ret
+1:      jump_builtin _builtin_le, 2  /* ppc:5669 */
+endsp builtin_le
+
+/* ported from ppc-spentry.s:5672-5689 (PPC64 branch) */
+spentry builtin_eql
+        cmp arg_y, arg_z
+        b.eq 1f
+
+        and imm2, arg_y, #fulltagmask
+        and imm3, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne 2f
+        cmp imm3, #fulltag_misc
+        b.ne 2f
+
+        ldrb w0, [arg_y, #misc_subtag_offset]
+        ldrb w1, [arg_z, #misc_subtag_offset]
+        cmp imm0, imm1
+        b.ne 2f
+
+        /* Same subtag - dispatch to generic eql */
+        jump_builtin _builtin_eql, 2  /* ppc:5685 */
+
+1:      add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+        ret
+2:      mov arg_z, rnil
+        ret
+endsp builtin_eql
+
+/* ========== BUILTIN SEQUENCE OPS ========== */
+
+/* ported from ppc-spentry.s:5691-5759 (PPC64 branch) */
+spentry builtin_length
+        cmp arg_z, rnil
+        b.eq 1f
+
+        /* Check typecode */
+        and imm0, arg_z, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne 3f  /* Maybe cons */
+
+        ldrb w0, [arg_z, #misc_subtag_offset]
+        cmp imm0, #subtag_simple_vector
+        b.eq 0f
+        cmp imm0, #subtag_vectorH
+        b.eq 2f
+
+        /* Check if CL ivector (ppc:5698-5700 ivector_typecode_p + compare).
+           Exclude node-headers (arrayH etc.): they are >= min_cl_ivector_subtag
+           numerically in this tag scheme but are not CL sequences, so dispatch
+           them to Lisp.  See builtin_aref1 for the rationale. */
+        and imm1, imm0, #tagmask
+        cmp imm1, #tag_nodeheader
+        b.eq 8f
+        cmp imm0, #min_cl_ivector_subtag
+        b.ge 0f
+
+        /* Check for cons */
+        and imm0, arg_z, #fulltagmask
+        cmp imm0, #fulltag_cons
+        b.eq 4f
+        b 8f  /* Error */
+
+0:      /* Simple vector or ivector - get length from header */
+        ldr imm0, [arg_z, #misc_header_offset]
+        /* Extract length as fixnum */
+        lsr imm0, imm0, #num_subtag_bits
+        lsl arg_z, imm0, #fixnumshift
+        ret
+
+1:      /* nil - length 0 */
+        mov arg_z, xzr
+        ret
+
+2:      /* vectorH - load logsize slot */
+        ldr arg_z, [arg_z, #vectorH.logsize]
+        ret
+
+3:      /* Check if cons */
+        cmp imm0, #fulltag_cons
+        b.ne 8f
+4:      /* List - count with Floyd cycle detection (ppc:5718-5737 PPC64).
+           PPC keeps cr0/cr1/cr7 live; flattened one-compare-per-branch:
+           fast pointer steps every iteration, slow pointer every SECOND
+           iteration (odd count), cycle iff fast==slow. */
+        mov temp2, #(-1 << fixnumshift)     /* ppc:5719                    */
+        mov temp0, arg_z                    /* ppc:5720 fast pointer       */
+        mov temp1, arg_z                    /* ppc:5721 slow pointer       */
+5:      and imm0, temp0, #fulltagmask       /* ppc:5723 extract_fulltag    */
+        add temp2, temp2, #fixnumone        /* ppc:5726                    */
+        cmp temp0, rnil                     /* ppc:5724 cmpdi cr7          */
+        b.eq 9f                             /* ppc:5727 done: proper end   */
+        cmp imm0, #fulltag_cons             /* ppc:5725 cmpdi cr1          */
+        b.ne 8f                             /* ppc:5729 not a list         */
+        and imm1, temp1, #fulltagmask       /* ppc:5730                    */
+        ldr temp0, [temp0, #cons.cdr]       /* ppc:5731 _cdr fast          */
+        tst temp2, #fixnumone               /* ppc:5728 andi. (odd/even)   */
+        b.eq 5b                             /* ppc:5733 even: skip slow    */
+        cmp imm1, #fulltag_cons             /* ppc:5732 cmpdi cr1          */
+        b.ne 8f                             /* ppc:5734                    */
+        ldr temp1, [temp1, #cons.cdr]       /* ppc:5735 _cdr slow          */
+        cmp temp0, temp1                    /* ppc:5736                    */
+        b.ne 5b                             /* ppc:5737 no cycle yet       */
+        /* fast==slow: circular; fall into the generic dispatch (ppc:5755) */
+8:      /* Not a sequence - dispatch to Lisp */
+        jump_builtin _builtin_length, 1  /* ppc:5756 */
+9:      mov arg_z, temp2
+        ret
+endsp builtin_length
+
+/* ported from ppc-spentry.s:5761-5784 (PPC64 branch) */
+spentry builtin_seqtype
+        cmp arg_z, rnil
+        b.eq 1f
+
+        and imm0, arg_z, #fulltagmask
+        cmp imm0, #fulltag_cons
+        b.eq 1f
+
+        cmp imm0, #fulltag_misc
+        b.ne 2f
+        ldrb w0, [arg_z, #misc_subtag_offset]
+        cmp imm0, #subtag_simple_vector
+        b.eq 0f
+        cmp imm0, #subtag_vectorH
+        b.eq 0f
+
+        /* Check if CL ivector (ppc:5775-5777 ivector_typecode_p + compare).
+           Exclude node-headers (arrayH etc.) → dispatch to Lisp.  See
+           builtin_aref1 for the tag-scheme rationale. */
+        and imm1, imm0, #tagmask
+        cmp imm1, #tag_nodeheader
+        b.eq 2f
+        cmp imm0, #min_cl_ivector_subtag
+        b.lt 2f
+
+0:      mov arg_z, rnil
+        ret
+1:      add arg_z, rnil, #t_offset      /* t_value = NIL + t_offset        */
+        ret
+2:      jump_builtin _builtin_seqtype, 1  /* ppc:5784 */
+endsp builtin_seqtype
+
+/* ported from ppc-spentry.s:5786-5802 (PPC64 branch).
+ * PPC keeps three CRs live (cr0 = car match, cr1 = tail nil, cr2 = pair
+ * nil); flattened with one compare per branch.  trap_unless_list is only
+ * reached with a non-nil operand, so the cons-tag check suffices (on
+ * Matt's design nil has its own fulltag, arm64-constants.h:94). */
+spentry builtin_assq
+        cmp arg_z, rnil                 /* ppc:5787                        */
+        b.eq 9f                         /* ppc:5788 beqlr                  */
+1:      and imm0, arg_z, #fulltagmask   /* ppc:5789 trap_unless_list       */
+        cmp imm0, #fulltag_cons
+        b.eq 0f
+        uuo_interr error_object_not_list, arg_z
+0:      ldr arg_x, [arg_z, #cons.car]   /* ppc:5790                        */
+        ldr arg_z, [arg_z, #cons.cdr]   /* ppc:5791                        */
+        cmp arg_x, rnil                 /* ppc:5792 cmpri cr2              */
+        b.eq 2f                         /* ppc:5794 beq cr2 (skip nil pair)*/
+        and imm0, arg_x, #fulltagmask   /* ppc:5795 trap_unless_list       */
+        cmp imm0, #fulltag_cons
+        b.eq 3f
+        uuo_interr error_object_not_list, arg_x
+3:      ldr temp0, [arg_x, #cons.car]   /* ppc:5796                        */
+        cmp temp0, arg_y                /* ppc:5797                        */
+        b.ne 2f                         /* ppc:5798                        */
+        mov arg_z, arg_x                /* ppc:5799 found                  */
+        ret                             /* ppc:5800                        */
+2:      cmp arg_z, rnil                 /* ppc:5793 cmpri cr1 (recomputed) */
+        b.ne 1b                         /* ppc:5801                        */
+9:      ret                             /* ppc:5802                        */
+endsp builtin_assq
+
+/* ported from ppc-spentry.s:5804-5815 (PPC64 branch); flag/trap notes as
+ * builtin_assq.  Returns the tail of arg_z whose car is eq to arg_y. */
+spentry builtin_memq
+        cmp arg_z, rnil                 /* ppc:5805 cmpri cr1              */
+        b 2f                            /* ppc:5806                        */
+1:      and imm0, arg_z, #fulltagmask   /* ppc:5807 trap_unless_list       */
+        cmp imm0, #fulltag_cons
+        b.eq 0f
+        uuo_interr error_object_not_list, arg_z
+0:      ldr arg_x, [arg_z, #cons.car]   /* ppc:5808                        */
+        ldr temp0, [arg_z, #cons.cdr]   /* ppc:5809                        */
+        cmp arg_x, arg_y                /* ppc:5810                        */
+        b.eq 9f                         /* ppc:5812 beqlr (found this cons)*/
+        mov arg_z, temp0                /* ppc:5813                        */
+        cmp arg_z, rnil                 /* ppc:5811 cmpri cr1 (recomputed) */
+2:      b.ne 1b                         /* ppc:5814                        */
+9:      ret                             /* ppc:5815                        */
+endsp builtin_memq
+
+/* ========== BUILTIN CALL DISPATCHERS ========== */
+
+/* ported from ppc-spentry.s:5270-5274 (PPC64 branch)
+ * callbuiltin: imm0 = boxed index into %builtin-functions%; dispatch to that
+ * symbol's function definition.  nargs already set by caller. */
+spentry callbuiltin
+        /* ppc:5271 ref_nrs_value(fname,builtin_functions) */
+        /* ppc:5272 la imm0,misc_data_offset(imm0) -- add data bias to index */
+        /* ppc:5273 ldrx(fname,fname,imm0) -- load symbol from vector */
+        /* ppc:5274 jump_fname() */
+        ref_nrs_value fname, builtin_functions
+        add imm0, imm0, #misc_data_offset
+        ldr fname, [fname, imm0]
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp callbuiltin
+
+/* ported from ppc-spentry.s:5280-5285 (PPC64 branch) */
+spentry callbuiltin0
+        set_nargs 0                     /* ppc:5281 */
+        /* ppc:5282-5285: ref_nrs_value + la + ldrx + jump_fname */
+        ref_nrs_value fname, builtin_functions
+        add imm0, imm0, #misc_data_offset
+        ldr fname, [fname, imm0]
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp callbuiltin0
+
+/* ported from ppc-spentry.s:5287-5292 (PPC64 branch) */
+spentry callbuiltin1
+        set_nargs 1                     /* ppc:5289 (set_nargs before ref in PPC) */
+        /* ppc:5288,5290-5292: ref_nrs_value + la + ldrx + jump_fname */
+        ref_nrs_value fname, builtin_functions
+        add imm0, imm0, #misc_data_offset
+        ldr fname, [fname, imm0]
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp callbuiltin1
+
+/* ported from ppc-spentry.s:5294-5299 (PPC64 branch) */
+spentry callbuiltin2
+        set_nargs 2                     /* ppc:5295 */
+        /* ppc:5296-5299: ref_nrs_value + la + ldrx + jump_fname */
+        ref_nrs_value fname, builtin_functions
+        add imm0, imm0, #misc_data_offset
+        ldr fname, [fname, imm0]
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp callbuiltin2
+
+/* ported from ppc-spentry.s:5302-5307 (PPC64 branch) */
+spentry callbuiltin3
+        set_nargs 3                     /* ppc:5303 */
+        /* ppc:5304-5307: ref_nrs_value + la + ldrx + jump_fname */
+        ref_nrs_value fname, builtin_functions
+        add imm0, imm0, #misc_data_offset
+        ldr fname, [fname, imm0]
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp callbuiltin3
+
+/* ========== FRAME RESTORE ========== */
+
+/* ported from ppc-spentry.s:5310-5318 (PPC64 branch)
+ * popj: restore context from lisp frame and return.
+ * PPC64 loads loc_pc from frame then mtlr+blr; ARM64 has no loc_pc register --
+ * load directly into lr (x30) and ret. */
+spentry popj
+        .globl C(popj)
+C(popj):
+        ldr x30, [sp, #lisp_frame.savelr]      /* ppc:5313 ldr(loc_pc,savelr) */
+        ldr vsp, [sp, #lisp_frame.savevsp]      /* ppc:5314 */
+        ldr fn, [sp, #lisp_frame.savefn]        /* ppc:5316 */
+        discard_lisp_frame                      /* ppc:5317 */
+        ret                                     /* ppc:5318 blr */
+endsp popj
+
+/* ========== BUILTIN LOGICAL OPERATIONS ========== */
+
+/* ported from ppc-spentry.s:5823-5845 (PPC64 branch)
+ * builtin_logbitp: (logbitp arg_y arg_z) for fixnum args where
+ * 0 <= arg_y < 61 (logbitp_max_bit on 64-bit). */
+.set logbitp_max_bit, 61
+
+spentry builtin_logbitp
+        /* ppc:5825 cmplri(cr2,arg_y,logbitp_max_bit<<fixnum_shift) */
+        cmp arg_y, #(logbitp_max_bit << fixnumshift)
+        /* ppc:5826-5829 extract tags, check both fixnum */
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        cmp imm1, #tag_fixnum
+        b.ne 1f
+        /* Bail if arg_y >= logbitp_max_bit (unsigned compare already set above;
+         * but we clobbered flags with the tag checks -- recompute) */
+        cmp arg_y, #(logbitp_max_bit << fixnumshift)
+        b.hs 1f
+        /* ppc:5830 unbox_fixnum(imm0,arg_y) */
+        asr imm0, arg_y, #fixnumshift
+        /* ppc:5831 subfic imm0,imm0,logbitp_max_bit -> compute shift amount */
+        /* PPC64: rldcl imm0,arg_z,imm0,63 = rotate arg_z left by imm0, clear
+         * bits 0-62, leaving only bit 63 (the target bit rotated to LSB).
+         * ARM64 equivalent: shift arg_z right by (logbitp_max_bit - imm0)
+         * positions within the fixnum bits, then AND #1. But PPC's subfic
+         * computes (logbitp_max_bit - bit_index), so after unboxing arg_z we
+         * right-shift by that amount. Actually simpler: just shift arg_z right
+         * by the bit position and mask. arg_z is a tagged fixnum so bit N of
+         * the fixnum value is at position N+fixnumshift in the register. */
+        add imm0, imm0, #fixnumshift    /* adjust for tag bits */
+        lsr imm0, arg_z, imm0           /* shift target bit to bit 0 */
+        and imm0, imm0, #1              /* isolate the bit */
+        /* ppc:5834 mulli imm0,imm0,t_offset; ppc:5842 addi arg_z,nil_value */
+        mov imm1, #t_offset
+        mul imm0, imm0, imm1
+        add arg_z, rnil, imm0
+        ret
+1:      /* ppc:5845 */
+        jump_builtin _builtin_logbitp, 2
+endsp builtin_logbitp
+
+/* ported from ppc-spentry.s:5847-5857 (PPC64 branch) */
+spentry builtin_logior
+        and imm0, arg_y, #tagmask       /* ppc:5848 */
+        and imm1, arg_z, #tagmask       /* ppc:5849 */
+        cmp imm0, #tag_fixnum           /* ppc:5850 */
+        b.ne 1f                         /* ppc:5852 */
+        cmp imm1, #tag_fixnum           /* ppc:5851 */
+        b.ne 1f                         /* ppc:5853 */
+        orr arg_z, arg_y, arg_z         /* ppc:5854 */
+        ret                             /* ppc:5855 */
+1:      jump_builtin _builtin_logior, 2 /* ppc:5857 */
+endsp builtin_logior
+
+/* ported from ppc-spentry.s:5859-5869 (PPC64 branch) */
+spentry builtin_logand
+        and imm0, arg_y, #tagmask       /* ppc:5860 */
+        and imm1, arg_z, #tagmask       /* ppc:5861 */
+        cmp imm0, #tag_fixnum           /* ppc:5862 */
+        b.ne 1f                         /* ppc:5864 */
+        cmp imm1, #tag_fixnum           /* ppc:5863 */
+        b.ne 1f                         /* ppc:5865 */
+        and arg_z, arg_y, arg_z         /* ppc:5866 */
+        ret                             /* ppc:5867 */
+1:      jump_builtin _builtin_logand, 2 /* ppc:5869 */
+endsp builtin_logand
+
+/* ported from ppc-spentry.s:5871-5990 (PPC64 branch)
+ * builtin_ash: arithmetic shift.  Positive arg_z = left shift, negative = right.
+ * PPC64 branch only (5872-5930). */
+spentry builtin_ash
+        /* ppc:5873 cmpdi cr1,arg_z,0 */
+        cmp arg_z, #0
+        /* ppc:5874-5877 extract tags, compare to fixnum */
+        and imm0, arg_y, #tagmask
+        and imm1, arg_z, #tagmask
+        cmp imm0, #tag_fixnum
+        b.ne 9f
+        cmp imm1, #tag_fixnum
+        b.ne 9f
+        /* ppc:5878 cmpdi cr2,arg_z,-(63<<3) -- check shift magnitude */
+        /* Retest arg_z sign (flags clobbered by tag checks) */
+        cmp arg_z, #0
+        b.gt 2f
+        /* ppc:5881 bne cr1,0f -- if arg_z != 0, proceed; else return arg_y */
+        b.ne 0f
+        mov arg_z, arg_y                /* ppc:5882 (ash n 0) => n */
+        ret                             /* ppc:5883 */
+0:
+        /* Negative shift (right shift) */
+        /* ppc:5885 unbox_fixnum(imm1,arg_y) */
+        asr imm1, arg_y, #fixnumshift
+        /* ppc:5886 unbox_fixnum(imm0,arg_z) -- shift count (negative) */
+        asr imm0, arg_z, #fixnumshift
+        /* ppc:5889 neg imm2,imm0 -- positive shift count */
+        neg imm2, imm0
+        /* ppc:5878/5890 bgt cr2 / li imm2,63 -- clamp to 63 */
+        cmp imm2, #63
+        b.le 1f
+        mov imm2, #63
+1:
+        /* ppc:5893 srad imm0,imm1,imm2 */
+        asr imm0, imm1, imm2
+        /* ppc:5894 box_fixnum(arg_z,imm0) */
+        lsl arg_z, imm0, #fixnumshift
+        ret                             /* ppc:5895 */
+2:
+        /* Positive shift (left shift) */
+        /* ppc:5897 Integer-length of arg_y/imm1 to imm2 */
+        asr imm1, arg_y, #fixnumshift   /* ppc:5885 (reuse) */
+        asr imm0, arg_z, #fixnumshift   /* ppc:5886 (reuse) */
+        /* ppc:5898 cntlzd. imm2,imm1 */
+        cmp imm1, #0
+        b.ge 3f
+        /* Negative value: count leading zeros of NOT(imm1) */
+        mvn imm2, imm1                  /* ppc:5900 not imm2,imm1 */
+        clz imm2, imm2                  /* ppc:5901 cntlzd imm2,imm2 */
+        b 4f
+3:      clz imm2, imm1                  /* ppc:5898 cntlzd imm2,imm1 */
+4:
+        /* ppc:5903 subfic imm2,imm2,64 -- integer-length = 64 - clz */
+        mov imm3, #64
+        sub imm2, imm3, imm2
+        /* ppc:5904 add imm2,imm2,imm0 -- total bits needed */
+        add imm2, imm2, imm0
+        /* ppc:5905 cmpdi cr1,imm2,63-fixnumshift -- fits in fixnum? */
+        cmp imm2, #(63 - fixnumshift)
+        /* ppc:5907 sld imm2,imm1,imm0 -- perform the shift */
+        lsl imm2, imm1, imm0
+        b.gt 6f
+        /* ppc:5909 box_fixnum(arg_z,imm2) -- result fits */
+        lsl arg_z, imm2, #fixnumshift
+        ret                             /* ppc:5910 */
+6:
+        /* Result does not fit in a fixnum */
+        /* ppc:5906 cmpdi cr2,imm0,64 */
+        cmp imm0, #64
+        b.gt 9f                         /* ppc:5912 shift > 64: bail to generic */
+        b.eq ash_shift64                /* ppc:5913 shift == 64 exactly */
+        /* ppc:5920-5925: Shift left by fewer than 64 bits, result not fixnum */
+        /* ppc:5921 subfic imm0,imm0,64 */
+        mov imm3, #64
+        sub imm3, imm3, imm0           /* 64 - shift_count */
+        /* Need to check sign for signed vs unsigned result */
+        cmp imm1, #0
+        b.lt 8f
+        /* ppc:5923 srd imm0,imm1,imm0 -- high part (unsigned) */
+        lsr imm0, imm1, imm3
+        mov imm1, imm2                  /* ppc:5924 mr imm1,imm2 (low part) */
+        b _SPmakeu128                   /* ppc:5925 */
+8:
+        /* ppc:5927 srad imm0,imm1,imm0 -- high part (signed) */
+        asr imm0, imm1, imm3
+        mov imm1, imm2                  /* ppc:5928 */
+        b _SPmakes128                   /* ppc:5929 */
+ash_shift64:
+        /* ppc:5915-5918: Shift left by exactly 64 bits */
+        mov imm0, imm1                  /* ppc:5915 mr imm0,imm1 */
+        mov imm1, #0                    /* ppc:5916 li imm1,0 */
+        /* ppc:5917-5918: beq _SPmakes128 / b _SPmakeu128
+         * PPC branches on cr0.eq from cntlzd. -- this reflects whether
+         * original value was negative. */
+        cmp imm0, #0
+        b.lt _SPmakes128
+        b _SPmakeu128
+9:
+        /* ppc:5990 */
+        jump_builtin _builtin_ash, 2
+endsp builtin_ash
+
+/* ported from ppc-spentry.s:5992-6013 (PPC64 branch)
+ * builtin_negate: negate a fixnum, overflow to bignum. */
+spentry builtin_negate
+        /* ppc:5993 extract_lisptag_(imm0,arg_z) */
+        and imm0, arg_z, #tagmask
+        /* ppc:5994 bne- cr0,1f */
+        cmp imm0, #tag_fixnum
+        b.ne 1f
+        /* ppc:5995 nego. arg_z,arg_z -- negate with overflow detect.
+         * ARM64: negs sets NZCV; V=1 iff overflow (arg_z == INT64_MIN-equivalent,
+         * i.e., most-negative-fixnum). */
+        negs arg_z, arg_z
+        /* ppc:5996 bnslr+ -- return if no overflow */
+        b.vc 2f
+        /* Overflow: arg_z holds the WRAPPED negation of most-negative-fixnum.
+         * ppc:5997 mtxer rzero (clear OV -- no ARM64 equivalent needed)
+         * ppc:5998-6004: unbox and store as a two-digit bignum with the sign
+         * bit flipped (PPC's rotldi+xoris = flip bit 2^63 of the unboxed
+         * value; the wrapped unboxed result is -2^60 but the true value is
+         * +2^60, and eor #0xe000... corrects the top bits).  This is EXACTLY
+         * Matt's own _SPfix_overflow body (arm64-spentry.s:10-17) -- mirror it. */
+        asr imm0, arg_z, #fixnumshift          /* ppc:5998 unbox_fixnum */
+        eor imm0, imm0, #0xe000000000000000    /* ppc:6001-6002 sign-flip trick */
+        mov imm1, #two_digit_bignum_header     /* ppc:6000 */
+        Misc_Alloc_Fixed arg_z, imm1, aligned_bignum_size(2)  /* ppc:6003 */
+        str imm0, [arg_z, #misc_data_offset]   /* ppc:6004 */
+2:      ret
+1:      /* ppc:6013 */
+        jump_builtin _builtin_negate, 1
+endsp builtin_negate
+
+/* ported from ppc-spentry.s:6015-6025 (PPC64 branch) */
+spentry builtin_logxor
+        and imm0, arg_y, #tagmask       /* ppc:6016 */
+        and imm1, arg_z, #tagmask       /* ppc:6017 */
+        cmp imm0, #tag_fixnum           /* ppc:6018 */
+        b.ne 1f                         /* ppc:6020 */
+        cmp imm1, #tag_fixnum           /* ppc:6019 */
+        b.ne 1f                         /* ppc:6021 */
+        eor arg_z, arg_y, arg_z         /* ppc:6022 */
+        ret                             /* ppc:6023 */
+1:      jump_builtin _builtin_logxor, 2 /* ppc:6025 */
+endsp builtin_logxor
+
+/* ========== BUILTIN ARRAY ACCESS ========== */
+
+/* ported from ppc-spentry.s:3213-3221 (PPC64 branch)
+ * builtin_aref1: fast path for simple-vector / CL ivector aref;
+ * falls through to _SPsubtag_misc_ref or dispatches to Lisp. */
+spentry builtin_aref1
+        /* ppc:3214 extract_typecode(imm0,arg_y) */
+        and imm0, arg_y, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne 1f
+        ldrb w0, [arg_y, #misc_subtag_offset]
+        /* ppc:3215 cmpri(cr0,imm0,subtag_simple_vector) */
+        cmp imm0, #subtag_simple_vector
+        /* ppc:3216 box_fixnum(arg_x,imm0) -- save typecode for subtag_misc_ref */
+        lsl arg_x, imm0, #fixnumshift
+        b.eq _SPsubtag_misc_ref         /* ppc:3217 */
+        /* ppc:3218 ivector_typecode_p(imm1,imm0,imm2) (ppc-macros.s:747):
+           ONLY immediate-header subtags are CL ivectors; the macro zeroes a
+           node-header subtag so the following compare fails.  We must do the
+           same: node-header subtags (vectorH=0xae, arrayH=0xa6, ...) are
+           numerically >= min_cl_ivector_subtag (0x94) in this tag scheme, so a
+           raw compare misclassifies a complex array as a simple ivector and
+           does a raw misc_ref on its HEADER (bound = header slot count = 5),
+           instead of dispatching to Lisp %aref1 (which unwraps the vectorH).
+           tag_nodeheader (low nlisptagbits) is shared by fulltag_nodeheader_0/1. */
+        and imm1, imm0, #tagmask
+        cmp imm1, #tag_nodeheader
+        b.eq 1f
+        cmp imm0, #min_cl_ivector_subtag  /* ppc:3219-3220 */
+        b.ge _SPsubtag_misc_ref
+1:      jump_builtin _builtin_aref1, 2  /* ppc:3221 */
+endsp builtin_aref1
+
+/* ported from ppc-spentry.s:6030-6038 (PPC64 branch)
+ * builtin_aset1: fast path for simple-vector / CL ivector aset;
+ * falls through to _SPsubtag_misc_set or dispatches to Lisp. */
+spentry builtin_aset1
+        /* ppc:6031 extract_typecode(imm0,arg_x) */
+        and imm0, arg_x, #fulltagmask
+        cmp imm0, #fulltag_misc
+        b.ne 1f
+        ldrb w0, [arg_x, #misc_subtag_offset]
+        /* ppc:6032 cmpri(cr0,imm0,subtag_simple_vector) */
+        cmp imm0, #subtag_simple_vector
+        /* ppc:6033 box_fixnum(temp0,imm0) -- subtag_misc_set wants boxed typecode */
+        lsl temp0, imm0, #fixnumshift
+        b.eq _SPsubtag_misc_set         /* ppc:6034 */
+        /* ppc:6035-6037 ivector_typecode_p + compare.  Exclude node-headers
+           (vectorH/arrayH) before the >= test — see builtin_aref1 for the
+           tag-scheme rationale (raw compare would treat a complex array as an
+           ivector and misc_set into its header). */
+        and imm1, imm0, #tagmask
+        cmp imm1, #tag_nodeheader
+        b.eq 1f
+        cmp imm0, #min_cl_ivector_subtag
+        b.ge _SPsubtag_misc_set
+1:      jump_builtin _builtin_aset1, 3  /* ppc:6038 */
+endsp builtin_aset1
+
+/* ========== DEBUGGER / RESET ========== */
+
+/* ported from ppc-spentry.s:6043-6046 (PPC64 branch)
+ * breakpoint: enter the debugger.
+ * PPC: tw 28,sp,sp (unconditional trap).
+ *
+ * ARM64: uuo_debug_trap (arm64-uuo.s: uuo_misc 3), NOT `brk #N'.  This
+ * carried an #error and a "brk #<encoding> TBD" note for far too long; the
+ * encoding was never undecided, it was already defined upstream and simply
+ * not looked for.  Two things made it stay wrong: `breakpoint' is not
+ * reached by our boot or test path, so nothing ever failed; and the note
+ * assumed brk, which is the same mistake patch 0047 swept out of 61 other
+ * sites -- brk does NOT satisfy the kernel's IS_UUO test
+ * (`((i) & 0xffff0000) == 0', arm64-exceptions.c:175), so a brk here would
+ * have reached handle_uuo's caller as an unrecognized SIGTRAP rather than
+ * as a debugger entry.  udf, which is what uuo_misc emits, does satisfy it.
+ * The macro reaches us via arm64-macros.s:4. */
+spentry breakpoint
+        mov x0, #0                      /* ppc:6044 li r3,0 */
+        uuo_debug_trap                  /* ppc:6045 tw 28,sp,sp */
+        ret                             /* ppc:6046 blr -- if handler returned */
+endsp breakpoint
+
+/* ported from ppc-spentry.s:4941-4949 (PPC64 branch)
+ * reset: signal stack overflow by throwing to toplcatch with XSTKOVER.
+ * PPC: nop (for alignment); ref_nrs_value(temp0,toplcatch); push tag+code;
+ * set_nargs(1); b _SPthrow. */
+spentry reset
+        .globl _SPthrow
+        nop                             /* ppc:4943 alignment nop */
+        ref_nrs_value temp0, toplcatch  /* ppc:4944                        */
+        mov temp1, #XSTKOVER            /* ppc:4945 (deferr errors.s:196)  */
+        vpush1 temp0                    /* ppc:4946 */
+        vpush1 temp1                    /* ppc:4947 */
+        set_nargs 1                     /* ppc:4948 */
+        b _SPthrow                      /* ppc:4949 */
+endsp reset
+
+/* ========== MULTIPLE-VALUE STACK OPERATIONS ========== */
+
+/* ported from ppc-spentry.s:4954-4968 (PPC64 branch)
+ * mvslide: slide nargs worth of values up the vstack.
+ * imm0 = difference between current vsp and target (byte offset).
+ * Copies nargs bytes of values from [vsp..vsp+nargs) to
+ * [vsp+nargs+imm0 - nargs .. vsp+nargs+imm0), i.e., slides them
+ * up by imm0 bytes, then sets vsp to the new base. */
+spentry mvslide
+        /* PPC computes imm2/imm0 BEFORE testing nargs (branch-delay style) */
+        mov imm3, nargs                 /* ppc:4956 mr imm3,nargs */
+        add imm2, vsp, nargs            /* ppc:4957 add imm2,vsp,nargs */
+        add imm2, imm2, imm0           /* ppc:4958 add imm2,imm2,imm0 -- target end */
+        add imm0, vsp, nargs            /* ppc:4959 add imm0,vsp,nargs -- source end */
+        cbz nargs, 2f                   /* ppc:4955/4960 cmpri+beq (after setup) */
+1:      /* ppc:4962-4966 copy loop (pre-decrement load/store) */
+        sub imm3, imm3, #(1 << fixnumshift)  /* ppc:4963 subi imm3,fixnum_one */
+        ldr temp0, [imm0, #-node_size]! /* ppc:4964 ldru(temp0,-node_size(imm0)) */
+        str temp0, [imm2, #-node_size]! /* ppc:4965 stru(temp0,-node_size(imm2)) */
+        cbnz imm3, 1b                   /* ppc:4962/4966 cmpri+bne */
+2:      mov vsp, imm2                   /* ppc:4968 mr vsp,imm2 */
+        ret                             /* ppc:4969 blr */
+endsp mvslide
+
+/* ========== ARGUMENT REGISTER OPERATIONS ========== */
+
+/* ported from ppc-spentry.s:3859-3878 (PPC64 branch)
+ * vpopargregs: pop 0-3 values from vstack into arg registers based on nargs.
+ * nargs=0: do nothing. nargs=8(1 arg): pop arg_z.
+ * nargs=16(2 args): pop arg_z, arg_y. nargs>=24(3+): pop arg_z, arg_y, arg_x. */
+spentry vpopargregs
+        cbz nargs, 4f                   /* ppc:3860 cmpri(cr0,nargs,0); beqlr */
+        cmp nargs, #(2 << fixnumshift)  /* ppc:3861 cmpri(cr1,nargs,2<<fixnumshift) */
+        b.eq 2f                         /* ppc:3863 beq cr1,yz */
+        b.lt 3f                         /* ppc:3864 blt cr1,z */
+        /* 3+ args: pop all three */
+        ldr arg_z, [vsp, #(node_size * 0)]  /* ppc:3865 */
+        ldr arg_y, [vsp, #(node_size * 1)]  /* ppc:3866 */
+        ldr arg_x, [vsp, #(node_size * 2)]  /* ppc:3867 */
+        add vsp, vsp, #(node_size * 3)  /* ppc:3868 la vsp,node_size*3(vsp) */
+        ret                             /* ppc:3869 */
+2:      /* 2 args */
+        ldr arg_z, [vsp, #(node_size * 0)]  /* ppc:3871 */
+        ldr arg_y, [vsp, #(node_size * 1)]  /* ppc:3872 */
+        add vsp, vsp, #(node_size * 2)  /* ppc:3873 */
+        ret                             /* ppc:3874 */
+3:      /* 1 arg */
+        ldr arg_z, [vsp, #(node_size * 0)]  /* ppc:3876 */
+        add vsp, vsp, #(node_size * 1)  /* ppc:3877 */
+4:      ret                             /* ppc:3878 / 3862 beqlr fallthrough */
+endsp vpopargregs
+
+/* ========== MULTIPLE-VALUE PASS VIA SYMBOL ========== */
+
+/* ported from ppc-spentry.s:6886-6898 (PPC64 branch)
+ * mvpasssym: like mvpass, but fname is known to be a symbol.
+ * Build lisp frame, set lr to ret1val_addr, jump through fname. */
+spentry mvpasssym
+        /* ppc:6887 cmpri(cr0,nargs,node_size*nargregs) */
+        cmp nargs, #(node_size * nargregs)
+        /* ppc:6888 mflr loc_pc -- save return address; ARM64: lr already is it */
+        mov imm0, vsp                   /* ppc:6889 mr imm0,vsp */
+        b.le 1f                         /* ppc:6890 ble+ cr0,1f */
+        sub imm0, imm0, #(node_size * nargregs)  /* ppc:6891 */
+        add imm0, imm0, nargs          /* ppc:6892 */
+1:
+        /* ppc:6894 build_lisp_frame(fn,loc_pc,imm0) -- MARKER frame
+         * (Matt's popj layout; no backlink word). */
+        sub sp, sp, #lisp_frame.size
+        mov temp0, #lisp_frame_marker
+        str temp0, [sp, #lisp_frame.marker]
+        str imm0, [sp, #lisp_frame.savevsp]
+        str fn, [sp, #lisp_frame.savefn]
+        str x30, [sp, #lisp_frame.savelr]
+        /* ppc:6895 ref_global(loc_pc,ret1val_addr); ppc:6897 mtlr */
+        ref_global lr, ret1val_addr     /* ppc:6895+6897 */
+        mov fn, xzr                     /* ppc:6896 li fn,0 */
+        /* ppc:6898 jump_fname() */
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp0, [nfn, #_function.codevector]
+        br temp0
+endsp mvpasssym
+
+/* NOTES */
+
+/* OPEN #error SITES (deduped in upstream-port/MISSING-CONSTANTS-RATIFY.md):
+ * - breakpoint trap encoding (this file's only remaining #error) --
+ *   Matt's-call ratify item.
+ * RESOLVED since first draft: NRS/lisp_globals ref idiom
+ * (arm64-globals-proposed.s -- jump_builtin, callbuiltin, ksignalerr,
+ * reset, mvpass all real now), EGC write-barrier globals (rplaca/rplacd),
+ * trap encodings (canonical arm64-uuo.s scheme + PROPOSED extensions; see
+ * the trap block above and spentry-A's namespace doc).  All other former
+ * MISSING-CONSTANT holes are derived locally in the header block above
+ * (symbol.fcell, _function.codevector, t_offset, lisp_frame marker layout,
+ * vectorH.logsize, XSTKOVER, XNOSPREAD, error_object_not_list). */
+
+/* PORT-TODO items requiring design decisions or missing mechanisms:
+ *
+ * 1. fn-volatile protocol (HIGH PRIORITY): PPC64 fn is nonvolatile (callee-saved),
+ *    but ARM64 fn=x7 is VOLATILE per upstream design. Every place PPC64 code depends
+ *    on fn surviving a BL needs a protocol decision - either:
+ *    a) Save/restore fn around calls (where?)
+ *    b) Change calling convention to make fn nonvolatile (conflicts with AAPCS64?)
+ *    c) Use a different register for fn in ARM64
+ *    Affected subprims: jmpsym, funcall, mvpass, tfuncall*, tcall*
+ *
+ * 2. .SPbuiltin dispatch mechanism: RESOLVED -- jump_builtin macro defined
+ *    locally (line ~122), fully real via ref_nrs_value
+ *    (arm64-globals-proposed.s). All 12 prior PORT-TODO dispatcher sites
+ *    replaced with jump_builtin invocations.
+ *
+ * 3. EGC write barrier: rplaca/rplacd have complex refbits/ephemeral_refidx
+ *    manipulation that requires access to global state. Need to verify the
+ *    mechanism in upstream ARM64.
+ *
+ * 4. keyword_args / call_closure: These have very complex stack manipulation
+ *    that needs careful line-by-line porting with full understanding of the
+ *    keyword binding protocol and closure layout.
+ *
+ * 5. Missing subprims referenced: _SPkeyword_bind, _SPmakes128, ret1val_addr,
+ *    and various error handlers. These are defined elsewhere and need to be
+ *    coordinated.
+ *
+ * 6. Numeric local labels: This file uses simple numeric labels (1:, 2:, etc.)
+ *    following the style of his existing code. These are file-scoped in GNU as,
+ *    which matches his style, but differs from our high-tag port's approach
+ *    of using local_label() macros. His style is cleaner for short subprims.
+ */
+
+/* UNCERTAINTIES:
+ *
+ * - nargs arithmetic: PPC64 nargs is a TAGGED fixnum (confirmed in both ports).
+ *   All nargs comparisons use (nargregs << fixnumshift) to convert untagged
+ *   constant to tagged form. This is correct for fixnumshift=3.
+ *
+ * - register allocation in complex subprims: Some subprims use many temporaries
+ *   and may exceed available ARM64 temp registers (temp0-4 = x13-x17, only 5).
+ *   May need to spill to stack or use save registers with care.
+ *
+ * - Branch distance: Some of the dispatch-heavy subprims (keyword_args,
+ *   builtin_length) have many forward/backward branches that may exceed
+ *   ARM64's ±1MB branch range if separated. Should be fine within one file.
+ */

--- a/lisp-kernel/spentry-E-ffi.s
+++ b/lisp-kernel/spentry-E-ffi.s
@@ -1,0 +1,922 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * E-ffi cluster: 8 subprims ported from PPC64 to ARM64 low-tag
+ *   ffcall, ffcall_return_registers, ffcallX (trap-only), callback,
+ *   callbackX (trap-only), syscall, lexpr_entry, spread_lexprz
+ *
+ * Source: vendor/ccl/lisp-kernel/ppc-spentry.s (PPC64 poweropen_* branches:
+ *   ffcall @1595, ffcall_return_registers @1796, callbackX @2068,
+ *   ffcallX @3526, spread_lexprz @4883, callback @5031, lexpr_entry @5362,
+ *   syscall @5402).  The eabi_* bodies (@6055/6158/6346) are PPC32 and were
+ *   NOT used.  AAPCS64 mechanics (FPCR/FPSR split, d0-d7 arg staging,
+ *   callee-saved x19-x28/d8-d15, svc #0) follow the boot-validated
+ *   implementations in ../../lisp-kernel/arm64-spentry.s (eabi_ff_call,
+ *   arm64_syscall, eabi_callback, lexpr_entry, spread_lexprz), re-mapped to
+ *   Matt Emerson's register assignments and low-tag scheme.
+ * Target: Matt Emerson's upstream ARM64 low-tag design (pin 115b7aa).
+ *
+ * Register map (arm64-constants.h @ 115b7aa, unified): imm0-5=x0-x5,
+ * nargs=x6 (holds FIXNUMS), fn=x7 (VOLATILE), arg_w-arg_z=x8-x11,
+ * temp0-temp5=x12-x17 (nfn=temp2, fname=temp3), save0-3=x19-x22,
+ * rnil=x23, tsp=x24, vsp=x25, allocptr=x26, allocbase=x27, rcontext=x28.
+ * fixnumshift=3, node_size=8.
+ *
+ * AAPCS64 facts this port leans on (vs PPC):
+ *   - rcontext=x28, rnil=x23, tsp=x24, vsp=x25, allocptr/allocbase=x26/x27
+ *     and save0-3=x19-x22 are ALL callee-saved: a conforming C callee
+ *     preserves them, so PPC's "mr save0,rcontext / restore" dance and the
+ *     nil-out of rnil-adjacent registers are unnecessary.  save0-3 are
+ *     still vpushed so the GC can SEE them while the thread is foreign.
+ *   - fn=x7 and nargs=x6 are AAPCS64 argument registers: clobbered by the
+ *     C-arg loads, so fn is saved in the lisp_frame (savefn slot) exactly
+ *     as on PPC.
+ *   - loc_pc -> lr ([D3] convention, cf. spentry-D): AArch64 keeps the
+ *     return pc in lr; frames save/restore lr.
+ *   - PPC FPSCR (one register) -> FPCR (control) + FPSR (status).
+ *
+ * STATUS: all 8 subprims carry real ported bodies (ffcallX/callbackX are
+ * trap-only ON PPC64 - `.long 0x7c800008` debug traps - and are ported as
+ * brk traps).  Sites depending on constants/conventions Matt has not yet
+ * defined carry #error + the intended instruction in a comment.
+ */
+
+#include "arm64-constants.h"
+#include "arm64-macros.s"
+#include "arm64-globals-proposed.s"
+
+/*
+ * ===========================================================================
+ * PROPOSED-CONSTANTS (ratify with Matt)
+ * ---------------------------------------------------------------------------
+ * NOT in arm64-constants.h.  Values DERIVED from the cited sources; the C
+ * runtime and compiler must agree.
+ * ===========================================================================
+ */
+
+/* fixnum 1 and the *INTERRUPT-LEVEL* tlb index (x86-constants64.s:414/867;
+   same equates as spentry-C). */
+.set fixnumone, (1<<fixnumshift)
+.set INTERRUPT_LEVEL_BINDING_INDEX, fixnumone
+
+/* Thread valence values: lisp-kernel/constants.h:27-28 (present verbatim in
+   Matt's tree; a C header, so re-equated here for the assembler). */
+.set TCR_STATE_LISP,    0
+.set TCR_STATE_FOREIGN, 1
+
+/* lisp_frame: Matt's ARM-family MARKER frame (ground truth: his popj vinsn,
+   compiler/ARM64/arm64-vinsns.lisp:61-67, + subtag_lisp_frame_marker,
+   arm64-constants.h:177).  Same equates as spentry-A:55-59. */
+.set lisp_frame.marker,  0
+.set lisp_frame.savevsp, 8
+.set lisp_frame.savefn,  16
+.set lisp_frame.savelr,  24
+.set lisp_frame.size,    32
+
+/* symbol.fcell / function codevector: slot order from ppc-constants64.s
+   :237-245/:223-226.  Symbols keep their dedicated pointer tag; a function
+   is an ordinary miscobj (fulltag_function removed, patch 0055), so its
+   codevector slot is misc_data_offset.  Same equates as spentry-A. */
+.set symbol.fcell, (3*node_size - fulltag_symbol)
+.set _function.codevector, misc_data_offset
+
+/* area: ppc-constants64.s:382-401 _struct(area,0).
+   16m41 CORRECTION: the note here said "Matt's tcr has NO
+   tcr.last_lisp_frame, so [writing area.active from asm] is the line-port".
+   STALE -- arm64-constants.h:470 (asm) / :531 (C) both carry
+   last_lisp_frame at this pin, and nothing in this file ever wrote
+   area.active either, so the boundary went unrecorded entirely.  The
+   protocol now lives in tcr.last_lisp_frame (see the macros above); the C
+   side does the area lookup in normalize_tcr, which also keeps the
+   cs_area->older chain consistent, something a raw asm store could not. */
+_struct area, 0
+  _node pred
+  _node succ
+  _node low
+  _node high
+  _node active
+  _node softlimit
+  _node hardlimit
+_ends
+
+/* c_frame (the outgoing-argument staging frame built by the compiler's
+   alloc-c-frame vinsn) is defined in arm64-constants.h since upstream
+   patch 0003: {backlink, savelr, params...} -- the 8 GPR argument words
+   at c_frame.params, stack (overflow) words immediately above.  The
+   pre-w13 local definition that lived here (with a reserved transition
+   lisp_frame above the frame) is retired. */
+
+/*
+ * ---------------------------------------------------------------------------
+ * Local helper macros (same equates/idioms as spentry-C:176-273)
+ * ---------------------------------------------------------------------------
+ */
+
+.macro vpush1 reg
+        str \reg, [vsp, #-node_size]!
+.endm
+.macro vpop1 reg
+        ldr \reg, [vsp], #node_size
+.endm
+.macro set_nargs n
+        mov nargs, #((\n)<<fixnumshift)
+.endm
+.macro discard_lisp_frame
+        add sp, sp, #lisp_frame.size
+.endm
+
+/* Spill/reload the boxed NVRs to/from the vstack so the GC can see them
+   while the thread is in foreign code (ppc-macros.s vpush_saveregs, sized
+   to this design's nsaveregs=4). */
+.macro vpush_saveregs
+        vpush1 save0
+        vpush1 save1
+        vpush1 save2
+        vpush1 save3
+.endm
+.macro vpop_saveregs
+        vpop1 save3
+        vpop1 save2
+        vpop1 save1
+        vpop1 save0
+.endm
+
+/* ===========================================================================
+ * THE LISP <-> FOREIGN CSTACK BOUNDARY PROTOCOL          (16m41; ARM64-DEVIATION)
+ * ===========================================================================
+ *
+ * A thread's cs_area is its whole pthread stack (thread_manager.c:1550
+ * register_cstack_holding_area_lock(stack_base, stack_size)), so it holds C
+ * frames as well as lisp frames -- glibc's TLS block and the thread's C
+ * startup frames at the top, the callee's frames below every ff-call.  The GC
+ * walks [cs_area->active, cs_area->high) LINEARLY and asserts it lands exactly
+ * on ->high (arm64-gc.c mark_cstack_area), because Matt's frames are MARKER
+ * frames: word 0 is subtag_lisp_frame_marker, NOT a backlink.
+ *
+ * PPC64 needs nothing here and so is not the donor: its frames ARE backlinks,
+ * the C ABI mandates one at word 0 of every frame, and ppc-gc.c:1022 is a
+ * chain walk that strides over a C region for free (ppc-subprims.s:73
+ * start_lisp does no bookkeeping at all).  AAPCS64 mandates no such chain --
+ * x29 is optional and gcc -O2 omits it -- so on a marker walk the C regions
+ * have to be described explicitly.  Matt's WIP has no start_lisp/ffcall to
+ * adopt from.  The mechanism below is therefore the ARM-family one (marker
+ * frames + linear walk is the same shape there), rendered for AAPCS64:
+ *
+ *   tcr.last_lisp_frame = the LOWEST lisp-owned cstack word while the thread
+ *   is foreign; initialized to cs_area->high (= "no lisp frames yet") in
+ *   thread_manager.c:1553.  The GC reads it in normalize_tcr's ff-call branch.
+ *
+ *   lisp -> foreign (ffcall): store the c_frame base there.  Its word 0 is
+ *   the frame's own ivector header, so the walk starts on a self-describing
+ *   region; the old value is parked in a dead param word (inside that
+ *   ivector, hence unscanned, and above SP, hence untouchable by the callee).
+ *
+ *   foreign -> lisp (start_lisp, callback): the C region between the new lisp
+ *   SP and the previous boundary cannot be walked, so COVER it with a
+ *   synthetic u64-vector header that strides exactly onto the previous
+ *   boundary.  16m41 observed the cost of not doing this: the walk climbed
+ *   three real lisp frames, ran into the C region above them, guessed through
+ *   an x29 hop and four zero words, then read a spilled 0.9d0
+ *   (0x3feccccccccccccd) as an ivector header and strode 1.8e16 words.
+ *
+ * Arithmetic (mirrors the ARM-family idiom, re-derived for 64-bit):
+ *   count = ((OLD - sp) + node_size) >> node_shift   u64 elements
+ *   header = (count << num_subtag_bits) | subtag_u64_vector
+ * with the pair {header, OLD} pushed at sp-16, skip_over_ivector
+ * (arm64-gc.c:1033) returns (sp-16) + dnode_align(count*8 + 8) == OLD, since
+ * OLD and sp are both 16-aligned (AAPCS64) so count*8 + 8 == OLD - (sp-16)
+ * exactly.  A single `lsl #(num_subtag_bits - node_shift)' does the two
+ * shifts because (OLD - sp) + 8 always has its low 3 bits clear.
+ */
+.macro cover_foreign_stack_region hdr, old
+        ldr  \old, [rcontext, #tcr.last_lisp_frame]
+        mov  \hdr, sp                   /* SP cannot be the Rm of a SUB */
+        sub  \hdr, \old, \hdr           /* bytes of C region above sp */
+        add  \hdr, \hdr, #node_size
+        lsl  \hdr, \hdr, #(num_subtag_bits - node_shift)
+        add  \hdr, \hdr, #subtag_u64_vector   /* low 8 bits clear: add == orr */
+        stp  \hdr, \old, [sp, #-16]!
+.endm
+
+/* Pop the cover pair and restore the ENCLOSING boundary.  Restoring matters:
+   without it a nested transition (lisp -> ffcall -> callback -> lisp ->
+   ffcall -> return -> callback returns) would leave last_lisp_frame naming a
+   region that has already been popped, and the next walk would start in dead
+   stack. */
+.macro uncover_foreign_stack_region scratch, old
+        ldp  \scratch, \old, [sp], #16
+        str  \old, [rcontext, #tcr.last_lisp_frame]
+.endm
+
+/* Poll for a deferred interrupt (ppc-macros.s check_pending_interrupt;
+   clobbers nargs).  arm64-uuo.s's uuo_interrupt_now, which is
+   uuo_misc 4 at pin 9c61574 -- it was misc 3 @115b7aa, before
+   uuo_debug_trap was inserted at 3.  We invoke the MACRO, so the renumber
+   costs nothing; only a hardcoded number would have broken.  Stack-overflow
+   sites use the PROPOSED uuo_interr extension. */
+.set error_stack_overflow, 5            /* errors.s:25 */
+.macro check_pending_interrupt
+        ldr nargs, [rcontext, #tcr.tlb_pointer]
+        ldr nargs, [nargs, #INTERRUPT_LEVEL_BINDING_INDEX]
+        cmp nargs, #0
+        b.lt 8887f                       /* interrupts disabled: done */
+        b.gt 8886f                       /* level>0: cannot be pending here */
+        ldr nargs, [rcontext, #tcr.interrupt_pending]
+        cbz nargs, 8887f
+8886:   uuo_interrupt_now                /* uuo_misc 4 at pin 9c61574 (was 3 @115b7aa, before he
+                                            inserted uuo_debug_trap at 3) */
+8887:
+.endm
+
+/*
+ * ===========================================================================
+ * FFI SUBPRIMS
+ * ===========================================================================
+ */
+
+/* _SPffcall lives in arm64-spentry.s (upstream patch 0003): it was
+ * re-ported there against the w13 aapcs64-ff-call codegen unit's
+ * c_frame protocol ([backlink,savelr,params...]; entry point unboxed
+ * from a macptr OR a fixnum-locative; no FPCR switching -- lisp runs
+ * with the process-default FPCR; FPSR exception flags published to
+ * tcr.foreign_fpsr per Matt's f067047 TCR).  The earlier draft that
+ * lived here used the pre-w13 frame layout and the removed
+ * tcr.lisp_mxcsr/ffi_exception slots. */
+
+/* Just like ffcall, but saves all AAPCS64 result registers into a buffer
+ * whose macptr is passed in arg_y, before returning to lisp (ppc:1796
+ * poweropen_ffcall_return_registers; needed because several C result
+ * registers are dedicated lisp registers).
+ * PROPOSED buffer layout (RATIFY - lisp-side ff-call glue must match):
+ *   [0..56]   x0..x7   (8 GPRs; PPC stores its 8 GPR args/results)
+ *   [64..120] d0..d7   (8 FPRs; PPC stores f1-f13 - AAPCS64 result FPRs
+ *                       are d0-d7, so 8 doubles here)
+ */
+/* Body = patch-0003 _SPffcall with the result-buffer stores inserted
+ * at the return; save2 carries the buffer address across the call
+ * (callee-saved), parked on the vstack like save3/fn. */
+spentry ffcall_return_registers
+        str fn, [vsp, #-node_size]!             /* ppc:1799 vpush_saveregs   */
+        str save3, [vsp, #-node_size]!
+        mov save3, sp
+        /* Park lr in the boundary lisp_frame his alloc-c-frame RESERVED at the
+         * frame top, and publish it by shrinking the header count by 4.  The
+         * c_frame has NO savelr and [sp,#8] is the saved SP; writing lr there
+         * and restoring sp from the header word gave sp=0xded (16m30).
+         * CANONICAL NOTE: `spentry ffcall' in arm64-spentry.s. */
+        ldr imm0, [sp, #c_frame.header]
+        lsr imm1, imm0, #num_subtag_bits        /* element count = words-1 */
+        sub imm1, imm1, #3
+        mov imm2, sp                            /* add-shifted with Rn=sp is */
+        add imm2, imm2, imm1, lsl #node_shift   /* an encoding trap */
+        mov imm1, #lisp_frame_marker
+        str imm1, [imm2, #lisp_frame.marker]
+        str vsp, [imm2, #lisp_frame.savevsp]
+        str fn,  [imm2, #lisp_frame.savefn]
+        str lr,  [imm2, #lisp_frame.savelr]
+        sub imm0, imm0, #(4 << num_subtag_bits)
+        str imm0, [sp, #c_frame.header]
+        /* Buffer address -> save2 (PPC uses save7, ppc:1800). */
+        str save2, [vsp, #-node_size]!
+        ldur save2, [arg_y, #macptr.address]
+        /* Unbox the entry point into temp4 (ppc:1802-1814
+           extract_typecode): macptr iff fulltag_misc AND header subtag
+           == subtag_macptr; anything else the raw bits ARE the address.
+           A bare `tst #tagmask` misclassifies 4-aligned C entry points
+           (lisp_malloc = ...eac, fulltag 0xc) as macptrs (16m5l). */
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne 8f
+        ldurb w2, [arg_z, #misc_subtag_offset]
+        cmp imm2, #subtag_macptr
+        b.ne 8f
+        ldur temp4, [arg_z, #macptr.address]
+        b 9f
+8:      mov temp4, arg_z        // fixnum-locative / raw code address
+9:
+        /* Publish lisp state to the TCR for the GC, then go foreign
+           (ppc:1816-1827). */
+        str vsp, [rcontext, #tcr.save_vsp]
+        str tsp, [rcontext, #tcr.save_tsp]
+        str allocptr, [rcontext, #tcr.save_allocptr]
+        str allocbase, [rcontext, #tcr.save_allocbase]
+        /* Load the outgoing GPR args and pop the frame head + param
+           words so stack args sit exactly at SP (ppc:1836-1843).
+           Above the valence store since 16m41: see the ordering note in
+           `spentry ffcall' (arm64-spentry.s) -- the boundary has to be
+           recorded before this thread advertises foreign valence, and the
+           park slot is only dead once the args are loaded. */
+        ldp x0, x1, [sp, #c_frame.params]
+        ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
+        ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
+        ldp x6, x7, [sp, #(c_frame.params + 6*node_size)]
+        /* AAPCS64, no stack args (<=8 GPR/<=8 FP, enforced loud in the
+         * w13 codegen): keep SP at the frame head -- the callee's stack
+         * grows BELOW its incoming SP, so popping the frame here hands
+         * the saved lr/backlink to the callee as scratch (16m5c crash in
+         * the _SPffcall twin: return jumped into the c_frame).  Stack-arg
+         * layout = ratify item (frame head must move above params). */
+        /* Boundary bookkeeping + valence, identical to `spentry ffcall' in
+         * arm64-spentry.s -- see the protocol note at the top of this file.
+         * temp0, not imm0: imm0 is x0, now an outgoing argument. */
+        ldr temp0, [rcontext, #tcr.last_lisp_frame]
+        str temp0, [sp, #c_frame.params]
+        mov temp0, sp
+        str temp0, [rcontext, #tcr.last_lisp_frame]
+        mov temp0, #TCR_STATE_FOREIGN
+        str temp0, [rcontext, #tcr.valence]
+        blr temp4                               /* ppc:1849 bctrl            */
+        /* Store every AAPCS64 result register into the buffer
+           (ppc:1851-1871 stores r3-r10/f1-f13). */
+        stp x0, x1, [save2, #(0*node_size)]
+        stp x2, x3, [save2, #(2*node_size)]
+        stp x4, x5, [save2, #(4*node_size)]
+        stp x6, x7, [save2, #(6*node_size)]
+        stp d0, d1, [save2, #((8*node_size) + 0*8)]
+        stp d2, d3, [save2, #((8*node_size) + 2*8)]
+        stp d4, d5, [save2, #((8*node_size) + 4*8)]
+        stp d6, d7, [save2, #((8*node_size) + 6*8)]
+        /* ---- common return path (= patch-0003 ffcall) ---- */
+        mrs imm1, fpsr
+        str imm1, [rcontext, #tcr.foreign_fpsr]
+        msr fpsr, xzr
+        /* A GC may have run while we were foreign. */
+        ldr allocptr, [rcontext, #tcr.save_allocptr]
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        /* lr from the boundary lisp_frame; sp from the SAVED SP word, not the
+         * header at offset 0 (16m30).  Count is already shrunk by 4, so
+         * reserved_base = save3 + node_size*(count+1).  imm1/imm2 only. */
+        ldr imm1, [save3, #c_frame.header]
+        lsr imm1, imm1, #num_subtag_bits
+        add imm1, imm1, #1
+        add imm2, save3, imm1, lsl #node_shift
+        ldr lr, [imm2, #lisp_frame.savelr]
+        ldr imm1, [save3, #c_frame.savedsp]
+        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
+        ldr imm2, [save3, #c_frame.params]
+        str imm2, [rcontext, #tcr.last_lisp_frame]
+        mov sp, imm1
+        ldr save2, [vsp], #node_size
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        mov arg_w, rnil
+        mov arg_x, rnil
+        mov arg_y, rnil
+        mov arg_z, rnil
+        mov temp0, rnil
+        mov temp1, rnil
+        mov temp2, rnil
+        mov temp3, rnil
+        mov temp4, rnil
+        mov temp5, rnil
+        mov nargs, xzr
+        str xzr, [rcontext, #tcr.valence]   // TCR_STATE_LISP
+        check_pending_interrupt
+        ret
+endsp ffcall_return_registers
+
+/* Deprecated "swap exception handling info" variant.  TRAP-ONLY ON PPC64
+ * TOO: ppc-spentry.s:3526-3527 is just `.long 0x7c800008` (debug trap). */
+spentry ffcallX
+        brk #0                                  /* ppc:3527 debug trap       */
+endsp ffcallX
+
+/* Darwin-JNI exception-port variant.  TRAP-ONLY ON PPC64 TOO:
+ * ppc-spentry.s:2068-2069 is just `.long 0x7c800008` (debug trap). */
+spentry callbackX
+        brk #0                                  /* ppc:2069 debug trap       */
+endsp callbackX
+
+/* C-to-lisp callback (ppc:5031 poweropen_callback).  Restore lisp context,
+ * then funcall %pascal-functions% with two args: callback-index and a
+ * "frame pointer" fixnum from which the lisp glue reads the C arguments
+ * and into which it writes the C result.
+ *
+ * PROPOSED-CONVENTION CALLBACK-IDX (RATIFY): the make-callback trampoline
+ * stub enters here with the UNBOXED callback index in arg_w=x8 (16m14:
+ * fixed a =x9 typo here — the code below reads arg_w, which is x8; the
+ * level-1/arm64-callback-support.lisp generator stamps x8) (PPC uses
+ * r11; any AAPCS64 caller-saved scratch works - the trampoline generator
+ * is a lisp-side deliverable that must match).
+ *
+ * PROPOSED frame contract (RATIFY - lisp-side callback glue must match;
+ * boot-validated shape from our v2 tree): x0..x7 are pushed so the x0 slot
+ * abuts the incoming sp; CBF = &x0save.  The C caller's stack args then
+ * sit contiguously at CBF+64 (the PowerOpen single-linear-offset property,
+ * reproduced).  d0..d7 saves at CBF-64..-8.  The GPR result is reloaded
+ * from CBF+0/+8, the FPR result from CBF-64.  CBF is 16-aligned, so it is
+ * its own fixnum boxing.
+ *
+ * ARM64-DEVIATION (vs PPC64 poweropen_callback):
+ *   - callee-saved set = x19-x28 + fp/lr and d8-d15 (+FPCR/FPSR pair), NOT
+ *     PPC's r13-r31/f-block; lisp may clobber d8-d15, so they are saved
+ *     here (RATIFY: alternatively restrict Matt's compiler FPR pool).
+ *   - get_tcr is reached by a direct `bl` (kernel-internal symbol;
+ *     PPC indirects through a lisp_global for TOC reasons, ppc:5115).
+ *   - save0-3 enter lisp as 0 (valid fixnums; our v2-validated choice)
+ *     rather than PPC's restore_saveregs-from-vstack (ppc:5149).  The
+ *     outer ffcall reloads its own save0-3 from its vstack spill, so
+ *     values are never lost.  RATIFY if Matt wants PPC's reload.
+ */
+spentry callback
+        /* Save the C argument registers so the lisp glue can read them
+           (ppc:5036-5043 stores r3-r10 into the caller frame; AAPCS64 has
+           no reserved param area, so push them - x0 slot lands at CBF). */
+        stp x6, x7, [sp, #-16]!
+        stp x4, x5, [sp, #-16]!
+        stp x2, x3, [sp, #-16]!
+        stp x0, x1, [sp, #-16]!
+        mov arg_x, sp                           /* arg_x=x10: CBF            */
+        stp d6, d7, [sp, #-16]!
+        stp d4, d5, [sp, #-16]!
+        stp d2, d3, [sp, #-16]!
+        stp d0, d1, [sp, #-16]!                 /* d0 save @ CBF-64          */
+        /* Save the AAPCS64 callee-saved GPRs (ppc:5052-5071 saves r13-r31). */
+        stp x19, x20, [sp, #-16]!
+        stp x21, x22, [sp, #-16]!
+        stp x23, x24, [sp, #-16]!
+        stp x25, x26, [sp, #-16]!
+        stp x27, x28, [sp, #-16]!
+        stp x29, lr,  [sp, #-16]!
+        /* Save the callee-saved FPRs + the foreign FPCR/FPSR
+           (ppc:5072-5096 saves f1-f13 + FPSCR). */
+        stp d8,  d9,  [sp, #-16]!
+        stp d10, d11, [sp, #-16]!
+        stp d12, d13, [sp, #-16]!
+        stp d14, d15, [sp, #-16]!
+        mrs imm0, fpcr
+        mrs imm1, fpsr
+        stp imm0, imm1, [sp, #-16]!
+        /* Stash index + CBF in just-saved callee-saved regs: they must
+           survive the get_tcr C call (x9-x17 are caller-saved, and a
+           linker veneer may clobber x16/x17). */
+        mov save0, arg_w
+        mov save1, arg_x
+        /* Recover the thread context (ppc:5114-5124 get_tcr(1)). */
+        mov x0, #1
+        bl get_tcr
+        mov rcontext, x0
+        /* Stash the exact foreign sp for the return path. */
+        mov imm0, sp
+        stp imm0, xzr, [sp, #-16]!
+        /* Restore lisp context (ppc:5127-5147). */
+        ldr vsp, [rcontext, #tcr.save_vsp]
+        ldr tsp, [rcontext, #tcr.save_tsp]
+        /* FP state (ppc:5141-5142 restores the lisp FPSCR): no FPCR
+           switch in Matt's TCR design (f067047 removed lisp_mxcsr; lisp
+           runs with the process-default FPCR) -- just clear the sticky
+           exception flags before entering lisp code. */
+        msr fpsr, xzr
+        /* Marshal the lisp args from the stash BEFORE zeroing (ppc:5109-
+           5112): boxed index; CBF is 16-aligned = its own fixnum. */
+        lsl arg_y, save0, #fixnumshift
+        mov arg_z, save1
+        /* Zero the remaining node registers (ppc:5102-5108,5133-5140; 0 is
+           fixnum 0, GC-valid).  fn=0: subprim, not a lisp function. */
+        mov fn, #0
+        mov arg_w, #0
+        mov arg_x, #0
+        mov temp0, #0
+        mov temp1, #0
+        mov temp2, #0
+        mov temp3, #0
+        mov temp4, #0
+        mov save0, #0
+        mov save1, #0
+        mov save2, #0
+        mov save3, #0
+        /* Re-materialize rnil (ppc:5130 restores NIL as part of
+           restore_lisp_context).  We entered from FOREIGN state: a conforming
+           C callee preserves x23, but the caller that reaches .SPcallback
+           (callback_to_lisp's foreign trampoline) is under no such contract,
+           so rnil=x23 arrives clobbered (observed 16m20: x23=0x2, garbage ->
+           the rnil-relative nrs.callbacks ref below SIGSEGV'd).  Every other
+           spentry assumes rnil is live; the callback is the sole re-entry that
+           must reload it.  Use the SAME idiom as start_lisp below: nil_value
+           is patched into the C global lisp_nil at initial heap mapping (Matt
+           2026-07-11), so it is NOT a compile-time immediate. */
+        ldr rnil, =lisp_nil
+        ldr rnil, [rnil]
+        /* Cover the foreign region below the enclosing lisp boundary -- the C
+           caller's frames plus every register block this spentry just pushed --
+           so the GC's linear cstack walk strides from here straight to
+           tcr.last_lisp_frame (the enclosing ff-call's c_frame, or
+           cs_area->high for a C thread that has never run lisp).  Pushed LAST,
+           so the header sits at the lowest address of what it describes; the
+           exit path accounts for the extra 16 bytes.  BEFORE the valence store,
+           so this thread never advertises lisp valence with a stretch of
+           unwalkable stack under it.  ARM64-DEVIATION: PPC's chain walk needs
+           no cover (protocol note near the top of this file). */
+        cover_foreign_stack_region imm0, imm1
+        mov imm0, #TCR_STATE_LISP               /* ppc:5130/5145             */
+        str imm0, [rcontext, #tcr.valence]
+        ldr allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5146-5147     */
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        /* Call (%pascal-functions% index CBF) (ppc:5151-5158). */
+        set_nargs 2
+        ref_nrs_symbol fname, callbacks         /* ppc:5157 li fname,nrs.callbacks */
+        ldr nfn, [fname, #symbol.fcell]
+        ldr temp4, [nfn, #_function.codevector]
+        blr temp4
+        /* Lisp wrote the result into CBF+0/+8 / CBF-64 (glue contract).
+           CBF is recomputed below from the restored sp (fixed layout);
+           first publish lisp state back to the tcr (ppc:5159-5169). */
+        str allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5166-5169     */
+        str allocbase, [rcontext, #tcr.save_allocbase]
+        str vsp,       [rcontext, #tcr.save_vsp]
+        str tsp,       [rcontext, #tcr.save_tsp]
+        /* Exit lisp context (ppc:5171-5172). */
+        mov imm0, #TCR_STATE_FOREIGN
+        str imm0, [rcontext, #tcr.valence]
+        /* Drop the C-region cover FIRST (it was pushed last) and restore the
+           enclosing boundary, then unwind to the foreign sp stash that now
+           sits 16 bytes above SP. */
+        uncover_foreign_stack_region imm0, imm1
+        /* Unwind to the exact foreign sp stash. */
+        ldr imm0, [sp]
+        mov sp, imm0
+        /* Restore foreign FPCR/FPSR + callee-saved FPRs (ppc:5174-5178). */
+        ldp imm0, imm1, [sp], #16
+        msr fpcr, imm0
+        msr fpsr, imm1
+        ldp d14, d15, [sp], #16
+        ldp d12, d13, [sp], #16
+        ldp d10, d11, [sp], #16
+        ldp d8,  d9,  [sp], #16
+        /* Reload the C result BEFORE x19/x20 are restored: sp now points at
+           the callee-saved GPR block; CBF = sp + 96 + 64. */
+        add imm2, sp, #(6*16 + 4*16)            /* imm2 = CBF                */
+        ldr x0, [imm2]                          /* GPR result (ppc:5213-5214)*/
+        ldr x1, [imm2, #8]
+        ldur d0, [imm2, #-64]                   /* FPR result                */
+        /* Restore callee-saved GPRs (ppc:5179-5197) and pop the arg-save
+           areas (ppc:5212); x0/x1/d0 carry the result (ppc:5225 blr). */
+        ldp x29, lr,  [sp], #16
+        ldp x27, x28, [sp], #16
+        ldp x25, x26, [sp], #16
+        ldp x23, x24, [sp], #16
+        ldp x21, x22, [sp], #16
+        ldp x19, x20, [sp], #16
+        add sp, sp, #(16*8)                     /* drop d0-d7 + x0-x7 saves  */
+        ret
+endsp callback
+
+/* Do a LINUX system call (ppc:5402 poweropen_syscall; the Darwin
+ * carry-flag/return-twice protocol is NOT ported).  Same c_frame contract
+ * and lisp<->foreign transition as ffcall; the middle is the AArch64
+ * Linux syscall sequence instead of a call:
+ *   x8 = syscall number (unboxed from arg_z), x0-x5 = args, `svc #0'
+ * (analog of x86-spentry64.s:4619 syscall; AArch64 Linux takes <=6
+ * integer args).
+ * ARM64-DEVIATION: Linux/AArch64 returns -errno directly in x0, so PPC's
+ * error-path negation (ppc:5441-5454) has no analog - imm0 carries the
+ * raw result.  No FP args => the FPCR dance is skipped (as on PPC, which
+ * doesn't touch the FPSCR in syscall). */
+#ifdef DARWIN
+#error "Darwin syscall convention not ported (svc #0x80 + carry-flag error protocol)"
+#endif
+/* Body = patch-0003 _SPffcall shape (same c_frame contract and
+ * lisp<->foreign transition) with the AArch64 Linux syscall sequence
+ * in the middle instead of a call. */
+spentry syscall
+        str fn, [vsp, #-node_size]!             /* ppc:5404 vpush_saveregs   */
+        str save3, [vsp, #-node_size]!
+        mov save3, sp
+        /* Park lr in the boundary lisp_frame his alloc-c-frame RESERVED at the
+         * frame top, and publish it by shrinking the header count by 4.  The
+         * c_frame has NO savelr and [sp,#8] is the saved SP; writing lr there
+         * and restoring sp from the header word gave sp=0xded (16m30).
+         * CANONICAL NOTE: `spentry ffcall' in arm64-spentry.s. */
+        ldr imm0, [sp, #c_frame.header]
+        lsr imm1, imm0, #num_subtag_bits        /* element count = words-1 */
+        sub imm1, imm1, #3
+        mov imm2, sp                            /* add-shifted with Rn=sp is */
+        add imm2, imm2, imm1, lsl #node_shift   /* an encoding trap */
+        mov imm1, #lisp_frame_marker
+        str imm1, [imm2, #lisp_frame.marker]
+        str vsp, [imm2, #lisp_frame.savevsp]
+        str fn,  [imm2, #lisp_frame.savefn]
+        str lr,  [imm2, #lisp_frame.savelr]
+        sub imm0, imm0, #(4 << num_subtag_bits)
+        str imm0, [sp, #c_frame.header]
+        /* Publish lisp state to the TCR for the GC, then go foreign
+           (ppc:5405-5422). */
+        str vsp, [rcontext, #tcr.save_vsp]
+        str tsp, [rcontext, #tcr.save_tsp]
+        str allocptr, [rcontext, #tcr.save_allocptr]
+        str allocbase, [rcontext, #tcr.save_allocbase]
+        str xzr, [rcontext, #tcr.foreign_fpsr]  /* syscalls raise no FP
+                           exceptions; publish a clean slate (PPC zeroes
+                           ffi_exception here, ppc:5415-5419) */
+        /* Syscall number + up to 6 args (ppc:5424-5432 loads r3-r10 + r0). */
+        asr x8, arg_z, #fixnumshift             /* ppc:5432 unbox_fixnum     */
+        ldp x0, x1, [sp, #c_frame.params]
+        ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
+        ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
+        /* 16m41 PARITY (this spentry goes foreign exactly like ffcall and was
+         * missing the same bookkeeping): park the enclosing boundary in the
+         * now-dead param word 0, then record the boundary and only then
+         * advertise foreign valence.  Unlike ffcall this frame is POPPED
+         * before the trap, so the boundary is taken AFTER the pop and names
+         * live stack -- the caller's own region, since the c_frame (still
+         * intact below SP, which is what the return path already relies on)
+         * has nothing the GC needs. */
+        ldr temp0, [rcontext, #tcr.last_lisp_frame]
+        str temp0, [sp, #c_frame.params]
+        add sp, sp, #(c_frame.size + 8*node_size)
+        mov temp0, sp
+        str temp0, [rcontext, #tcr.last_lisp_frame]
+        mov temp0, #TCR_STATE_FOREIGN
+        str temp0, [rcontext, #tcr.valence]
+        svc #0                                  /* ppc:5433 sc               */
+        /* ---- return path (x0 = raw result / -errno) (ppc:5455-5489) ---- */
+        ldr allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5470-5472     */
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        /* lr from the boundary lisp_frame; sp from the SAVED SP word, not the
+         * header at offset 0 (16m30).  Count is already shrunk by 4, so
+         * reserved_base = save3 + node_size*(count+1).  imm1/imm2 only. */
+        ldr imm1, [save3, #c_frame.header]
+        lsr imm1, imm1, #num_subtag_bits
+        add imm1, imm1, #1
+        add imm2, save3, imm1, lsl #node_shift
+        ldr lr, [imm2, #lisp_frame.savelr]
+        ldr imm1, [save3, #c_frame.savedsp]
+        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
+        ldr imm2, [save3, #c_frame.params]
+        str imm2, [rcontext, #tcr.last_lisp_frame]
+        mov sp, imm1
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        mov arg_w, rnil                         /* ppc:5461-5468             */
+        mov arg_x, rnil
+        mov arg_y, rnil
+        mov arg_z, rnil
+        mov temp0, rnil
+        mov temp1, rnil
+        mov temp2, rnil
+        mov temp3, rnil
+        mov temp4, rnil
+        mov temp5, rnil
+        mov nargs, xzr
+        str xzr, [rcontext, #tcr.valence]       /* TCR_STATE_LISP; ppc:5481  */
+        check_pending_interrupt                 /* ppc:5488                  */
+        ret                                     /* ppc:5489 blr              */
+endsp syscall
+
+/*
+ * ===========================================================================
+ * LEXPR SUBPRIMS
+ * ===========================================================================
+ */
+
+/* lexpr_entry (ppc:5362, PPC64 branch).  Nargs is valid; all arg regs +
+ * lexpr-count already vpushed by the caller's prologue; imm0 = the vsp to
+ * restore (entry-vsp).  Return all values the caller returns to ITS
+ * caller, hiding the variable-length arglist; if the caller's caller
+ * expects one value, take the simpler path.
+ *
+ * PROPOSED-CONVENTION LEXPR-RA (RATIFY): PPC compares/keeps the CALLER's
+ * return pc in loc_pc, while lr holds the return-to-prologue from the
+ * `bla' - two live return addresses.  Matt's map has no loc_pc (x24=tsp),
+ * so the lexpr function's prologue must pass the caller's return pc in
+ * temp4=x16 before `bl _SPlexpr_entry`; lr = return-to-prologue.  On the
+ * multiple-value path temp4 comes back = ret1val_addr for the prologue's
+ * save-lisp-context-lexpr to store; on the single-value path temp4 =
+ * lexpr_return1v (both as on PPC, which returns them in loc_pc). */
+spentry lexpr_entry
+        ref_global imm1, ret1val_addr           /* ppc:5363 (idiom: arm64-globals-proposed.s) */
+        cmp imm1, temp4                         /* ppc:5364 cmpr w/ loc_pc   */
+        /* FRAME-A (ppc:5365 build_lisp_frame(fn,loc_pc,imm0)): marker
+           frame; savevsp=entry-vsp, savelr=caller return pc. */
+        sub sp, sp, #lisp_frame.size
+        mov imm2, #lisp_frame_marker
+        str imm2,  [sp, #lisp_frame.marker]
+        str imm0,  [sp, #lisp_frame.savevsp]
+        str fn,    [sp, #lisp_frame.savefn]
+        str temp4, [sp, #lisp_frame.savelr]
+        b.ne 1f                                 /* ppc:5366                  */
+        /* Multiple-value case (caller's caller expects MVs).  FRAME-B
+           (ppc:5367-5368 build_lisp_frame(rzero,lexpr_return,vsp)):
+           savevsp=vsp (the count cell), savefn=0 (frame owns no fn),
+           savelr=lexpr_return. */
+        ref_global imm2, lexpr_return           /* ppc:5367 */
+        sub sp, sp, #lisp_frame.size
+        mov imm3, #lisp_frame_marker
+        str imm3, [sp, #lisp_frame.marker]
+        str vsp,  [sp, #lisp_frame.savevsp]
+        str xzr,  [sp, #lisp_frame.savefn]
+        str imm2, [sp, #lisp_frame.savelr]
+        mov temp4, imm1                         /* ppc:5369 loc_pc=ret1val   */
+        /* Control-stack limit check (ppc:5370-5371 trllt(sp,cs_limit)). */
+        ldr imm0, [rcontext, #tcr.cs_limit]
+        cmp sp, imm0
+        b.hi 2f
+        uuo_interr error_stack_overflow, sp /* ppc:5371 trllt (PROPOSED ext) */
+2:      mov fn, #0                              /* ppc:5372                  */
+        ret                                     /* ppc:5373 blr (to prologue)*/
+        /* Single-value case: return to something that pops the variable-
+           length frame off the vstack (ppc:5377-5382). */
+1:
+        ref_global temp4, lexpr_return1v        /* ppc:5378 */
+        ldr imm0, [rcontext, #tcr.cs_limit]     /* ppc:5379-5380             */
+        cmp sp, imm0
+        b.hi 3f
+        uuo_interr error_stack_overflow, sp /* ppc:5380 trllt (PROPOSED ext) */
+3:      mov fn, #0                              /* ppc:5381                  */
+        ret                                     /* ppc:5382 blr              */
+endsp lexpr_entry
+
+/* "Spread" the lexpr in arg_z (ppc:4883, PPC64 branch).  arg_z = a fixnum
+ * pointing at the lexpr block {count, argN-1 ... arg0}; the boxed count
+ * (fixnumshift=3) IS the byte length of the arg block, exactly as on
+ * PPC64 - so PPC's `add imm1,arg_z,imm0' ports verbatim.
+ * ppc2-invoke-fn assumes temp1 is preserved here.
+ * NOTE (label discipline): `9:' is deliberately defined ONCE per branch
+ * region below - GNU as numeric labels are file-scoped and a dangling
+ * `9f' binds to the NEXT `9:' anywhere in the file (the exact bug our
+ * v2 tree hit in this very subprim, s92 cont-56). */
+spentry spread_lexprz
+        ldr imm0, [arg_z, #0]                   /* ppc:4884 lexpr count      */
+        add imm1, arg_z, imm0                   /* ppc:4887                  */
+        add nargs, nargs, imm0                  /* ppc:4889                  */
+        add imm1, imm1, #node_size              /* ppc:4892 la node_size     */
+        cmp imm0, #(3<<fixnumshift)             /* ppc:4885/4893             */
+        b.ge 9f
+        cmp imm0, #(2<<fixnumshift)             /* ppc:4886/4894             */
+        b.eq 2f
+        cmp imm0, #0                            /* ppc:4888/4895             */
+        b.ne 1f
+        /* lexpr count was 0: vpop the arg regs the caller vpushed
+           (ppc:4896-4904; ldr does not disturb NZCV, so one cmp per
+           condition suffices). */
+        cmp nargs, #0                           /* ppc:4890 cr1              */
+        b.eq 4f
+        vpop1 arg_z
+        cmp nargs, #(2<<fixnumshift)            /* ppc:4891 cr2              */
+        b.lt 4f
+        vpop1 arg_y
+        b.eq 4f
+        vpop1 arg_x
+4:      ret
+
+        /* vpush args from the lexpr until only three remain, then assign
+           them to arg_x/arg_y/arg_z (ppc:4909-4919). */
+8:      cmp imm0, #(4<<fixnumshift)             /* ppc:4910 cr3              */
+        sub imm0, imm0, #fixnumone              /* ppc:4911                  */
+        ldr arg_z, [imm1, #-node_size]!         /* ppc:4912 ldru             */
+        vpush1 arg_z                            /* ppc:4913                  */
+9:      b.ne 8b                                 /* ppc:4915                  */
+        ldr arg_x, [imm1, #-(node_size*1)]      /* ppc:4916                  */
+        ldr arg_y, [imm1, #-(node_size*2)]      /* ppc:4917                  */
+        ldr arg_z, [imm1, #-(node_size*3)]      /* ppc:4918                  */
+        ret
+
+        /* count 2: set arg_y/arg_z from the lexpr, maybe vpop arg_x
+           (ppc:4923-4928). */
+2:      cmp nargs, #(2<<fixnumshift)
+        ldr arg_y, [imm1, #-(node_size*1)]
+        ldr arg_z, [imm1, #-(node_size*2)]
+        b.eq 5f                                 /* ppc:4926 beqlr cr2        */
+        vpop1 arg_x
+5:      ret
+
+        /* count 1: set arg_z from the lexpr, maybe vpop arg_y/arg_x
+           (ppc:4932-4938). */
+1:      cmp nargs, #(2<<fixnumshift)
+        ldr arg_z, [imm1, #-node_size]
+        b.lt 6f                                 /* ppc:4934 bltlr cr2        */
+        vpop1 arg_y
+        b.eq 6f                                 /* ppc:4936 beqlr cr2        */
+        vpop1 arg_x
+6:      ret
+endsp spread_lexprz
+
+/*
+ * ===========================================================================
+ * OPEN #error SITES (dedupe into upstream-port/MISSING-CONSTANTS-RATIFY.md)
+ * ---------------------------------------------------------------------------
+ *  - ARM64 lisp_globals ref idiom: ret1val_addr, lexpr_return,
+ *    lexpr_return1v (lexpr_entry x3)
+ *  - (RESOLVED 16m20) nil_value materialization from foreign state
+ *    (callback): reload rnil from the C global lisp_nil, as start_lisp does.
+ *  - stack-overflow (trllt) trap convention (lexpr_entry x2; shared with
+ *    spentry-C:1646)
+ *  - Darwin syscall protocol (guarded, Linux-only build unaffected)
+ * ===========================================================================
+ */
+
+/* ===========================================================================
+ * start_lisp: the C -> Lisp world entry (called by pmcl-kernel.c's
+ * start_lisp callers / thread startup with x0 = TCR, w1 = resetp).
+ * ported from ppc-subprims.s:73-205 (PPC64/EABI branch logic): save the
+ * C callee-saved state, establish the Lisp register world from the
+ * TCR's save_* slots, set valence, call toplevel_loop (C) -- or _SPreset
+ * when resetp -- then tear back down to the C world.
+ * ARM64-DEVIATION (mechanics): AAPCS64 callee set = x19-x28 + d8-d15 +
+ * fp/lr (PPC saved r13-r31); rnil has no PPC analog (PPC materializes
+ * nil as an immediate) and is loaded from the C global lisp_nil, which
+ * the image loader updates at mapping time (Matt 2026-07-11 mail:
+ * nil_value/t_value are patched at initial heap mapping).
+ * =========================================================================== */
+        .globl C(start_lisp)
+C(start_lisp):
+        stp     x29, x30, [sp, #-16]!   /* ppc:74 mflr/save               */
+        mov     x29, sp
+        stp     x19, x20, [sp, #-16]!   /* ppc:102-121 save nonvolatiles  */
+        stp     x21, x22, [sp, #-16]!
+        stp     x23, x24, [sp, #-16]!
+        stp     x25, x26, [sp, #-16]!
+        stp     x27, x28, [sp, #-16]!
+        stp     d8,  d9,  [sp, #-16]!   /* AAPCS64 callee-saved FP lows   */
+        stp     d10, d11, [sp, #-16]!
+        stp     d12, d13, [sp, #-16]!
+        stp     d14, d15, [sp, #-16]!
+        mov     rcontext, x0            /* ppc:126 mr rcontext,r3         */
+        mov     w9, w1                  /* stash resetp (volatile scratch;
+                                           no call before the test)       */
+        /* Zero the node registers (ppc:144-159). */
+        mov     fn, xzr
+        mov     arg_w, xzr
+        mov     arg_x, xzr
+        mov     arg_y, xzr
+        mov     arg_z, xzr
+        mov     temp0, xzr
+        mov     temp1, xzr
+        mov     temp2, xzr
+        mov     temp3, xzr
+        mov     temp4, xzr
+        mov     temp5, xzr
+        mov     save0, xzr
+        mov     save1, xzr
+        mov     save2, xzr
+        mov     save3, xzr
+        /* rnil: from the C global (image loader patches nil_value). */
+        ldr     rnil, =lisp_nil
+        ldr     rnil, [rnil]
+        /* Lisp stack/alloc state from the TCR (ppc:162-165). */
+        ldr     vsp, [rcontext, #tcr.save_vsp]
+        ldr     tsp, [rcontext, #tcr.save_tsp]
+        ldr     allocptr, [rcontext, #tcr.save_allocptr]
+        ldr     allocbase, [rcontext, #tcr.save_allocbase]
+        /* Cover the C region we are entering lisp from -- everything between
+           this SP and tcr.last_lisp_frame (= cs_area->high on a thread's first
+           entry, so glibc's TLS block and the whole C startup path) -- so the
+           GC's linear cstack walk strides over it in one step.  MUST be the
+           last thing pushed before lisp runs: the header has to sit at the
+           lowest address of the region it describes.  See the protocol note
+           above (ARM64-DEVIATION: PPC needs none, ppc-subprims.s:73). */
+        cover_foreign_stack_region imm0, imm1
+        mov     imm0, #TCR_STATE_LISP   /* ppc:166-167                    */
+        str     imm0, [rcontext, #tcr.valence]
+        cbnz    w9, 1f                  /* ppc:168 bne cr0,1f             */
+        bl      C(toplevel_loop)        /* ppc:169                        */
+        b       2f                      /* ppc:170                        */
+1:      bl      _SPreset                /* ppc:172                        */
+2:      /* Save the Lisp world back (ppc:174-179). */
+        str     allocptr, [rcontext, #tcr.save_allocptr]
+        str     allocbase, [rcontext, #tcr.save_allocbase]
+        str     tsp, [rcontext, #tcr.save_tsp]
+        str     vsp, [rcontext, #tcr.save_vsp]
+        mov     imm0, #TCR_STATE_FOREIGN
+        str     imm0, [rcontext, #tcr.valence]
+        /* Drop the C-region cover and hand the enclosing boundary back: this
+           thread is foreign again with no lisp frames of ours left. */
+        uncover_foreign_stack_region imm0, imm1
+        ldp     d14, d15, [sp], #16     /* restore nonvolatiles           */
+        ldp     d12, d13, [sp], #16
+        ldp     d10, d11, [sp], #16
+        ldp     d8,  d9,  [sp], #16
+        ldp     x27, x28, [sp], #16
+        ldp     x25, x26, [sp], #16
+        ldp     x23, x24, [sp], #16
+        ldp     x21, x22, [sp], #16
+        ldp     x19, x20, [sp], #16
+        ldp     x29, x30, [sp], #16
+        ret
+
+/* toplevel_loop: run the vpushed toplevel function under %toplevel-catch%
+ * until it leaves NIL on the vstack.  ported from ppc-subprims.s:34-64.
+ * The `b 3f' after `bl _SPmkcatch1v' is the CLEANUP ADDRESS, not control
+ * flow: mkcatch decodes it from [lr] and returns to lr+4 (spentry-C:286-294
+ * protocol, same as PPC).  Called from start_lisp with the Lisp world live. */
+        .globl C(toplevel_loop)
+C(toplevel_loop):
+        stp     x29, x30, [sp, #-16]!   /* ppc:35-40 mflr/save            */
+        mov     x29, sp
+        b       3f                      /* ppc:41 b test                  */
+1:      /* loop, ppc:42-45 */
+        ref_nrs_value arg_z, toplcatch  /* ppc:43 catch tag = %toplevel-catch% value */
+        bl      _SPmkcatch1v            /* ppc:44                         */
+        b       3f                      /* ppc:45 cleanup address word    */
+        /* catch body, ppc:47-51 */
+        set_nargs 0                     /* ppc:47                         */
+        bl      _SPfuncall              /* ppc:48 funcall temp0           */
+        mov     arg_z, rnil             /* ppc:49 li arg_z,nil_value      */
+        mov     imm0, #fixnumone        /* ppc:50                         */
+        bl      _SPnthrow1value         /* ppc:51 unwind the catch        */
+3:      /* test, ppc:52-55 */
+        ldr     temp0, [vsp]            /* ppc:53 the toplevel fn (vpushed by caller) */
+        cmp     temp0, rnil             /* ppc:54                         */
+        b.ne    1b                      /* ppc:55                         */
+        ldp     x29, x30, [sp], #16     /* ppc:56-62 restore lr, return   */
+        ret

--- a/lisp-kernel/thread_manager.c
+++ b/lisp-kernel/thread_manager.c
@@ -1551,7 +1551,7 @@ thread_init_tcr(TCR *tcr, void *stack_base, natural stack_size)
   UNLOCK(lisp_global(TCR_AREA_LOCK),tcr);
   TCR_AUX(tcr)->cs_area = a;
   a->owner = tcr;
-#ifdef ARM
+#if defined(ARM) || defined(ARM64) /* PROPOSED */
   tcr->last_lisp_frame = (natural)(a->high);
 #endif
   TCR_AUX(tcr)->cs_limit = (LispObj)ptr_to_lispobj(a->softlimit);


### PR DESCRIPTION
The other half of the Linux/arm64 port: the kernel runtime and the arm64-only
Lisp sources. #560 carries the Lisp-side *changes* to files you already have;
this carries the files you don't. **35 files, +19,983/−358, and 26 of them are
new** — so the two PRs are disjoint and can land in either order.

Based at `9c61574`, same as #560.

This is also the direct answer to "do I have access to the files needed to build
your Linux/arm64 ccl?" — with #560 and this, you do. Nothing is held back.

### The ff-call / callback design you described

We built it, and independently arrived at your invariant: **every non-scannable
cstack region is covered by a u64-vector whose element count, through
`skip_over_ivector`, lands exactly on the next boundary.** In `spentry-E-ffi.s`:

```
count  = ((OLD - sp) + node_size) >> node_shift
header = (count << num_subtag_bits) | subtag_u64_vector
```

pushed as the pair `{header, OLD}` at `sp-16`. OLD and sp are both 16-aligned by
AAPCS64, so `count*8 + 8 == OLD - (sp-16)` exactly and one
`lsl #(num_subtag_bits - node_shift)` does both shifts. Nested transitions
restore the *enclosing* boundary on the way out — without that, a
lisp→ffcall→callback→lisp→ffcall→return sequence leaves the boundary naming
popped stack and the next walk starts in dead memory.

**Where we differ, and it's the interesting part.** You publish the boundary *on
the stack*, shrinking the vector's count by 4 to expose a lisp frame whose
`savefn`/`savelr` are zeros until the frame is real. We keep the boundary in the
**tcr** — `tcr.last_lisp_frame`, which the GC reads in `normalize_tcr`'s ff-call
branch. Same guarantee, but the GC never *discovers* the boundary by walking, so
there is no ordering window: no interval where a half-built frame is visible and
no dependency on the store order of `savefn`/`savelr`. Yours keeps all the state
on the stack, which is tidier for backtrace. If you want one shape across both
ports I would rather adopt yours than maintain two — but the ordering constraint
in your third paragraph is the part I would want covered by a test that actually
GCs inside that window, because it is invisible when it is wrong.

Agreed on loading FPR args in Lisp and saving only x0-x7 for `.SPffcall`.

Not covering the C region cost us a real bug, which is the strongest argument
for the invariant: the marker walk climbed three real lisp frames, ran into the
C region above them, guessed through an x29 hop and four zero words, then read a
spilled `0.9d0` (`0x3feccccccccccccd`) as an ivector header and strode 1.8e16
words.

### The commits

1. **kernel runtime** — `spentry-{A..E}.s` (the subprimitive bodies), asmutils,
   the linuxarm64 platform header, `arm64_print.c`, and the GC/exceptions work.
   Also populates the subprimitive jump table: **130 of 132 rows**, where the tip
   ships 119 of 123 as `.quad 0`. Without it every compiler-emitted
   `ldr xN,[rcontext,#sptab+8*i]; blr xN` jumps to address 0.
2. **`level-0/ARM64/`** — 11 new LAP sources.
3. **`level-1/` + `lib/`** — callback support, error-signal, trap-support,
   threads-utils, backtrace.
4. **`linuxarm64`: make the kernel build.** The Makefile has never been run and
   is stale ARM32 inheritance: the `.s.o` rule assumes m4 where the arm64 asm
   layer is cpp (`imports.s` is the genuine m4 exception and keeps its own
   rule), `-mfloat-abi=` is not a valid aarch64 option, `-T ./armlinux.x` names
   a nonexistent linker script, `SPOBJ` needs the five new objects, `COBJ` wants
   `arm64_print.o` rather than the ARM32-tag-scheme `arm_print.o`, and `SPINC`
   still lists `arm64-constants.s`, which you removed at `f067047`. Plus
   `bits.h`, `albt.c` (`sp` is not in `regs[]` on arm64) and the `imports.s` PTR
   ladder.
5. **`thread_manager.c`** — `tcr->last_lisp_frame` was initialized under
   `#ifdef ARM`, so on arm64 it stayed 0 for the life of the thread. That is the
   boundary above. ARM32 needs it for the same reason (marker frames + linear
   walk); PPC does not, having a backlink chain.
6. **`arm64-constants.h`** — `gc.h:103` keys `is_symbol_fulltag` on
   `#ifdef fulltag_symbol`. x8664 defines it as a real macro; here it is a
   `DEFCONST`, i.e. an enum member, invisible to `#ifdef` — so arm64 silently
   compiled the `fulltag_misc` branch and the predicate matched nothing, ever.
   On a full GC, GCTWA then neither rescued worthy package-itab symbols nor
   scrubbed dead ones, and `compact_dynamic_heap` forwarded itab references to
   unmarked symbols. Heap corruption after the first full GC following heavy
   interning — in practice an in-image `compile-file`. gdb-confirmed:
   `compact_dynamic_heap -> node_forwarding_address`, `tag_n 7`.

### Two things that are your call

- **`arm64-spentry.s` renames your `misc_ref` spentry** to
  `misc_ref_upstream_sketch`. Yours is self-described as "just for playing with
  the uuos" and our `spentry-B` carries a complete body, so they collide at
  link time. Renaming yours is presumptuous — say which you want and we'll do it
  the other way round.
- **`spentry-E-ffi.s:572` keeps an `#error`** for the unported Darwin syscall
  convention (`svc #0x80` + carry-flag error protocol). It is `#ifdef DARWIN`,
  so it never fires on Linux.

### Verification, stated honestly

This branch has **not** been build-verified standalone. Our boxes build the
equivalent tree, but they get there by a script that applies these same changes
as `sed`s to a checkout, so "our build is green" is evidence about the content,
not about this branch. I am verifying the branch itself next and will report
here either way. Where the port gets to with this content plus #560: the ANSI
suite runs to completion at **21679 executed, 20 failures, no exclusions**.

Two build gotchas that will otherwise cost you an afternoon: the host CCL used
for the cross-compile must know the `aapcs64-ff-call` nx1 operator (a pristine
1.12.2 does not — a 1.13 from your `arm64` branch does), and a working install
is six parts, not two — omit `arm64-headers64/` and it dies with a bare SIGSEGV
because `CDB-OPEN` fails inside the error path.
