### PR TITLE
tools: add xlinuxarm64.lisp, the linuxarm64 cross-setup file

### DIFF
--- a/tools/xlinuxarm64.lisp
+++ b/tools/xlinuxarm64.lisp
@@ -1,0 +1,40 @@
+;;;; -*- Mode: Lisp; Package: CCL -*-
+;;;;
+;;;; SPDX-License-Identifier: Apache-2.0
+
+;;; Load the linuxarm64 backend into a host lisp, so that
+;;;
+;;;     (cross-compile-ccl :linuxarm64 t)
+;;;     (cross-xload-level-0 :linuxarm64 :force)
+;;;
+;;; work.  This is the linuxarm64 twin of tools/xarm64.lisp, which does the same
+;;; job for darwinarm64.
+;;;
+;;; Without it, both forms fail before doing any work: SETUP-ARM64-FTD is called
+;;; only from tools/xarm64.lisp, which passes *DARWINARM64-BACKEND*, so
+;;; *LINUXARM64-BACKEND* has no foreign type data and
+;;; %WITH-CROSS-COMPILATION-TARGET signals
+;;;
+;;;     No foreign type data loaded for target named :LINUXARM64
+;;;
+;;; Every module named below is already registered: ffi-linuxarm64 in
+;;; lib/systems.lisp, and (:linuxarm64 'ffi-linuxarm64) in lib/compile-ccl.lisp.
+;;; The ARM64 FTD in compiler/ARM64/arm64-backend.lisp gives its interface
+;;; package as "ARM64-LINUX".
+
+(in-package "CCL")
+
+(defpackage "ARM64-LINUX" (:use))
+
+(defun load-linuxarm64-backend ()
+  (in-development-mode
+    (load "ccl:lib;systems.lisp")
+    (load "ccl:lib;compile-ccl"))
+  (update-modules '(arm64-arch arm64-asm arm64-lap arm64-backend
+                    arm64-vinsns arm642)
+                  t)
+  (setup-arm64-ftd *linuxarm64-backend*)
+  (update-modules '(arm64-lapmacros arm64-disassemble ffi-linuxarm64) t)
+  (update-modules *arm64-xload-modules* t))
+
+(load-linuxarm64-backend)


### PR DESCRIPTION
This is the missing piece behind "no linuxarm64 build instructions" — the little
.lisp file `doc/porting/porting.md` refers to when it says "define the backend,
possibly by loading a little .lisp file which does it for you". For linuxarm64 it
did not exist, so both documented forms fail before doing any work:

```
(cross-compile-ccl :linuxarm64 t)
(cross-xload-level-0 :linuxarm64 :force)
  => No foreign type data loaded for target named :LINUXARM64
```

`setup-arm64-ftd` has exactly one caller in the tree — `tools/xarm64.lisp` — and
it passes `*darwinarm64-backend*`, so `*linuxarm64-backend*` never gets an FTD
and `%with-cross-compilation-target` signals in `lib/nfcomp.lisp`.

The file is a mechanical transliteration of `tools/xarm64.lisp`, darwin → linux.
Nothing is invented: `ffi-linuxarm64` is already registered in
`lib/systems.lisp`, `lib/compile-ccl.lisp` already maps
`(:linuxarm64 'ffi-linuxarm64)`, and the ARM64 FTD in
`compiler/ARM64/arm64-backend.lisp` already names its interface package
`"ARM64-LINUX"`.

Verified on a clean clone of `arm64` with nothing else applied: with this loaded,
both forms run.

Two things it does **not** fix, so you don't lose time on them:

- You still need an arm64 interface database at `ccl:arm64-headers;` — the
  reader hits `#$` in `level-1/linux-files.lisp` and reports
  `Foreign variable "RTLD_GLOBAL" not found`, which points nowhere useful. Ours
  is published at
  https://github.com/cyclistmass/ccl-linux-arm64/releases/download/arm64-headers-20260804/arm64-headers.tar.gz
  (81 ffigen `.ffi` files; unpacks as `arm64-headers/`). Not publishing it was
  our omission and is why you hit this first.
- The `check-type` error you saw is separate and portable — compiling
  `level-1/l1-typesys.lisp` for a 64-bit cross target breaks
  `(specifier-type '(real 0 <host-bignum>))` in the compiling image, and
  `linux-files.lisp` is just the only later file that uses such a type. Details
  and a reproducer are in the mail thread; that one still needs a real fix rather
  than this patch.