### PR TITLE
arm64: the linuxarm64 boot image is arm64-boot, not arm64-boot.image

### DIFF
--- a/xdump/xarm64fasload.lisp
+++ b/xdump/xarm64fasload.lisp
@@ -157,7 +157,7 @@
    :macro-apply-code-function 'arm64-fixup-macro-apply-code
    :closure-trampoline-code *arm64-closure-trampoline-code*
    :udf-code *arm64-udf-code*
-   :default-image-name "ccl:ccl;arm64-boot.image"
+   :default-image-name "ccl:ccl;arm64-boot"
    :default-startup-file-name "level-1.la64fsl"
    :subdirs '("ccl:level-0;ARM64;")
    :compiler-target-name :linuxarm64


### PR DESCRIPTION
`REBUILD-CCL` cannot complete on linuxarm64. It recompiles everything, writes the bootstrapping image, rebuilds the kernel, and then dies reloading what it just wrote:

```
;Wrote bootstrapping image: #P".../arm64-boot.image"
;Building lisp-kernel ...
;Kernel built successfully.
> Error: Errors (:EXITED 255) reloading boot image:
>        Couldn't load lisp heap image from arm64-boot: No such file or directory
```

Two names for one file. XLOAD writes the xload backend's `DEFAULT-IMAGE-NAME`; `REBUILD-CCL` reloads the name `STANDARD-BOOT-IMAGE-NAME` returns. For `:linuxarm64` those disagree, because `*linuxarm64-xload-backend*` was line-ported from its darwinarm64 twin twenty-five lines below it and kept Darwin's suffix. My mistake, in the file I contributed.

`STANDARD-BOOT-IMAGE-NAME` is the one that is right, and every other platform agrees with it — the suffix is a Darwin/Windows convention and no Linux target uses it:

| target | `lib/compile-ccl.lisp` | `xdump/*.lisp` `DEFAULT-IMAGE-NAME` |
|---|---|---|
| `:linuxppc32` | `ppc-boot` | `ccl:ccl;ppc-boot` |
| `:linuxx8632` | `x86-boot32` | `ccl:ccl;x86-boot32` |
| `:linuxx8664` | `x86-boot64` | `ccl:ccl;x86-boot64` |
| `:linuxarm` | `arm-boot` | `ccl:ccl;arm-boot` |
| **`:linuxarm64`** | **`arm64-boot`** | **`ccl:ccl;arm64-boot.image`** ← |
| `:darwinx8664` | `x86-boot64.image` | `ccl:ccl;x86-boot64.image` |
| `:darwinarm64` | `arm64-boot.image` | `ccl:ccl;arm64-boot.image` |

Cross-compiling names the image explicitly and boots it by path, so the cross path is unaffected and its suite is green either way. Only a native `REBUILD-CCL` asks the two functions for the same file and gets different answers, which is why nothing caught it until now.

**Verified.** On a pristine clone of `arm64` plus the interface database and a host built from the stock 1.12.2 release, with #569 also applied:

* cross-built: ANSI 21679 tests / 0 failures, ccl.lsp 243 / 0
* then `echo '(rebuild-ccl :full t)' | ./arm64cl -n` runs to completion — recompiles all of CCL and the kernel, writes `arm64cl.image`
* self-built: ANSI 21679 / 0, ccl.lsp 243 / 0

Without this patch the rebuild stops at the error above and writes no image; with it, both. Same tree, same command.