### PR TITLE
optimizers: look up REALP's target typecodes at expansion time, not read time

### DIFF
--- a/compiler/optimizers.lisp
+++ b/compiler/optimizers.lisp
@@ -2174,17 +2174,29 @@
 (define-compiler-macro realp (&whole call x)
   (if (not (eq *host-backend* *target-backend*))
     call
-    (let* ((typecode (gensym)))
+    ;; Look the target's typecodes up when this compiler macro is EXPANDED,
+    ;; not when this file is READ.  Reading them through the TARGET package
+    ;; nickname bakes whichever architecture was current at read time into the
+    ;; expansion, and DEFINE-COMPILER-MACRO takes effect at compile time: a
+    ;; cross-compilation of this file therefore reinstalls this compiler macro
+    ;; in the compiling HOST with the cross-target's subtags.  The host then
+    ;; open-codes REALP with foreign typecodes, so (TYPEP <host bignum> 'REAL)
+    ;; answers NIL and SPECIFIER-TYPE fails on any bignum-bounded REAL type.
+    ;; The other typecode-testing compiler macros here (INTEGERP, STRUCTUREP,
+    ;; LOCKP, BASE-STRING-P ...) already consult *TARGET-BACKEND* this way.
+    (let* ((typecode (gensym))
+           (arch (backend-target-arch *target-backend*))
+           (limit (- (arch::target-nbits-in-word arch)
+                     (arch::target-fixnum-shift arch)))
+           (mask (logior (ash 1 (arch::target-fixnum-tag arch))
+                         (ash 1 (nx-lookup-target-uvector-subtag :single-float))
+                         (ash 1 (nx-lookup-target-uvector-subtag :double-float))
+                         (ash 1 (nx-lookup-target-uvector-subtag :bignum))
+                         (ash 1 (nx-lookup-target-uvector-subtag :ratio)))))
       `(let* ((,typecode (typecode ,x)))
         (declare (type (unsigned-byte 8) ,typecode))
-        (and (< ,typecode (- target::nbits-in-word target::fixnumshift))
-         (logbitp (the (integer 0 (#.(- target::nbits-in-word target::fixnumshift)))
-                    ,typecode)
-                  (logior (ash 1 target::tag-fixnum)
-                          (ash 1 target::subtag-single-float)
-                          (ash 1 target::subtag-double-float)
-                          (ash 1 target::subtag-bignum)
-                          (ash 1 target::subtag-ratio))))))))
+        (and (< ,typecode ,limit)
+             (logbitp (the (integer 0 (,limit)) ,typecode) ,mask))))))
 
 (define-compiler-macro %composite-pointer-ref (size pointer offset)
   (if (constantp size)

--- a/compiler/optimizers.lisp
+++ b/compiler/optimizers.lisp
@@ -2171,32 +2171,20 @@
         t
         (= ,typecode ,bignum-tag)))))
 
-(define-compiler-macro realp (&whole call x)
-  (if (not (eq *host-backend* *target-backend*))
-    call
-    ;; Look the target's typecodes up when this compiler macro is EXPANDED,
-    ;; not when this file is READ.  Reading them through the TARGET package
-    ;; nickname bakes whichever architecture was current at read time into the
-    ;; expansion, and DEFINE-COMPILER-MACRO takes effect at compile time: a
-    ;; cross-compilation of this file therefore reinstalls this compiler macro
-    ;; in the compiling HOST with the cross-target's subtags.  The host then
-    ;; open-codes REALP with foreign typecodes, so (TYPEP <host bignum> 'REAL)
-    ;; answers NIL and SPECIFIER-TYPE fails on any bignum-bounded REAL type.
-    ;; The other typecode-testing compiler macros here (INTEGERP, STRUCTUREP,
-    ;; LOCKP, BASE-STRING-P ...) already consult *TARGET-BACKEND* this way.
-    (let* ((typecode (gensym))
-           (arch (backend-target-arch *target-backend*))
-           (limit (- (arch::target-nbits-in-word arch)
-                     (arch::target-fixnum-shift arch)))
-           (mask (logior (ash 1 (arch::target-fixnum-tag arch))
-                         (ash 1 (nx-lookup-target-uvector-subtag :single-float))
-                         (ash 1 (nx-lookup-target-uvector-subtag :double-float))
-                         (ash 1 (nx-lookup-target-uvector-subtag :bignum))
-                         (ash 1 (nx-lookup-target-uvector-subtag :ratio)))))
-      `(let* ((,typecode (typecode ,x)))
-        (declare (type (unsigned-byte 8) ,typecode))
-        (and (< ,typecode ,limit)
-             (logbitp (the (integer 0 (,limit)) ,typecode) ,mask))))))
+(define-compiler-macro realp (x)
+  (let* ((typecode (gensym))
+         (arch (backend-target-arch *target-backend*))
+         (limit (- (arch::target-nbits-in-word arch)
+                   (arch::target-fixnum-shift arch)))
+         (mask (logior (ash 1 (arch::target-fixnum-tag arch))
+                       (ash 1 (nx-lookup-target-uvector-subtag :single-float))
+                       (ash 1 (nx-lookup-target-uvector-subtag :double-float))
+                       (ash 1 (nx-lookup-target-uvector-subtag :bignum))
+                       (ash 1 (nx-lookup-target-uvector-subtag :ratio)))))
+    `(let* ((,typecode (typecode ,x)))
+       (declare (type (unsigned-byte 8) ,typecode))
+       (and (< ,typecode ,limit)
+            (logbitp (the (integer 0 (,limit)) ,typecode) ,mask)))))
 
 (define-compiler-macro %composite-pointer-ref (size pointer offset)
   (if (constantp size)


### PR DESCRIPTION
`define-compiler-macro realp` names its typecodes through the `TARGET` package
nickname **inside its backquote template**, so they are resolved when
`compiler/optimizers.lisp` is READ. `define-compiler-macro` expands to
`eval-when (:compile-toplevel …)` (`compiler/nx0.lisp:191`), and `optimizers` is in
`*compiler-modules*` (`lib/compile-ccl.lisp:40`), which `target-xcompile-ccl`
compiles before level-1.

**So cross-compiling this file reinstalls the compiling HOST's `realp` compiler
macro with the cross-target's subtags.** The host then open-codes `REALP` with
foreign typecodes, `(typep <host bignum> 'real)` answers NIL, and
`specifier-type` fails on any bignum-bounded `REAL`:

```
Bound is not *, a REAL or a list of a REAL: 9223372036854775807
```

The existing `(eq *host-backend* *target-backend*)` guard cannot help:
`%compile-time-eval` (`lib/nfcomp.lisp:307-309`) rebinds `*target-backend*` to
`*host-backend*` — correctly, the form is host code — so the guard passes and the
foreign template generates host code.

Measured rather than argued:

* the `realp` compiler-macro-function moves `#x300000A5C75F` → `#x3020023782EF`
  **exactly** at the target-compile of `optimizers` (`nxenv` and `nx` do not move
  it), and the expansion then prints `ARM64::SUBTAG-BIGNUM`;
* the reinstalled `REAL` type translator disassembles byte-identical except one
  immediate — `#x100012000018` → `#x010201000018`, i.e. typecodes
  `{0,1,22,25,41}` → `{0,1,21,30,37}`;
* the type system's *data* stays correct throughout (`info-type-builtin`,
  `specifier-type`, `type-predicate`, `%typep`, interpreted `typep`). Only freshly
  **compiled** host code is wrong, which is why `compile` inside the cross-target
  looks innocent.

The fix looks the constants up at expansion time from `*target-backend*` — the
idiom the neighbouring typecode-testing macros in this same file already use,
which is why `INTEGERP`, `STRUCTUREP`, `LOCKP` and `BASE-STRING-P` are unaffected.

Semantics-preserving for all six ports, checked per arch file rather than assumed:
every one of x8664, x8632, ppc64, ppc32, arm and arm64 maps
`:bignum/:ratio/:single-float/:double-float` in its `*…-target-uvector-subtags*` to
exactly the `subtag-*` constants the old template named, and every one passes
`:fixnum-tag tag-fixnum` and `:fixnum-shift fixnumshift`.

Latent since 2010. Only a **64-bit cross** target reaches it: 32-bit targets make
that bound a host fixnum, and x86-64 is built natively, so the sequence never
arises.

Verification, one variable, on a clean clone of `arm64` at `9084aa7c` with a host
rebuilt from it and the `check-type` forms in `level-1/linux-files.lisp` left
untouched:

```
optimizers.lisp 4db3cd2d  ->  CCC ERROR: Bound is not *, a REAL ... (dies on linux-files.lisp)
optimizers.lisp 7f8e5703  ->  CROSS-COMPILE-CCL RETURNED OK
```

Target fasls are byte-identical either way (determinism control), and our
linuxarm64 suite is unchanged: ANSI 21679/0 and `ccl.lsp` 243/0.

`compiler/optimizers.lisp` is byte-identical on `master` and `arm64` (blob
`6dcd3822`), so this one patch serves both; sent against `master` as the portable
fix it is.