### PR TITLE
arm64: tstack push must not use a writeback store with Rt == Rn

### DIFF
--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -3535,8 +3535,10 @@
 ;;; verbatim -- his kernel's tstack walker doesn't exist yet and must
 ;;; match this layout when it lands.
 (define-arm64-vinsn make-stack-cons (((dest :lisp))
-                                     ((car :lisp) (cdr :lisp)))
-  (str tsp (:@! tsp (:$ -32)))
+                                     ((car :lisp) (cdr :lisp))
+                                     ((link :u64)))
+  (mov link tsp)
+  (str link (:@! tsp (:$ -32)))
   (str xzr (:@ tsp (:$ 8)))
   (str xzr (:@ tsp (:$ 16)))
   (str xzr (:@ tsp (:$ 24)))
@@ -4137,9 +4139,10 @@
 ;;; macptr-header = his define-header (arch:709), fits movz.
 (define-arm64-vinsn macptr->stack (((dest :lisp))
                                    ((address :u64))
-                                   ((header :u64)))
+                                   ((header :u64) (link :u64)))
   (movz header (:$ arm64::macptr-header))
-  (str tsp (:@! tsp (:$ -48)))
+  (mov link tsp)
+  (str link (:@! tsp (:$ -48)))
   (str xzr (:@ tsp (:$ 8)))
   (str header (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::macptr.header))))
   (str address (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::macptr.address))))
@@ -4363,7 +4366,8 @@
 ;;;     (() ()) (ld tsp 0 tsp))
 ;;; -- pop the temp-stack frame by loading the BACKLINK, which every
 ;;; tstack frame stores at [tsp, #0] (our V3b make-stack-cons writes it
-;;; with (str tsp (:@! tsp (:$ -32))); same PPC64 stdu protocol --
+;;; with (mov link tsp) + (str link (:@! tsp (:$ -32))); same PPC64 stdu
+;;; protocol, but NOT PPC64's single stdu -- see make-stack-cons --
 ;;; RATIFY item "tstack frame shape" already queued with Matt).
 ;;; tsp = his x24 (arm64-asm.lisp:215); frames are 16-aligned so the
 ;;; offset-0 scaled LDR encodes.
@@ -4613,9 +4617,10 @@
 ;;; dest+misc-data-offset (=tsp+24) under the 8b1ed24 -12/-4 layout.
 (define-arm64-vinsn make-stack-vcell (((dest :lisp))
                                       ((closed :lisp))
-                                      ((header :u64)))
+                                      ((header :u64) (link :u64)))
   (movz header (:$ arm64::value-cell-header))
-  (str tsp (:@! tsp (:$ -32)))
+  (mov link tsp)
+  (str link (:@! tsp (:$ -32)))
   (str xzr (:@ tsp (:$ 8)))
   (str header (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::misc-header-offset))))
   (str closed (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::misc-data-offset))))

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -3538,10 +3538,16 @@
                                      ((car :lisp) (cdr :lisp))
                                      ((link :u64)))
   (mov link tsp)
-  (str link (:@! tsp (:$ -32)))
-  (str xzr (:@ tsp (:$ 8)))
+  ;; backlink AND a non-zero tsp_frame.type in one instruction, so the frame
+  ;; is born marked "raw" and no GC can scan it while the data slots still
+  ;; hold garbage.  PPC64 needs two (stdu; std tsp,8(tsp)) and covers the
+  ;; window with pc_luser_xp's MARK_TSP_FRAME_INSTRUCTION; stp closes it
+  ;; outright.  Old tsp is the value stored, and is never 0.
+  (stp link link (:@! tsp (:$ -32)))
   (str xzr (:@ tsp (:$ 16)))
   (str xzr (:@ tsp (:$ 24)))
+  ;; only now is the data valid: mark the frame as containing nodes.
+  (str xzr (:@ tsp (:$ 8)))
   (str car (:@ tsp (:$ (+ 16 arm64::fulltag-cons arm64::cons.car))))
   (str cdr (:@ tsp (:$ (+ 16 arm64::fulltag-cons arm64::cons.cdr))))
   (add dest tsp (:$ (+ 16 arm64::fulltag-cons))))
@@ -4142,8 +4148,11 @@
                                    ((header :u64) (link :u64)))
   (movz header (:$ arm64::macptr-header))
   (mov link tsp)
-  (str link (:@! tsp (:$ -48)))
-  (str xzr (:@ tsp (:$ 8)))
+  ;; backlink + non-zero tsp_frame.type atomically.  This frame stays "raw"
+  ;; for its whole life -- a macptr holds a foreign address, not a node --
+  ;; exactly as PPC64's macptr->stack does (it never stores 0 to the type
+  ;; word).  Ours used to mark it as containing nodes.
+  (stp link link (:@! tsp (:$ -48)))
   (str header (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::macptr.header))))
   (str address (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::macptr.address))))
   (str xzr (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::macptr.domain))))
@@ -4620,7 +4629,11 @@
                                       ((header :u64) (link :u64)))
   (movz header (:$ arm64::value-cell-header))
   (mov link tsp)
-  (str link (:@! tsp (:$ -32)))
+  ;; backlink + non-zero tsp_frame.type atomically; see make-stack-cons.
+  (stp link link (:@! tsp (:$ -32)))
+  (str xzr (:@ tsp (:$ 16)))
+  (str xzr (:@ tsp (:$ 24)))
+  ;; data valid: mark the frame as containing nodes.
   (str xzr (:@ tsp (:$ 8)))
   (str header (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::misc-header-offset))))
   (str closed (:@ tsp (:$ (+ 16 arm64::fulltag-misc arm64::misc-data-offset))))


### PR DESCRIPTION
This is the startup crash you hit running the linuxarm64 binaries under Linux on
Apple Silicon.

    Unhandled exception 4 at 0x300000034c9c, insn 0xf81d0f18 (neither udf nor brk)
    #<Function REFRESH-EXTERNAL-ENTRYPOINTS> <- #<Function RESTORE-LISP-POINTERS>

`0xf81d0f18` is `str x24, [x24, #-48]!` — a store with writeback whose transfer
register and base register are the same register. The ARM ARM makes that
CONSTRAINED UNPREDICTABLE (`Unpredictable_WBOVERLAPST`, C3.2.1) and UNDEFINED is
one of the permitted behaviours, so whether it executes at all is an
implementation choice. Your hardware takes the UNDEFINED option.

### How it was rooted

Not from the register dump. From the exception number: the kernel prints the
faulting word only for SIGILL or SIGTRAP (`arm64-exceptions.c:1989`), and a store
into mapped writable memory cannot raise SIGILL. So the fault had to be the
*encoding*, not the address.

GNU `as` says the same thing without any special hardware:

    wb.s:4: Warning: unpredictable transfer with writeback -- `str x24,[x24,#-48]!'

and assembles it to exactly `f81d0f18`.

### Where it came from

Three tstack-push vinsns — `make-stack-cons`, `macptr->stack`,
`make-stack-vcell` — transliterated from PPC64's

    (define-ppc64-vinsn make-stack-cons ... (stdu tsp -32 tsp))

where `stdu rX,-N(rX)` is the ordinary, well-defined stack push. AArch64 has no
equivalent single instruction: the store must name a register other than the base
it updates. The kernel `.s` files are clean; this is only in the compiler.

### The fix

`mov link, tsp` then `str link, [tsp, #-N]!`, so Rt != Rn. Same frame layout, and
the same backlink at `[tsp, #0]` that `discard-temp-frame` reads. Assembles with
no warning.

### On the GC-safety question

You raised that your two candidate fixes could leave a half-built frame visible
to an async interrupt. **This form does not have that problem.** The store and
the base update are still a single instruction, so an interrupt lands either
strictly before or strictly after the push — the GC never observes a partially
constructed tstack frame. No `pc_luser_xp` work is needed.

### Red-then-green, measured without your hardware

The check is whether the encoding is present in the built image at all:

- before: image `79a1606c` contains `f81d0f18` **× 33**
- after:  image `6488e51a` contains it **× 0**

Full builds are green on the fix: x86 cross-build `rc0=0 rc1=0 rc2=0`; on
Graviton, ANSI `21679/0` and `ccl.lsp` `243/0`, `EXIT:0`.

Worth noting for the record: this survived months of green ANSI runs on the
identical bytes, because the implementations we test on take the benign option.
A green suite says nothing about a CONSTRAINED UNPREDICTABLE encoding.
