### PR TITLE
arm64: AAPCS64 record returns, HFA/HVA classification, callbacks, stack arguments, and natural operators

### DIFF
--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -860,6 +860,11 @@
 (defconstant callback-frame.fp-save-offset -64)
 (defconstant callback-frame.savelr-offset -152)
 (defconstant callback-frame.stack-args-offset 64)
+;;; Incoming x8 (the AAPCS64 6.9 indirect result-area pointer, live when
+;;; the callback returns a >16-byte non-HFA record), captured by
+;;; _SPcallback into the padding word of its foreign-sp stash pair
+;;; (spentry-E-ffi.s `stp imm0, save2').
+(defconstant callback-frame.x8-save-offset -248)
 
 (defmacro define-header (name element-count subtag)
   `(defconstant ,name (logior (ash ,element-count num-subtag-bits) ,subtag)))

--- a/compiler/ARM64/arm64-arch.lisp
+++ b/compiler/ARM64/arm64-arch.lisp
@@ -1406,7 +1406,12 @@
                           ;; catch/throw/unwind-protect/progv cluster (w10;
                           ;; spentry-C-bind-catch-throw.s:319/326/334/1663/
                           ;; 343/440/550, spentry-B:478/1044)
-                          (defsubprim .SPnmkunwind)))))))
+                          (defsubprim .SPnmkunwind)
+                          ;; AAPCS64 6.9 indirect-result (x8) ff-call
+                          ;; variant, for >16-byte non-HFA record-by-value
+                          ;; returns (16m71 HFA lane); body in
+                          ;; spentry-E-ffi.s, sptab index 132
+                          (defsubprim .SPffcall-indirect-result)))))))
 
 ;;; The extension above rebinds the arm64::*subprims* VARIABLE, but
 ;;; ccl::subprim-name->offset resolves through the arch STRUCT's

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -300,8 +300,32 @@
 (define-arm64-vinsn (alloc-variable-c-frame) (()
                                               ((n-c-args :lisp))
                                               ((header (:u64 #.arm64::imm0))
-                                               (size :u64)
-                                               (prevsp (:imm #.arm64::imm1))))
+                                               ;; ALL THREE temps are WIRED
+                                               ;; (:u64 mode, not the :imm
+                                               ;; CLASS -- a wired temp is
+                                               ;; allocated by MODE and
+                                               ;; allocate-temporary-vreg has
+                                               ;; no :imm entry; the original
+                                               ;; (:imm imm1) type-errored the
+                                               ;; FIRST time this vinsn was
+                                               ;; ever emitted, since the old
+                                               ;; %ff-call passed a constant
+                                               ;; frame size and only
+                                               ;; ALLOC-C-FRAME was live).
+                                               ;; size is wired too because
+                                               ;; the temp allocator handed
+                                               ;; an UNWIRED size the same x1
+                                               ;; the wired prevsp claims --
+                                               ;; mov prevsp,sp then clobbered
+                                               ;; size and `sub sp,sp,size'
+                                               ;; zeroed SP (observed in a
+                                               ;; boot core, sp=0 at the stp).
+                                               ;; imm0/imm1 must keep their
+                                               ;; wiring: pc_luser_xp
+                                               ;; recognizes the stp below by
+                                               ;; its exact encoding.
+                                               (size (:u64 #.arm64::imm2))
+                                               (prevsp (:u64 #.arm64::imm1))))
   (add size n-c-args (:$ '6))        ;+ header + prevsp + 4-word frame
   (add size size (:$ (:apply 1- arm64::dnode-size))) ;round byte size up...
   (and size size (:$ (:apply - arm64::dnode-size)))  ; ...to a dnode boundary

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -6489,8 +6489,9 @@
 
 ;;; ============ set-c-arg / set-single-c-arg / set-double-c-arg ============
 ;;; argnum is a WORD index into the param area (param0 = word 0); the
-;;; handler assigns words 0-7 to GPR args, 8.. to overflow, then FP
-;;; staging.  Byte offsets are 16+8k: 8-aligned, scaled-STR encodable
+;;; handler assigns words 0-7 to GPR args, 8.. to the NSAA stack-arg
+;;; block (overflow args of BOTH register classes, in source order --
+;;; AAPCS64 has ONE next-stacked-argument address), then FP staging.  Byte offsets are 16+8k: 8-aligned, scaled-STR encodable
 ;;; through the whole u16const range.  Little-endian: singles store/
 ;;; load at offset+0 (PPC's +4 was big-endian) -- v2 donor deviation
 ;;; kept.  Register width (X/S/D form) follows the operand class, as

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -6541,6 +6541,22 @@
   (ldr temp (:@ rcontext temp))
   (blr temp))
 
+;;; ============ ff-call-return-registers ============
+;;; ff-call variant for record-by-value returns: same frame and entry
+;;; contract as ff-call, plus a regbuf macptr in arg_y into which the
+;;; subprim stores every AAPCS64 result register on return
+;;; ({x0-x7 @ 0..56, d0-d7 @ 64..120}; `spentry ffcall_return_registers',
+;;; spentry-E-ffi.s).  x86-64 pairs the same way:
+;;; (define-x8664-subprim-call-vinsn (ff-call-return-registers)
+;;; .SPffcall-return-registers), x8664-vinsns.lisp; PPC64's donor is
+;;; .SPpoweropen-ffcall-return-registers (ppc64-vinsns.lisp).
+(define-arm64-vinsn (ff-call-return-registers :call :subprim) (()
+                                                               ()
+                                                               ((temp (:u64 #.arm64::imm1))))
+  (movz temp (:$ (:apply arm64::subprimitive-offset ".SPffcall-return-registers")))
+  (ldr temp (:@ rcontext temp))
+  (blr temp))
+
 ;;; ============ eep.address ============
 ;;; PPC64 ppc64-vinsns.lisp:3829: load slot 1 (the address) of an
 ;;; external-entry-point gvector, trap if NIL (unresolved eep -- PPC's

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -6890,6 +6890,49 @@
                                       (y :u64)))
   (eor dest x y))
 
+;;; ============ natural (unboxed u64) arithmetic and shifts ============
+;;; Demand: acode-rewrite.lisp:241-246 rewrites + and - to %natural+ and
+;;; %natural- whenever BOTH operand types are subtypes of target-natural-type,
+;;; with no reader conditional -- so ordinary portable source that declares
+;;; (unsigned-byte 64) operands at speed 3 produces these operators on arm64,
+;;; and without a handler the compile fails.  natural-shift-left/right arrive
+;;; the same way for constant shift counts.  ANSI cannot reach any of it (a
+;;; declared-type open-coded path), which is why 21679/0 never saw it.
+;;;
+;;; PPC64 ppc64-vinsns.lisp:3834-3849 (%natural+ add / %natural- sub) and
+;;; :2960-2966 (natural-shift-left/right).  PPC64 expresses the shifts with
+;;; rldicr because it has no dedicated 64-bit shift-immediate;
+;;; ;;; ARM64-DEVIATION: AArch64 has lsl/lsr with an immediate (UBFM aliases),
+;;; so the rotate-and-mask encoding has no analogue and is not imitated.  The
+;;; count is :u8const on both ports, matching PPC64's assumption that nx1 has
+;;; already established a constant amount in range.
+;;;
+;;; The -c (constant-operand) variants PPC64 carries are deliberately NOT
+;;; ported: the arm64 natural family established by %natural-logand/-logior/
+;;; -logxor above has no -c forms either, and their handlers always materialise
+;;; both operands into imm registers.  Matching the neighbouring arm64
+;;; convention keeps one spelling of the family and avoids an imm12-range
+;;; question that buys only one movz.
+(define-arm64-vinsn %natural+ (((dest :u64))
+                               ((x :u64)
+                                (y :u64)))
+  (add dest x y))
+
+(define-arm64-vinsn %natural- (((dest :u64))
+                               ((x :u64)
+                                (y :u64)))
+  (sub dest x y))
+
+(define-arm64-vinsn natural-shift-left (((dest :u64))
+                                        ((src :u64)
+                                         (count :u8const)))
+  (lsl dest src (:$ count)))
+
+(define-arm64-vinsn natural-shift-right (((dest :u64))
+                                         ((src :u64)
+                                          (count :u8const)))
+  (lsr dest src (:$ count)))
+
 ;;; ============ ivector-typecode-p / gvector-typecode-p ============
 ;;; Demand (16m28, pin advance to 33e61e6): his arm642-ivector-typecode-p
 ;;; and arm642-gvector-typecode-p (arm642.lisp:6188/6195) emit them, and

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -6557,6 +6557,21 @@
   (ldr temp (:@ rcontext temp))
   (blr temp))
 
+;;; ============ ff-call-indirect-result ============
+;;; ff-call variant for >16-byte non-HFA record-by-value RETURNS: same
+;;; frame and entry contract as ff-call, plus the caller-allocated result
+;;; buffer's macptr in arg_y; the subprim loads its ADDRESS into x8 (the
+;;; AAPCS64 6.9 indirect result-area register) immediately before the
+;;; call (`spentry ffcall_indirect_result', spentry-E-ffi.s).  No other
+;;; port needs this: SysV/PowerOpen pass the hidden result pointer as the
+;;; first integer argument, AAPCS64 alone dedicates x8 to it.
+(define-arm64-vinsn (ff-call-indirect-result :call :subprim) (()
+                                                              ()
+                                                              ((temp (:u64 #.arm64::imm1))))
+  (movz temp (:$ (:apply arm64::subprimitive-offset ".SPffcall-indirect-result")))
+  (ldr temp (:@ rcontext temp))
+  (blr temp))
+
 ;;; ============ eep.address ============
 ;;; PPC64 ppc64-vinsns.lisp:3829: load slot 1 (the address) of an
 ;;; external-entry-point gvector, trap if NIL (unresolved eep -- PPC's

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -9866,3 +9866,48 @@
   (def-natural-logical arm642-%natural-logand %natural-logand logand)
   (def-natural-logical arm642-%natural-logior %natural-logior logior)
   (def-natural-logical arm642-%natural-logxor %natural-logxor logxor))
+
+;;; Natural arithmetic, the same shape as the logical ops above.  PPC64
+;;; ppc2.lisp:8711 (%natural+) and :8735 (%natural-) additionally special-case a
+;;; u15 constant operand via %natural+-c/%natural--c; that leg is omitted here
+;;; for the reason given at the vinsns -- the arm64 natural family has no -c
+;;; forms.  Constant folding is kept: PPC64 folds both-constant operands through
+;;; ppc2-natural-constant, and arm642-absolute-natural is the arm64 equivalent
+;;; already used by def-natural-logical.
+(macrolet ((def-natural-arith (handler-name op-name folder)
+             `(defarm642 ,handler-name ,op-name (seg vreg xfer x y)
+                (if (null vreg)
+                  (progn
+                    (arm642-form seg nil nil x)
+                    (arm642-form seg nil xfer y))
+                  (let* ((naturalx (nx-natural-constant-p x))
+                         (naturaly (nx-natural-constant-p y)))
+                    (if (and naturalx naturaly)
+                      (arm642-absolute-natural seg vreg xfer
+                                               (logand (,folder naturalx naturaly)
+                                                       #xffffffffffffffff))
+                      (progn
+                        (with-imm-target () (xreg :natural)
+                          (with-imm-target (xreg) (yreg :natural)
+                            (arm642-two-targeted-reg-forms seg x xreg y yreg)
+                            (! ,op-name xreg xreg yreg))
+                          (<- xreg))
+                        (^))))))))
+  (def-natural-arith arm642-%natural+ %natural+ +)
+  (def-natural-arith arm642-%natural- %natural- -))
+
+;;; Natural shifts by a CONSTANT amount.  PPC64 ppc2.lisp:8852/8859 -- the count
+;;; is read straight out of the acode with acode-fixnum-form-p, which is also how
+;;; PPC64 relies on nx1 having established a constant; a variable amount would
+;;; hand the vinsn NIL for a :u8const operand and fail at definition time on both
+;;; ports.  Mirrored rather than "improved", per the no-workarounds rule: if a
+;;; variable-count path is ever needed it belongs upstream in both backends.
+(macrolet ((def-natural-shift (handler-name op-name)
+             `(defarm642 ,handler-name ,op-name (seg vreg xfer num amt)
+                (with-imm-target () (dest :natural)
+                  (arm642-one-targeted-reg-form seg num dest)
+                  (! ,op-name dest dest (acode-fixnum-form-p amt))
+                  (<- dest)
+                  (^)))))
+  (def-natural-shift arm642-natural-shift-left natural-shift-left)
+  (def-natural-shift arm642-natural-shift-right natural-shift-right))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -9104,6 +9104,7 @@
          (nfpr-args 0)
          (ngpr-args 0)
          (return-registers nil)
+         (indirect-result nil)
          (fp-loads ()))
     (declare (fixnum nsingle-floats ndouble-floats nfpr-args ngpr-args
                      nother-words gpr-offset other-offset
@@ -9127,6 +9128,19 @@
         ;; handed to .SPffcall-return-registers in arg_y; consumes no
         ;; C argument slot (x862.lisp is the donor shape).
         (:registers (setq return-registers t))
+        ;; Indirect-result buffer (>16-byte non-HFA record returns): a
+        ;; macptr handed to .SPffcall-indirect-result in arg_y, whose
+        ;; ADDRESS the subprim loads into x8 before the call (AAPCS64
+        ;; 6.9 indirect result-area register); consumes no C slot.
+        ;; Duplicate check HERE, not only in nx1: on a cross host whose
+        ;; nx1 predates the keyword it arrives through the generic
+        ;; *arg-spec-keywords* arm (see lib/ffi-linuxarm64.lisp), which
+        ;; has no duplicate check -- and a second one would vpush a
+        ;; second buffer that the single vpop below never pops.
+        (:indirect-result
+         (when indirect-result
+           (compiler-bug "aapcs64-ff-call: duplicate :indirect-result"))
+         (setq indirect-result t))
         (t (incf ngpr-args)
            (if (> ngpr-args 8)
              (incf nother-words)))))
@@ -9166,11 +9180,11 @@
              (spec (car specs))
              (absptr (acode-absolute-ptr-p valform)))
         (case spec
-          ;; Return-registers buffer: evaluate the regbuf macptr and
-          ;; park it on the vstack; it is popped into arg_y just before
-          ;; the call (LIFO with the address pushed above).  Donor:
-          ;; x862.lisp's (:registers ...) arm.
-          (:registers
+          ;; Return-registers / indirect-result buffer: evaluate the
+          ;; macptr and park it on the vstack; it is popped into arg_y
+          ;; just before the call (LIFO with the address pushed above).
+          ;; Donor: x862.lisp's (:registers ...) arm.
+          ((:registers :indirect-result)
            (let* ((reg (arm642-one-untargeted-reg-form
                         seg valform arm64::arg_z)))
              (unless *arm642-reckless*
@@ -9250,16 +9264,18 @@
     (when (> ngpr-args 8)
       (compiler-bug "aapcs64-ff-call: more than 8 GPR args (~d) -- stack-arg ~
                      frame layout not ratified (16m5c)" ngpr-args))
-    ;; LIFO: the regbuf (if any) was pushed after the address, so it
-    ;; pops first.  .SPffcall-return-registers reads the buffer macptr
-    ;; from arg_y (spentry-E-ffi.s) and stores {x0-x7 @ 0..56,
-    ;; d0-d7 @ 64..120} into it on return.
-    (when return-registers
+    ;; LIFO: the regbuf/indirect buffer (if any) was pushed after the
+    ;; address, so it pops first.  Both subprim variants read the buffer
+    ;; macptr from arg_y (spentry-E-ffi.s): .SPffcall-return-registers
+    ;; stores {x0-x7 @ 0..56, d0-d7 @ 64..120} into it on return;
+    ;; .SPffcall-indirect-result loads its address into x8 before the
+    ;; call (AAPCS64 6.9).
+    (when (or return-registers indirect-result)
       (arm642-vpop-register seg ($ arm64::arg_y)))
     (arm642-vpop-register seg ($ arm64::arg_z))
-    (if return-registers
-      (! ff-call-return-registers)
-      (! ff-call))
+    (cond (return-registers (! ff-call-return-registers))
+          (indirect-result (! ff-call-indirect-result))
+          (t (! ff-call)))
     ;; .SPffcall popped the c-frame at runtime; restore the static
     ;; accounting NOW, not via the let*-shadow.  The shadow only
     ;; unwinds after this handler returns -- but (^) below emits the

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -9103,6 +9103,7 @@
          (nother-words 0)
          (nfpr-args 0)
          (ngpr-args 0)
+         (return-registers nil)
          (fp-loads ()))
     (declare (fixnum nsingle-floats ndouble-floats nfpr-args ngpr-args
                      nother-words gpr-offset other-offset
@@ -9122,6 +9123,10 @@
            ;; stop until the AAPCS64 packing is ratified (header note).
            (compiler-bug "aapcs64-ff-call: more than 8 floating-point ~
                           args (~s) not yet supported" argspecs)))
+        ;; Return-registers buffer (record-by-value returns): a macptr
+        ;; handed to .SPffcall-return-registers in arg_y; consumes no
+        ;; C argument slot (x862.lisp is the donor shape).
+        (:registers (setq return-registers t))
         (t (incf ngpr-args)
            (if (> ngpr-args 8)
              (incf nother-words)))))
@@ -9161,6 +9166,16 @@
              (spec (car specs))
              (absptr (acode-absolute-ptr-p valform)))
         (case spec
+          ;; Return-registers buffer: evaluate the regbuf macptr and
+          ;; park it on the vstack; it is popped into arg_y just before
+          ;; the call (LIFO with the address pushed above).  Donor:
+          ;; x862.lisp's (:registers ...) arm.
+          (:registers
+           (let* ((reg (arm642-one-untargeted-reg-form
+                        seg valform arm64::arg_z)))
+             (unless *arm642-reckless*
+               (! trap-unless-macptr reg))
+             (arm642-vpush-register seg reg)))
           ;; FPR regspecs are raw FPR numbers under :class :fpr (his
           ;; arm642-immediate idiom); no dN name constants in his arch.
           ;; Staging register d1 mirrors the v2 donor's fp1 choice.
@@ -9235,8 +9250,16 @@
     (when (> ngpr-args 8)
       (compiler-bug "aapcs64-ff-call: more than 8 GPR args (~d) -- stack-arg ~
                      frame layout not ratified (16m5c)" ngpr-args))
+    ;; LIFO: the regbuf (if any) was pushed after the address, so it
+    ;; pops first.  .SPffcall-return-registers reads the buffer macptr
+    ;; from arg_y (spentry-E-ffi.s) and stores {x0-x7 @ 0..56,
+    ;; d0-d7 @ 64..120} into it on return.
+    (when return-registers
+      (arm642-vpop-register seg ($ arm64::arg_y)))
     (arm642-vpop-register seg ($ arm64::arg_z))
-    (! ff-call)
+    (if return-registers
+      (! ff-call-return-registers)
+      (! ff-call))
     ;; .SPffcall popped the c-frame at runtime; restore the static
     ;; accounting NOW, not via the let*-shadow.  The shadow only
     ;; unwinds after this handler returns -- but (^) below emits the

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -9071,16 +9071,31 @@
 ;;;   [header]                     u64-vector header (frame base = SP)
 ;;;   [prevsp]                     element 0 (saved previous SP)
 ;;;   [GP save: 8 words, X0..X7]   <- .SPffcall loads all 8 unconditionally
-;;;   [FP save: 8 words, D0..D7]   <- p2 reloads V0..V(nfpr-1) inline
-;;;   [stack args: M words]        <- SP points here at the blr; arg0 lowest
-;;;   [reserved lisp frame: 4]     tcr.last_lisp_frame; above the call-time SP
+;;;   [stack args: M words]        <- the AAPCS64 NSAA area; SP points here
+;;;                                   at the blr (frame base + 80).  One
+;;;                                   8-byte slot per overflow arg of EITHER
+;;;                                   class, assigned in SOURCE ORDER (one
+;;;                                   NSAA, 5.4.2 stage C -- integer and FP
+;;;                                   overflow interleave; C.5 widens a
+;;;                                   single-float to a full slot, value in
+;;;                                   the low 4 bytes).  Arg 9 lowest.
+;;;   [FP staging: variable]       <- singles, then even-word-aligned
+;;;                                   doubles; p2 reloads d0..d(n-1) from
+;;;                                   here just before the call.  A private
+;;;                                   scratch area the callee never sees;
+;;;                                   it sits ABOVE the stack args.
+;;;   [reserved lisp frame: 4]     the boundary lisp_frame, directly below
+;;;                                   the saved previous SP
 ;;;
-;;; The arg area (GP save, FP save, stack args) begins at SP+dnode-size
-;;; (after header+prevsp); set-aapcs64-c-arg indexes it in words from there.
-;;; The GP and FP save areas are a fixed 8 words each, so every region has a
-;;; constant offset and .SPffcall is branch-free.  A value stored into an
-;;; unused save slot is harmless: the callee reads only the registers its
-;;; prototype names, and the p2 never reloads unused FP slots.
+;;; The arg area (GP save, stack args, FP staging) begins at SP+dnode-size
+;;; (after header+prevsp); set-c-arg and friends index it in 8-byte words
+;;; from there.  The GP save area is a fixed 8 words and the NSAA block
+;;; starts at arg-area word 8 = frame byte 80 = c_frame.size + 8*node_size,
+;;; which is exactly the constant .SPffcall steps SP by at the blr, so
+;;; .SPffcall stays branch-free.  A value stored into an unused save slot
+;;; is harmless: the callee reads only the registers its prototype names
+;;; and the stack slots its prototype implies, and the p2 never reloads
+;;; unused FP slots.
 ;;;
 ;;; .SPffcall must be FP-clean between entry and the blr, so the FP args the
 ;;; p2 loaded into V0..V(nfpr-1) survive the stack switch.
@@ -9120,10 +9135,15 @@
            (if (eq argspec :double-float)
              (incf ndouble-floats)
              (incf nsingle-floats))
-           ;; Overflow FP: v2's legs carry PPC32-EABI slotting; loud
-           ;; stop until the AAPCS64 packing is ratified (header note).
-           (compiler-bug "aapcs64-ff-call: more than 8 floating-point ~
-                          args (~s) not yet supported" argspecs)))
+           ;; AAPCS64 5.4.2 stage C: once v0-v7 are exhausted (C.1
+           ;; fails), an FP arg is copied to the stack at the NSAA --
+           ;; the SAME next-stacked-argument address integer overflow
+           ;; uses, advancing in source order; C.5 widens half/single
+           ;; precision to one full 8-byte slot.  ONE NSAA, not a
+           ;; per-class block, so this shares nother-words with the
+           ;; integer arm below, and pass 2 reproduces the identical
+           ;; decision (same counter, same threshold, same order).
+           (incf nother-words)))
         ;; Return-registers buffer (record-by-value returns): a macptr
         ;; handed to .SPffcall-return-registers in arg_y; consumes no
         ;; C argument slot (x862.lisp is the donor shape).
@@ -9193,20 +9213,42 @@
           ;; FPR regspecs are raw FPR numbers under :class :fpr (his
           ;; arm642-immediate idiom); no dN name constants in his arch.
           ;; Staging register d1 mirrors the v2 donor's fp1 choice.
+          ;;
+          ;; FP args 1-8 go to staging slots and are reloaded into d0-d7
+          ;; after the last form (arbitrary lisp code in a later form
+          ;; would clobber them).  FP args 9+ go straight into their NSAA
+          ;; stack slot NOW: the callee reads them from MEMORY, so there
+          ;; is no register load to defer, and the shared other-offset
+          ;; counter is what interleaves them with overflowing integer
+          ;; args in source order (AAPCS64 5.4.2: one NSAA for both
+          ;; classes -- pass 1 counted these same slots into
+          ;; nother-words).
           (:double-float
            (let* ((df ($ 1 :class :fpr :mode :double-float)))
              (incf nfpr-args)
              (arm642-one-targeted-reg-form seg valform df)
-             (! set-double-c-arg df double-float-offset)
-             (push (cons :double-float double-float-offset) fp-loads)
-             (incf double-float-offset 2)))
+             (cond ((<= nfpr-args 8)
+                    (! set-double-c-arg df double-float-offset)
+                    (push (cons :double-float double-float-offset) fp-loads)
+                    (incf double-float-offset 2))
+                   (t
+                    (! set-double-c-arg df other-offset)
+                    (incf other-offset)))))
           (:single-float
            (let* ((sf ($ 1 :class :fpr :mode :single-float)))
              (incf nfpr-args)
              (arm642-one-targeted-reg-form seg valform sf)
-             (! set-single-c-arg sf single-float-offset)
-             (push (cons :single-float single-float-offset) fp-loads)
-             (incf single-float-offset)))
+             (cond ((<= nfpr-args 8)
+                    (! set-single-c-arg sf single-float-offset)
+                    (push (cons :single-float single-float-offset) fp-loads)
+                    (incf single-float-offset))
+                   (t
+                    ;; C.5: a stacked single occupies a full 8-byte
+                    ;; slot with the value in its low 4 bytes; a
+                    ;; little-endian 32-bit str at the slot base does
+                    ;; exactly that.
+                    (! set-single-c-arg sf other-offset)
+                    (incf other-offset)))))
           ;; 64-bit integer: full value in imm0 via gets64/getu64
           ;; (w10), ONE GPR slot (v2 s86 AAPCS64 deviation kept).
           ((:signed-doubleword :unsigned-doubleword)
@@ -9257,13 +9299,11 @@
         (if (eq size :double-float)
           (! reload-double-c-arg ($ fpreg :class :fpr :mode :double-float) from)
           (! reload-single-c-arg ($ fpreg :class :fpr :mode :single-float) from))))
-    ;; No stack args reach the callee: _SPffcall keeps SP at the frame
-    ;; head during the call (16m5c -- popping freed the saved lr/backlink
-    ;; under the callee).  Args 9+ would sit in never-read stack slots,
-    ;; so refuse loudly until the stack-arg frame layout is ratified.
-    (when (> ngpr-args 8)
-      (compiler-bug "aapcs64-ff-call: more than 8 GPR args (~d) -- stack-arg ~
-                     frame layout not ratified (16m5c)" ngpr-args))
+    ;; Args 9+ of either class are already sitting in the NSAA block
+    ;; (arg-area words 8..): .SPffcall steps SP over header+prevsp+params
+    ;; at the blr, so the callee finds them AT [SP], per AAPCS64.  The
+    ;; 16m5c "not ratified" refusal that lived here is gone; the SP step
+    ;; in the three ffcall spentries is the kernel half of that change.
     ;; LIFO: the regbuf/indirect buffer (if any) was pushed after the
     ;; address, so it pops first.  Both subprim variants read the buffer
     ;; macptr from arg_y (spentry-E-ffi.s): .SPffcall-return-registers

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -9161,6 +9161,12 @@
          (when indirect-result
            (compiler-bug "aapcs64-ff-call: duplicate :indirect-result"))
          (setq indirect-result t))
+        ;; One raw 8-byte NSAA word -- one slot of a C.13 memory copy of
+        ;; a composite the ABI sends WHOLLY to the stack (emitted by
+        ;; expand-ff-call, which also burns the corresponding register
+        ;; class per C.3/C.11).  Always a stack slot; consumes no
+        ;; register of either class.
+        (:stack-doubleword (incf nother-words))
         (t (incf ngpr-args)
            (if (> ngpr-args 8)
              (incf nother-words)))))
@@ -9263,6 +9269,15 @@
                  (t
                   (! set-c-arg ($ arm64::imm0) other-offset)
                   (incf other-offset))))
+          ;; Raw NSAA word (C.13 whole-composite stack copy; see the
+          ;; pass-1 arm and expand-ff-call).  Same u64 value path as
+          ;; :unsigned-doubleword, but the slot is unconditionally a
+          ;; stack slot and no register-class counter moves.
+          (:stack-doubleword
+           (arm642-one-targeted-reg-form seg valform ($ arm64::arg_z))
+           (! getu64)
+           (! set-c-arg ($ arm64::imm0) other-offset)
+           (incf other-offset))
           (:address
            (with-imm-target () (ptr :address)
              (if absptr

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -9743,6 +9743,54 @@
              (! %current-frame-ptr target)))
          (^))))
 
+;;; The C stack IS the control stack, so the "foreign stack pointer" is
+;;; SP — after WITH-VARIABLE-C-FRAME allocates, this is the new c-frame's
+;;; base, which is how the frame variable gets bound (nx1.lisp binds it
+;;; to (%foreign-stack-pointer) as the body's first act).  PPC
+;;; (ppc2.lisp ppc2-%foreign-stack-pointer) and ARM32 (arm2.lisp) define
+;;; this identically for their unified stacks; x86-64 reads
+;;; tcr.foreign-sp instead (separate foreign stack).
+(defarm642 arm642-%foreign-stack-pointer %foreign-stack-pointer (seg vreg xfer)
+  (when vreg
+    (ensuring-node-target (target vreg)
+      (! %current-frame-ptr target)))
+  (^))
+
+;;; WITH-VARIABLE-C-FRAME: allocate a c-frame of SIZE param words around
+;;; BODY.  Model: x862-with-variable-c-frame (x862.lisp); the
+;;; interpreter-side %ff-call (arm64-def.lisp) is the only in-tree
+;;; linuxarm64 user.  The undo machinery already knew how to pop it —
+;;; $undo-arm64-c-frame => (! discard-c-frame) in the nlexit walker
+;;; below (previously dead: nothing opened that undo) — and the pop is
+;;; DYNAMIC (sp <- the frame's savedsp word at [sp,#8]), which is
+;;; correct both while the frame is live and after .SPffcall
+;;; (SUBPRIM-POPS) has replaced it with %%ff-result's fixed rebalance
+;;; frame.  All exits reach it: opening the undo bumps the same counter
+;;; arm642-unwind-stack treats as the catch diff, so normal falls into
+;;; arm642-nlexit, and arm642-do-return drains open undos the same way.
+;;;
+;;; ARM64-DEVIATION (vinsn choice, not operator semantics): a
+;;; compile-time-constant SIZE uses the constant alloc-c-frame vinsn,
+;;; whose single pre-indexed stp is ATOMIC w.r.t. suspension.  The
+;;; runtime-size alloc-variable-c-frame vinsn has a sub-sp/stp window
+;;; that pc_luser_xp does not finish yet (the vinsn pins header/prevsp
+;;; to imm0/imm1 for that recognizer; arm64-exceptions.c never grew the
+;;; case).  %ff-call always passes a constant; the runtime-size path has
+;;; no linuxarm64 caller today (objc-bridge is Darwin-only).  RATIFY:
+;;; implement the pc_luser_xp case before a runtime-size caller lands.
+(defarm642 arm642-with-variable-c-frame with-variable-c-frame (seg vreg xfer size body &aux
+                                                                   (old-stack (arm642-encode-stack)))
+  (let* ((fix (acode-fixnum-form-p size)))
+    (if (and fix
+             (typep fix 'fixnum)
+             (>= fix 0)
+             (<= (arm642-c-frame-words fix) 63)) ;stp scaled-imm7 reach
+      (! alloc-c-frame fix)
+      (let* ((reg (arm642-one-untargeted-reg-form seg size arm64::arg_z)))
+        (! alloc-variable-c-frame reg))))
+  (arm642-open-undo $undo-arm64-c-frame)
+  (arm642-undo-body seg vreg xfer body old-stack))
+
 (defun arm642-swap-unsigned-cond-bit (cr-bit)
   (cond ((eql cr-bit arm64::cond-hi) arm64::cond-lo)
         ((eql cr-bit arm64::cond-lo) arm64::cond-hi)

--- a/compiler/nx1.lisp
+++ b/compiler/nx1.lisp
@@ -1432,9 +1432,14 @@
           (progn 
             (push arg-keyword specs)
             (push value vals))
-          (if (eq arg-keyword :registers)
+          (if (memq arg-keyword '(:registers :indirect-result))
+            ;; :registers names a result-register capture buffer (the
+            ;; x8664/darwinppc64 regbuf protocol); :indirect-result names
+            ;; the AAPCS64 (arm64) indirect result-area pointer, loaded
+            ;; into x8 at the call.  Both describe THE record result, so
+            ;; at most one of either may appear.
             (if register-spec-seen
-              (error "duplicate :registers in ~s" arg-specs-and-result-spec)
+              (error "duplicate ~s in ~s" arg-keyword arg-specs-and-result-spec)
               (progn
                 (setq register-spec-seen t)
                 (push arg-keyword specs)

--- a/level-0/ARM64/arm64-def.lisp
+++ b/level-0/ARM64/arm64-def.lisp
@@ -148,6 +148,283 @@
 
 ;;; =====================================================================
 
+;;; =====================================================================
+;;; FF-call family — ppc:941-1119 (the #+ppc64-target block)
+;;; =====================================================================
+;;; The COMPILED %ff-call is a special form (nx1.lisp nx1-ff-call ->
+;;; arm642-aapcs64-ff-call), so compiled EXTERNAL-CALL never needs a
+;;; function binding.  The INTERPRETER (cheap-eval-in-environment)
+;;; funcalls the symbol, so every port also defines %FF-CALL as an
+;;; ordinary function: ppc-def.lisp:1011, x86-def.lisp:635,
+;;; arm-def.lisp:335.  Without these three, any toplevel
+;;; (external-call ...) dies with "Undefined function %FF-CALL" while
+;;; the same form works inside a compiled defun.
+
+;;; %%ff-result — ppc:954
+;;; Boxes a C result left in imm0(x0) or d0 (AAPCS64; PPC fp1 -> d0) AND
+;;; rebalances the control stack: %FF-CALL allocates its c-frame with
+;;; WITH-VARIABLE-C-FRAME, whose exit pops the frame DYNAMICALLY
+;;; (discard-c-frame: sp <- [sp,#8]), but .SPffcall already popped it
+;;; (SUBPRIM-POPS; `spentry ffcall', arm64-spentry.s).  The 16-byte frame
+;;; pushed here is what that exit pops instead (ppc:955 stdu -160).  Its
+;;; shape MUST be the alloc-c-frame contract {u64-vector header @0,
+;;; saved sp @8}: discard-c-frame reads the saved sp at +8, and the
+;;; @address/@double-float arms below can GC at uuo-alloc-trap, whose
+;;; linear cstack walk strides by the header at +0.  (This settles the
+;;; draft's W4-D12 question: a real header IS required; the draft's
+;;; {savedsp@0} scratch shape would have fed a stack address to the
+;;; walker as a frame header.)  The push is one pre-indexed stp, atomic
+;;; w.r.t. suspension.  Must NOT be called multiple-value-returning
+;;; (imm0 would be clobbered) — the caller wraps it in (values ...),
+;;; exactly as on PPC (ppc:943-953 comment).
+(defarm64lapfunction %%ff-result ((spec arg_z))
+  ;; ppc:955 (stdu sp -160 sp) — the rebalance frame, pushed atomically.
+  (mov imm2 sp)
+  (mov imm1 (:$ (logior (ash 1 arm64::num-subtag-bits) arm64::subtag-u64-vector)))
+  (stp imm1 imm2 (:@! sp (:$ -16)))
+  ;; ppc:956-973: six pool-constant compares held on cr0-cr5 ->
+  ;; sequential cmp/b.eq pairs (single NZCV), plus six sub-word specs
+  ;; (ARM64-DEVIATION below).  Pool-ref idiom as in arm64-clos.lisp.
+  (ldur arg_y (:@ nfn (:$ ':void)))           ; ppc:956
+  (cmp spec arg_y)                      ; ppc:957
+  (b.eq @void)                          ; ppc:968
+  (ldur arg_x (:@ nfn (:$ ':address)))        ; ppc:958
+  (cmp spec arg_x)                      ; ppc:959
+  (b.eq @address)                       ; ppc:969
+  (ldur temp3 (:@ nfn (:$ ':single-float)))   ; ppc:960
+  (cmp spec temp3)                      ; ppc:961
+  (b.eq @single-float)                  ; ppc:970
+  (ldur arg_y (:@ nfn (:$ ':double-float)))   ; ppc:962
+  (cmp spec arg_y)                      ; ppc:963
+  (b.eq @double-float)                  ; ppc:971
+  (ldur arg_x (:@ nfn (:$ ':unsigned-doubleword))) ; ppc:964
+  (cmp spec arg_x)                      ; ppc:965
+  (b.eq @unsigned-doubleword)           ; ppc:972
+  (ldur temp3 (:@ nfn (:$ ':signed-doubleword))) ; ppc:966
+  (cmp spec temp3)                      ; ppc:967
+  (b.eq @signed-doubleword)             ; ppc:973
+  ;; ARM64-DEVIATION (vs ppc:974's bare box-fixnum default): AAPCS64
+  ;; leaves x0's bits above the result width UNSPECIFIED (PowerOpen
+  ;; returns fullword results extended to 64 bits), so each sub-word
+  ;; spec extends explicitly before boxing — the same
+  ;; :s8/:u8/:s16/:u16/:s32/:u32 modes the compiled path applies in
+  ;; arm642-aapcs64-ff-call's result dispatch (arm642.lisp).
+  (ldur arg_y (:@ nfn (:$ ':signed-fullword)))
+  (cmp spec arg_y)
+  (b.eq @signed-fullword)
+  (ldur arg_x (:@ nfn (:$ ':unsigned-fullword)))
+  (cmp spec arg_x)
+  (b.eq @unsigned-fullword)
+  (ldur temp3 (:@ nfn (:$ ':signed-halfword)))
+  (cmp spec temp3)
+  (b.eq @signed-halfword)
+  (ldur arg_y (:@ nfn (:$ ':unsigned-halfword)))
+  (cmp spec arg_y)
+  (b.eq @unsigned-halfword)
+  (ldur arg_x (:@ nfn (:$ ':signed-byte)))
+  (cmp spec arg_x)
+  (b.eq @signed-byte)
+  (ldur temp3 (:@ nfn (:$ ':unsigned-byte)))
+  (cmp spec temp3)
+  (b.eq @unsigned-byte)
+  (box-fixnum arg_z imm0)               ; ppc:974
+  (ret)                                 ; ppc:975
+  @void
+  (mov arg_z rnil)                      ; ppc:977
+  (ret)                                 ; ppc:978
+  @address
+  ;; ppc:980-987: cons a macptr around imm0.  Canonical Misc_Alloc_Fixed
+  ;; shape (arm64-macros.s:65-74): b.hi over the trap, header stored at
+  ;; misc-header-offset off the TAGGED allocptr, then untag — as in the
+  ;; live consers (arm64-numbers.lisp:126-133).
+  (sub allocptr allocptr (:$ (- arm64::macptr.size arm64::fulltag-misc))) ; ppc:981
+  (cmp allocptr allocbase)              ; ppc:982 (tdlt allocptr allocbase)
+  (b.hi @macptr-ok)
+  (uuo-alloc-trap)
+  @macptr-ok
+  (mov imm1 (:$ arm64::macptr-header))  ; ppc:980 (li) — movz-able
+  (stur imm1 (:@ allocptr (:$ arm64::misc-header-offset))) ; ppc:983
+  (mov arg_z allocptr)                  ; ppc:984
+  ;; ppc:985 (clrrdi allocptr 4) — untag; ~fulltagmask via ldb wrap
+  (and allocptr allocptr (:$ (ldb (byte 64 0) (lognot arm64::fulltagmask))))
+  (stur imm0 (:@ arg_z (:$ arm64::macptr.address))) ; ppc:986
+  (ret)                                 ; ppc:987
+  @single-float
+  ;; ppc:988-990 (put-single-float fp1 arg_z): singles are IMMEDIATE
+  ;; (bits [63:32] | tag); AAPCS64 float result register = s0 (PPC fp1).
+  (put-single-float s0 arg_z)           ; ppc:989
+  (ret)                                 ; ppc:990
+  @double-float
+  ;; ppc:991-999: cons a double-float around d0.
+  (sub allocptr allocptr (:$ (- arm64::double-float.size arm64::fulltag-misc))) ; ppc:993
+  (cmp allocptr allocbase)              ; ppc:994
+  (b.hi @dfloat-ok)
+  (uuo-alloc-trap)
+  @dfloat-ok
+  (mov imm1 (:$ arm64::double-float-header)) ; ppc:992
+  (stur imm1 (:@ allocptr (:$ arm64::misc-header-offset))) ; ppc:995
+  (mov arg_z allocptr)                  ; ppc:996
+  (and allocptr allocptr (:$ (ldb (byte 64 0) (lognot arm64::fulltagmask)))) ; ppc:997
+  (put-double-float d0 arg_z)           ; ppc:998 (stfd fp1 ...)
+  (ret)                                 ; ppc:999
+  @unsigned-doubleword
+  ;; ppc:1001 (ba .SPmakeu64) — TAIL: lr must stay our caller's.
+  (jump-subprim .SPmakeu64)
+  @signed-doubleword
+  (jump-subprim .SPmakes64)             ; ppc:1003 (ba)
+  ;; ARM64-DEVIATION: sub-word extensions, lsl/asr and logical-immediate
+  ;; masks (all three masks are encodable bitmask immediates).
+  @signed-fullword
+  (lsl imm0 imm0 (:$ 32))
+  (asr imm0 imm0 (:$ 32))
+  (box-fixnum arg_z imm0)
+  (ret)
+  @unsigned-fullword
+  (and imm0 imm0 (:$ #xffffffff))
+  (box-fixnum arg_z imm0)
+  (ret)
+  @signed-halfword
+  (lsl imm0 imm0 (:$ 48))
+  (asr imm0 imm0 (:$ 48))
+  (box-fixnum arg_z imm0)
+  (ret)
+  @unsigned-halfword
+  (and imm0 imm0 (:$ #xffff))
+  (box-fixnum arg_z imm0)
+  (ret)
+  @signed-byte
+  (lsl imm0 imm0 (:$ 56))
+  (asr imm0 imm0 (:$ 56))
+  (box-fixnum arg_z imm0)
+  (ret)
+  @unsigned-byte
+  (and imm0 imm0 (:$ #xff))
+  (box-fixnum arg_z imm0)
+  (ret))
+
+;;; %do-ff-call — ppc:1006 ("just here so that we can jump to a subprim
+;;; from lisp").  regbuf nil => plain ffcall; else regbuf is a MACPTR to
+;;; the result-register buffer {x0-x7 @0..56, d0-d7 @64..120} that
+;;; `spentry ffcall_return_registers' (spentry-E-ffi.s) reads from arg_y.
+;;; BOTH exits are TAIL JUMPS (ppc ba/bnea — NO link): lr still holds our
+;;; caller's return address, which .SPffcall parks in the boundary lisp
+;;; frame; a linked call would clobber it.
+(defarm64lapfunction %do-ff-call ((regbuf arg_y) (entry arg_z))
+  (cmp regbuf rnil)                     ; ppc:1007 (cmpdi regbuf nil)
+  (b.eq @plain)
+  (jump-subprim .SPffcall-return-registers) ; ppc:1008 (bnea)
+  @plain
+  (jump-subprim .SPffcall))             ; ppc:1009 (ba)
+
+;;; %ff-call defun — ppc:1011-1119, re-shaped for AAPCS64 the way the
+;;; compiled path is (arm642-aapcs64-ff-call): integer/address args go
+;;; to the c-frame's 8 GPR param words (`spentry ffcall' loads x0-x7
+;;; from c-frame.param0 unconditionally), FP args go to a separate
+;;; 8-slot block loaded into d0-d7 by %load-fp-arg-regs (W4-D13(b),
+;;; arm64-float.lisp) immediately before %do-ff-call — .SPffcall is
+;;; FP-clean between entry and the blr.  x86-64's defun
+;;; (x86-def.lisp:635) is the closest analog (separate GPR/FPR
+;;; sequences); PPC64's PowerOpen defun reserves a param word per FP
+;;; arg, which AAPCS64 does not.
+;;; ARM64-DEVIATION: .SPffcall carries no stack args yet (refused loud
+;;; in the w13 codegen until the stack-arg frame layout is ratified,
+;;; arm642.lisp), so >8 GPR-class or >8 FP-class args error here the
+;;; same way the compiled path does.
+;;; A :single-float arg is stored at its fp slot's BASE: %load-fp-arg-regs
+;;; does 64-bit loads, and on little-endian the float bits land in the
+;;; d-register's low half, which is exactly s<n> — the callee reads only
+;;; that (same reasoning as the callback generator's LE deviation,
+;;; lib/ffi-linuxarm64.lisp).
+(defun %ff-call (entry &rest specs-and-vals)
+  (declare (dynamic-extent specs-and-vals))
+  (let* ((len (length specs-and-vals))
+         (regbuf nil))
+    (declare (fixnum len))
+    (let* ((result-spec (or (car (last specs-and-vals)) :void))
+           (nargs (ash (the fixnum (1- len)) -1))
+           (n-gpr-words 0)
+           (n-fp-args 0))
+      (declare (fixnum nargs n-gpr-words n-fp-args))
+      (ecase result-spec
+        ((:address :unsigned-doubleword :signed-doubleword
+                   :single-float :double-float
+                   :signed-fullword :unsigned-fullword
+                   :signed-halfword :unsigned-halfword
+                   :signed-byte :unsigned-byte
+                   :void)
+         (do* ((i 0 (1+ i))
+               (specs specs-and-vals (cddr specs))
+               (spec (car specs) (car specs)))
+              ((= i nargs))
+           (declare (fixnum i))
+           (case spec
+             (:registers nil)
+             ((:double-float :single-float)
+              (incf n-fp-args))
+             ((:address :unsigned-doubleword :signed-doubleword
+                        :signed-fullword :unsigned-fullword
+                        :signed-halfword :unsigned-halfword
+                        :signed-byte :unsigned-byte)
+              (incf n-gpr-words))
+             (t (if (typep spec 'unsigned-byte)
+                  (incf n-gpr-words spec)
+                  (error "unknown arg spec ~s" spec)))))
+         (when (> n-gpr-words 8)
+           (error "~d integer/address argument words in foreign call; ~
+                   .SPffcall passes at most 8 (no stack args yet)"
+                  n-gpr-words))
+         (when (> n-fp-args 8)
+           (error "~d floating-point arguments in foreign call; ~
+                   .SPffcall passes at most 8 (d0-d7, no stack args yet)"
+                  n-fp-args))
+         (%stack-block ((fp-args (* 8 8)))
+           (with-macptrs ((argptr))
+             (with-variable-c-frame
+                 8 frame
+                 (%setf-macptr-to-object argptr frame)
+                 (let* ((gpr-offset arm64::c-frame.param0)
+                        (fp-offset 0))
+                   (declare (fixnum gpr-offset fp-offset))
+                   (do* ((i 0 (1+ i))
+                         (specs specs-and-vals (cddr specs))
+                         (spec (car specs) (car specs))
+                         (val (cadr specs) (cadr specs)))
+                        ((= i nargs))
+                     (declare (fixnum i))
+                     (case spec
+                       (:registers (setq regbuf val))
+                       (:address
+                        (setf (%get-ptr argptr gpr-offset) val)
+                        (incf gpr-offset 8))
+                       ((:signed-doubleword :signed-fullword
+                                            :signed-halfword :signed-byte)
+                        (setf (%%get-signed-longlong argptr gpr-offset) val)
+                        (incf gpr-offset 8))
+                       ((:unsigned-doubleword :unsigned-fullword
+                                              :unsigned-halfword :unsigned-byte)
+                        (setf (%%get-unsigned-longlong argptr gpr-offset) val)
+                        (incf gpr-offset 8))
+                       (:double-float
+                        (setf (%get-double-float fp-args fp-offset) val)
+                        (incf fp-offset 8))
+                       (:single-float
+                        (setf (%get-single-float fp-args fp-offset) val)
+                        (incf fp-offset 8))
+                       (t
+                        ;; struct by value: spec = word count (<= 2 from
+                        ;; expand-ff-call), val = pointer to the bytes.
+                        (let* ((p 0))
+                          (declare (fixnum p))
+                          (dotimes (k (the fixnum spec))
+                            (setf (%get-ptr argptr gpr-offset) (%get-ptr val p))
+                            (incf p 8)
+                            (incf gpr-offset 8))))))
+                   (%load-fp-arg-regs n-fp-args fp-args)
+                   (%do-ff-call regbuf entry)
+                   (values (%%ff-result result-spec)))))))))))
+
+;;; =====================================================================
+
 (defarm64lapfunction %get-object ((macptr arg_y) (offset arg_z))
   (check-nargs 2)                       ; ppc:1127
   (trap-unless-typecode= arg_y arm64::subtag-macptr) ; ppc:1128 (W4-D16 brk)

--- a/level-0/ARM64/arm64-def.lisp
+++ b/level-0/ARM64/arm64-def.lisp
@@ -316,6 +316,15 @@
   @plain
   (jump-subprim .SPffcall))             ; ppc:1009 (ba)
 
+;;; Sibling of %do-ff-call for the AAPCS64 indirect-result case (>16-byte
+;;; non-HFA record-by-value returns): BUF is a MACPTR to the caller-
+;;; allocated result area; `spentry ffcall_indirect_result'
+;;; (spentry-E-ffi.s) reads it from arg_y and loads its address into x8
+;;; (the 6.9 indirect result-area register) just before the call.  TAIL
+;;; JUMP (no link), same reasoning as %do-ff-call above.
+(defarm64lapfunction %do-ff-call-indirect ((buf arg_y) (entry arg_z))
+  (jump-subprim .SPffcall-indirect-result))
+
 ;;; %ff-call defun — ppc:1011-1119, re-shaped for AAPCS64 the way the
 ;;; compiled path is (arm642-aapcs64-ff-call): integer/address args go
 ;;; to the c-frame's 8 GPR param words (`spentry ffcall' loads x0-x7
@@ -338,7 +347,8 @@
 (defun %ff-call (entry &rest specs-and-vals)
   (declare (dynamic-extent specs-and-vals))
   (let* ((len (length specs-and-vals))
-         (regbuf nil))
+         (regbuf nil)
+         (indirect-buf nil))
     (declare (fixnum len))
     (let* ((result-spec (or (car (last specs-and-vals)) :void))
            (nargs (ash (the fixnum (1- len)) -1))
@@ -358,7 +368,7 @@
               ((= i nargs))
            (declare (fixnum i))
            (case spec
-             (:registers nil)
+             ((:registers :indirect-result) nil)
              ((:double-float :single-float)
               (incf n-fp-args))
              ((:address :unsigned-doubleword :signed-doubleword
@@ -393,6 +403,7 @@
                      (declare (fixnum i))
                      (case spec
                        (:registers (setq regbuf val))
+                       (:indirect-result (setq indirect-buf val))
                        (:address
                         (setf (%get-ptr argptr gpr-offset) val)
                         (incf gpr-offset 8))
@@ -420,7 +431,9 @@
                             (incf p 8)
                             (incf gpr-offset 8))))))
                    (%load-fp-arg-regs n-fp-args fp-args)
-                   (%do-ff-call regbuf entry)
+                   (if indirect-buf
+                     (%do-ff-call-indirect indirect-buf entry)
+                     (%do-ff-call regbuf entry))
                    (values (%%ff-result result-spec)))))))))))
 
 ;;; =====================================================================

--- a/level-0/ARM64/arm64-def.lisp
+++ b/level-0/ARM64/arm64-def.lisp
@@ -335,10 +335,13 @@
 ;;; (x86-def.lisp:635) is the closest analog (separate GPR/FPR
 ;;; sequences); PPC64's PowerOpen defun reserves a param word per FP
 ;;; arg, which AAPCS64 does not.
-;;; ARM64-DEVIATION: .SPffcall carries no stack args yet (refused loud
-;;; in the w13 codegen until the stack-arg frame layout is ratified,
-;;; arm642.lisp), so >8 GPR-class or >8 FP-class args error here the
-;;; same way the compiled path does.
+;;; ARM64-DEVIATION: the COMPILED path now passes stack args (the NSAA
+;;; block at c-frame words 8.., exposed at [SP] by the SP step in the
+;;; ffcall spentries), but THIS interpreted defun still marshals only
+;;; the 8 GPR words and 8 FP regs -- extending it needs the interleaved
+;;; source-order NSAA bookkeeping and a variable frame size here, a
+;;; separate change -- so >8 of either class still errors below, now as
+;;; this defun's own limitation.
 ;;; A :single-float arg is stored at its fp slot's BASE: %load-fp-arg-regs
 ;;; does 64-bit loads, and on little-endian the float bits land in the
 ;;; d-register's low half, which is exactly s<n> — the callee reads only
@@ -381,11 +384,15 @@
                   (error "unknown arg spec ~s" spec)))))
          (when (> n-gpr-words 8)
            (error "~d integer/address argument words in foreign call; ~
-                   .SPffcall passes at most 8 (no stack args yet)"
+                   the interpreted %FF-CALL marshals at most 8 (the ~
+                   compiled ff-call path passes stack args; this defun ~
+                   does not yet)"
                   n-gpr-words))
          (when (> n-fp-args 8)
-           (error "~d floating-point arguments in foreign call; ~
-                   .SPffcall passes at most 8 (d0-d7, no stack args yet)"
+           (error "~d floating-point arguments in foreign call; the ~
+                   interpreted %FF-CALL marshals at most 8 (d0-d7; the ~
+                   compiled ff-call path passes stack args, this defun ~
+                   does not yet)"
                   n-fp-args))
          (%stack-block ((fp-args (* 8 8)))
            (with-macptrs ((argptr))

--- a/level-0/ARM64/arm64-def.lisp
+++ b/level-0/ARM64/arm64-def.lisp
@@ -335,13 +335,17 @@
 ;;; (x86-def.lisp:635) is the closest analog (separate GPR/FPR
 ;;; sequences); PPC64's PowerOpen defun reserves a param word per FP
 ;;; arg, which AAPCS64 does not.
-;;; ARM64-DEVIATION: the COMPILED path now passes stack args (the NSAA
-;;; block at c-frame words 8.., exposed at [SP] by the SP step in the
-;;; ffcall spentries), but THIS interpreted defun still marshals only
-;;; the 8 GPR words and 8 FP regs -- extending it needs the interleaved
-;;; source-order NSAA bookkeeping and a variable frame size here, a
-;;; separate change -- so >8 of either class still errors below, now as
-;;; this defun's own limitation.
+;;; Stack (NSAA) arguments: both register classes overflow into the
+;;; c-frame's param words 8.. (one shared counter, source order --
+;;; AAPCS64 5.4.2 has ONE next-stacked-argument address), which the
+;;; ffcall spentries expose AT [SP] for the callee.  The x86-64 defun
+;;; is the line donor here too: its shared other-offset past the 6 GPR
+;;; words (x86-def.lisp:635-745) is the same shape.  A word-count spec
+;;; (by-value composite payload) follows C.10/C.11: consecutive GPRs
+;;; when ALL its words fit, otherwise NGRN := 8 (the odd register is
+;;; wasted -- never a register/stack split) and the words go to the
+;;; stack.  :stack-doubleword (see lib/ffi-linuxarm64.lisp) is a raw
+;;; always-stacked word of a C.13 whole-composite copy.
 ;;; A :single-float arg is stored at its fp slot's BASE: %load-fp-arg-regs
 ;;; does 64-bit loads, and on little-endian the float bits land in the
 ;;; d-register's low half, which is exactly s<n> — the callee reads only
@@ -356,8 +360,9 @@
     (let* ((result-spec (or (car (last specs-and-vals)) :void))
            (nargs (ash (the fixnum (1- len)) -1))
            (n-gpr-words 0)
-           (n-fp-args 0))
-      (declare (fixnum nargs n-gpr-words n-fp-args))
+           (n-fp-args 0)
+           (n-stack-words 0))
+      (declare (fixnum nargs n-gpr-words n-fp-args n-stack-words))
       (ecase result-spec
         ((:address :unsigned-doubleword :signed-doubleword
                    :single-float :double-float
@@ -373,35 +378,38 @@
            (case spec
              ((:registers :indirect-result) nil)
              ((:double-float :single-float)
-              (incf n-fp-args))
+              (incf n-fp-args)
+              (when (> n-fp-args 8) (incf n-stack-words)))
              ((:address :unsigned-doubleword :signed-doubleword
                         :signed-fullword :unsigned-fullword
                         :signed-halfword :unsigned-halfword
                         :signed-byte :unsigned-byte)
-              (incf n-gpr-words))
+              (incf n-gpr-words)
+              (when (> n-gpr-words 8) (incf n-stack-words)))
+             (:stack-doubleword (incf n-stack-words))
              (t (if (typep spec 'unsigned-byte)
-                  (incf n-gpr-words spec)
+                  ;; by-value composite payload of SPEC words: C.10 when
+                  ;; they ALL fit the remaining GPRs, else C.11 -- NGRN
+                  ;; := 8 (odd register wasted, never split) and every
+                  ;; word stacks.  Mirrored EXACTLY in the marshal loop.
+                  (if (<= (+ n-gpr-words spec) 8)
+                    (incf n-gpr-words spec)
+                    (progn
+                      (setq n-gpr-words 8)
+                      (incf n-stack-words spec)))
                   (error "unknown arg spec ~s" spec)))))
-         (when (> n-gpr-words 8)
-           (error "~d integer/address argument words in foreign call; ~
-                   the interpreted %FF-CALL marshals at most 8 (the ~
-                   compiled ff-call path passes stack args; this defun ~
-                   does not yet)"
-                  n-gpr-words))
-         (when (> n-fp-args 8)
-           (error "~d floating-point arguments in foreign call; the ~
-                   interpreted %FF-CALL marshals at most 8 (d0-d7; the ~
-                   compiled ff-call path passes stack args, this defun ~
-                   does not yet)"
-                  n-fp-args))
          (%stack-block ((fp-args (* 8 8)))
            (with-macptrs ((argptr))
              (with-variable-c-frame
-                 8 frame
+                 (the fixnum (+ 8 n-stack-words)) frame
                  (%setf-macptr-to-object argptr frame)
                  (let* ((gpr-offset arm64::c-frame.param0)
-                        (fp-offset 0))
-                   (declare (fixnum gpr-offset fp-offset))
+                        (stack-offset (+ arm64::c-frame.param0 (* 8 8)))
+                        (fp-offset 0)
+                        (ngpr 0)
+                        (nfpr 0))
+                   (declare (fixnum gpr-offset stack-offset fp-offset
+                                    ngpr nfpr))
                    (do* ((i 0 (1+ i))
                          (specs specs-and-vals (cddr specs))
                          (spec (car specs) (car specs))
@@ -412,32 +420,76 @@
                        (:registers (setq regbuf val))
                        (:indirect-result (setq indirect-buf val))
                        (:address
-                        (setf (%get-ptr argptr gpr-offset) val)
-                        (incf gpr-offset 8))
+                        (incf ngpr)
+                        (cond ((<= ngpr 8)
+                               (setf (%get-ptr argptr gpr-offset) val)
+                               (incf gpr-offset 8))
+                              (t
+                               (setf (%get-ptr argptr stack-offset) val)
+                               (incf stack-offset 8))))
                        ((:signed-doubleword :signed-fullword
                                             :signed-halfword :signed-byte)
-                        (setf (%%get-signed-longlong argptr gpr-offset) val)
-                        (incf gpr-offset 8))
+                        (incf ngpr)
+                        (cond ((<= ngpr 8)
+                               (setf (%%get-signed-longlong argptr gpr-offset) val)
+                               (incf gpr-offset 8))
+                              (t
+                               (setf (%%get-signed-longlong argptr stack-offset) val)
+                               (incf stack-offset 8))))
                        ((:unsigned-doubleword :unsigned-fullword
                                               :unsigned-halfword :unsigned-byte)
-                        (setf (%%get-unsigned-longlong argptr gpr-offset) val)
-                        (incf gpr-offset 8))
+                        (incf ngpr)
+                        (cond ((<= ngpr 8)
+                               (setf (%%get-unsigned-longlong argptr gpr-offset) val)
+                               (incf gpr-offset 8))
+                              (t
+                               (setf (%%get-unsigned-longlong argptr stack-offset) val)
+                               (incf stack-offset 8))))
                        (:double-float
-                        (setf (%get-double-float fp-args fp-offset) val)
-                        (incf fp-offset 8))
+                        (incf nfpr)
+                        (cond ((<= nfpr 8)
+                               (setf (%get-double-float fp-args fp-offset) val)
+                               (incf fp-offset 8))
+                              (t
+                               (setf (%get-double-float argptr stack-offset) val)
+                               (incf stack-offset 8))))
                        (:single-float
-                        (setf (%get-single-float fp-args fp-offset) val)
-                        (incf fp-offset 8))
+                        (incf nfpr)
+                        (cond ((<= nfpr 8)
+                               (setf (%get-single-float fp-args fp-offset) val)
+                               (incf fp-offset 8))
+                              (t
+                               ;; C.5: a stacked single takes a full
+                               ;; 8-byte slot, value in the low 4 bytes
+                               ;; (LE store at the slot base).
+                               (setf (%get-single-float argptr stack-offset) val)
+                               (incf stack-offset 8))))
+                       (:stack-doubleword
+                        ;; raw always-stacked word (C.13 composite copy)
+                        (setf (%%get-unsigned-longlong argptr stack-offset) val)
+                        (incf stack-offset 8))
                        (t
                         ;; struct by value: spec = word count (<= 2 from
                         ;; expand-ff-call), val = pointer to the bytes.
+                        ;; C.10/C.11 -- all words in GPRs or all on the
+                        ;; stack, never split; mirrors the count pass.
                         (let* ((p 0))
                           (declare (fixnum p))
-                          (dotimes (k (the fixnum spec))
-                            (setf (%get-ptr argptr gpr-offset) (%get-ptr val p))
-                            (incf p 8)
-                            (incf gpr-offset 8))))))
-                   (%load-fp-arg-regs n-fp-args fp-args)
+                          (cond ((<= (+ ngpr (the fixnum spec)) 8)
+                                 (incf ngpr (the fixnum spec))
+                                 (dotimes (k (the fixnum spec))
+                                   (setf (%get-ptr argptr gpr-offset)
+                                         (%get-ptr val p))
+                                   (incf p 8)
+                                   (incf gpr-offset 8)))
+                                (t
+                                 (setq ngpr 8)
+                                 (dotimes (k (the fixnum spec))
+                                   (setf (%get-ptr argptr stack-offset)
+                                         (%get-ptr val p))
+                                   (incf p 8)
+                                   (incf stack-offset 8))))))))
+                   (%load-fp-arg-regs (min n-fp-args 8) fp-args)
                    (if indirect-buf
                      (%do-ff-call-indirect indirect-buf entry)
                      (%do-ff-call regbuf entry))

--- a/level-1/arm64-callback-support.lisp
+++ b/level-1/arm64-callback-support.lisp
@@ -15,11 +15,14 @@
 ;;; jump; neither encoding exists on AArch64, hence the x16 literal jump.
 ;;;
 ;;; Trampoline layout (32 bytes, entered by FOREIGN code under AAPCS64;
-;;; x8 (indirect-result reg, caller-saved for our purposes — _SPcallback
-;;; consumes it immediately) and x16 (IP0 scratch) are safe to clobber):
+;;; x10 and x16 (IP0) are caller-saved scratch, safe to clobber.  x8 is
+;;; NOT: AAPCS64 6.9 delivers the indirect result-area pointer there
+;;; when the callback returns a >16-byte non-HFA record, and _SPcallback
+;;; captures it into the callback frame -- the index lived in x8 until
+;;; 16m71 and silently destroyed that pointer):
 ;;;
-;;;    0: movz x8, #lo16(index)         ; unboxed callback index
-;;;    4: movk x8, #hi16(index), lsl 16
+;;;    0: movz x10, #lo16(index)        ; unboxed callback index
+;;;    4: movk x10, #hi16(index), lsl 16
 ;;;    8: ldr  x16, .+16                ; load _SPcallback address
 ;;;   12: br   x16                      ;   from the literal at +24
 ;;;   16: nop                           ; pad literal to 8-byte alignment
@@ -27,7 +30,7 @@
 ;;;   24: .quad <_SPcallback kernel address>
 ;;;
 ;;; MATCHED PAIR: _SPcallback (upstream-port/lisp-kernel/spentry-E-ffi.s)
-;;; reads the index from arg_w = x8 (`mov save0, arg_w`).  Change this
+;;; reads the index from arg_y = x10 (`mov save0, arg_y`).  Change this
 ;;; generator and that entry together.
 
 (in-package "CCL")
@@ -37,10 +40,10 @@
   (let* ((p (%allocate-callback-pointer 32))
          (addr (%lookup-subprim-address
                 #.(arm64::subprimitive-offset ".SPcallback"))))
-    (setf (%get-unsigned-long p 0)          ; movz x8,#lo16(index)
-          (logior #xd2800008 (ash (ldb (byte 16 0) index) 5))
-          (%get-unsigned-long p 4)          ; movk x8,#hi16(index),lsl #16
-          (logior #xf2a00008 (ash (ldb (byte 16 16) index) 5))
+    (setf (%get-unsigned-long p 0)          ; movz x10,#lo16(index)
+          (logior #xd280000a (ash (ldb (byte 16 0) index) 5))
+          (%get-unsigned-long p 4)          ; movk x10,#hi16(index),lsl #16
+          (logior #xf2a0000a (ash (ldb (byte 16 16) index) 5))
           (%get-unsigned-long p 8)  #x58000090   ; ldr x16,.+16
           (%get-unsigned-long p 12) #xd61f0200   ; br x16
           (%get-unsigned-long p 16) #xd503201f   ; nop

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -343,6 +343,26 @@
                   (argforms arg-type-spec)
                   (argforms arg-value-form))
                 (let* ((ftype (parse-foreign-type arg-type-spec)))
+                  ;; GCC transparent_union: the argument is passed with
+                  ;; the calling convention of the union's FIRST MEMBER,
+                  ;; never as the composite itself (GCC manual, Common
+                  ;; Type Attributes; GCC enforces that all members have
+                  ;; the same machine representation, which is what makes
+                  ;; first-member resolution ABI-sound).  Same arm as
+                  ;; x8664::expand-ff-call (x8664-backend.lisp) and
+                  ;; x8632.  Without it a glibc-style union of pointers
+                  ;; (e.g. __SOCKADDR_ARG) falls into the <=64-bit
+                  ;; composite case below, which DEREFERENCES the macptr
+                  ;; and passes 8 bytes of the pointee where the callee
+                  ;; expects the pointer.
+                  (when (and (typep ftype 'foreign-record-type)
+                             (eq (foreign-record-type-kind ftype)
+                                 :transparent-union))
+                    (ensure-foreign-type-bits ftype)
+                    (setq ftype (foreign-record-field-type
+                                 (car (foreign-record-type-fields ftype)))
+                          arg-type-spec (foreign-type-to-representation-type
+                                         ftype)))
                   (if (typep ftype 'foreign-record-type)
                     (let* ((bits (ensure-foreign-type-bits ftype)))
                       (multiple-value-bind (hfa-base hfa-count)

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -34,23 +34,35 @@
 ;;;   - SP       : stack pointer (16-byte aligned at public boundaries)
 ;;;
 ;;; Composite (struct) argument rules (AAPCS64 §6.8):
-;;;   - HFAs/HVAs of 1-4 fundamental SIMD&FP elements: passed in V0..V7
-;;;     (not yet detected here; conservatively treated as general composite).
-;;;   - Composite size <= 16 bytes (128 bits): passed in GPRs (split across
-;;;     X0..X7 as 1-2 doublewords, left-justified — NOT right-justified
+;;;   - HFA/HVA (homogeneous aggregate of 1-4 members with the same
+;;;     fundamental SIMD&FP type; B.3 exempts these from the >16-byte
+;;;     copy): one V register per member when NSRN + members <= 8 (C.2);
+;;;     otherwise the WHOLE aggregate goes to the stack (C.3/C.4) —
+;;;     never to GPRs, never by reference.  Detected by hfa-type-info
+;;;     below and passed by decomposing into scalar member argforms
+;;;     (the darwinppc64 model, lib/ffi-darwinppc64.lisp); the C.3
+;;;     stack case is refused loudly, exactly as >8 scalar FP args are
+;;;     (no stack args until the stack-arg frame layout is ratified).
+;;;   - Composite size <= 16 bytes (128 bits), not HFA: passed in GPRs
+;;;     (X0..X7 as 1-2 doublewords, left-justified — NOT right-justified
 ;;;     like PowerOpen).
-;;;   - Composite size > 16 bytes: passed by reference to a caller-allocated
-;;;     copy (single :address slot pointing to the copy).
+;;;   - Composite size > 16 bytes, not HFA: passed by reference to a
+;;;     caller-allocated copy (single :address slot pointing to the copy).
 ;;;
 ;;; Composite return rules (AAPCS64 §6.9):
-;;;   - Size <= 16 bytes (and not HFA): returned in X0/X1.
-;;;   - Size > 16 bytes (or HFA): caller allocates buffer, passes pointer
-;;;     in X8; function writes through X8 and returns void.
-;;;
-;;; HFA detection is a TODO; we conservatively use the size threshold only.
-;;; This is slightly pessimistic for HFA-eligible aggregates (which AAPCS64
-;;; allows in V-registers regardless of total size up to 4 elements) but is
-;;; never incorrect — pessimistic-but-correct over optimistic-but-wrong.
+;;;   - HFA/HVA (1-4 members, any size): returned in V0..V3, one register
+;;;     per member.  Captured via :registers/.SPffcall-return-registers
+;;;     (regbuf {x0-x7 @ 0..56, d0-d7 @ 64..120}, spentry-E-ffi.s) and
+;;;     copied out by struct-from-regbuf-values below — the same protocol
+;;;     x86-64 uses (x8664-backend.lisp) and PPC64-Darwin pioneered
+;;;     (.SPpoweropen-ffcall-return-registers).
+;;;   - Size <= 16 bytes, not HFA: returned in X0/X1; captured via the
+;;;     same regbuf, copied from the GPR half.
+;;;   - Size > 16 bytes, not HFA: caller allocates buffer, passes pointer
+;;;     in X8; function writes through X8 and returns void.  KNOWN GAP:
+;;;     the c-frame/.SPffcall protocol has no X8 slot yet, so the buffer
+;;;     pointer currently lands in X0 (unchanged pre-existing behavior;
+;;;     see comms/HFA-DETECTION-16m71.md §10).
 
 (in-package "CCL")
 
@@ -67,6 +79,75 @@
 
 
 ;;;-----------------------------------------------------------------------
+;;; (0) HFA/HVA classification — AAPCS64 §4.3.5 "Homogeneous Aggregates"
+;;;-----------------------------------------------------------------------
+;;; A Homogeneous Floating-point Aggregate is a composite type where all
+;;; fundamental data members have the same floating-point type and there
+;;; are AT MOST FOUR uniquely addressable members (§4.3.5.1-2).  Members
+;;; may be scalars, arrays of members, or nested homogeneous records
+;;; (SBCL's arm64 c-call.lisp hfa-member-info implements the same
+;;; flattening).  For a union the member count is the MAX over its
+;;; alternatives, not the sum (each alternative aliases the same
+;;; storage; GCC aarch64_vfp_is_call_or_return_candidate does the same).
+;;;
+;;; The base types recognized are :single-float and :double-float — the
+;;; only fundamental SIMD&FP types CCL's foreign-type system models.
+;;; Half- and quad-precision floats and short vector types (the HVA
+;;; case) have no CCL foreign-type representation, so aggregates of
+;;; them cannot be expressed and need no arm here.
+;;;
+;;; The top-level size cross-check (bits = count * member-bits) rejects
+;;; aggregates whose layout is not densely packed (e.g. over-aligned
+;;; types via aligned attributes): GCC applies the same size test, and
+;;; such a type is passed as a general composite, not an HFA.
+
+(defun arm64-linux::hfa-element-info (ftype)
+  ;; Flatten one potential HFA member.  Returns (values base count)
+  ;; with base in {:single-float :double-float}, or NIL if the type
+  ;; cannot be part of an HFA.
+  (typecase ftype
+    (foreign-single-float-type (values :single-float 1))
+    (foreign-double-float-type (values :double-float 1))
+    (foreign-array-type
+     (let* ((dims (foreign-array-type-dimensions ftype)))
+       (when (and dims (every #'(lambda (d) (typep d 'unsigned-byte)) dims))
+         (let* ((n (reduce #'* dims)))
+           (when (> n 0)
+             (multiple-value-bind (base count)
+                 (arm64-linux::hfa-element-info
+                  (foreign-array-type-element-type ftype))
+               (when base
+                 (values base (* n count)))))))))
+    (foreign-record-type
+     (let* ((base nil)
+            (count 0)
+            (union-p (eq (foreign-record-type-kind ftype) :union)))
+       (dolist (field (foreign-record-type-fields ftype)
+                      (when base (values base count)))
+         (multiple-value-bind (fbase fcount)
+             (arm64-linux::hfa-element-info (foreign-record-field-type field))
+           (when (or (null fbase)
+                     (and base (not (eq base fbase))))
+             (return nil))
+           (setq base fbase)
+           (if union-p
+             (setq count (max count fcount))
+             (incf count fcount))))))
+    (t nil)))
+
+(defun arm64-linux::hfa-type-info (ftype)
+  ;; If FTYPE is an HFA, return (values base count); else NIL.
+  (when (typep ftype 'foreign-record-type)
+    (let* ((bits (ensure-foreign-type-bits ftype)))
+      (multiple-value-bind (base count)
+          (arm64-linux::hfa-element-info ftype)
+        (when (and base
+                   (<= 1 count 4)
+                   (= bits (* count (if (eq base :single-float) 32 64))))
+          (values base count))))))
+
+
+;;;-----------------------------------------------------------------------
 ;;; (1) record-type-returns-structure-as-first-arg
 ;;;-----------------------------------------------------------------------
 ;;; PPC64 source (lines 28-36): always returns T for foreign-record-type
@@ -74,8 +155,9 @@
 ;;;  pointer in the first argument").
 ;;;
 ;;; ARM64-DEVIATION: AAPCS64 §6.9 returns composites <= 16 bytes (128
-;;; bits) in X0/X1 directly; only larger composites use the X8 indirect
-;;; result-area pointer.  We encode the size threshold explicitly.
+;;; bits) in X0/X1 directly, and HFAs/HVAs of 1-4 members in V0..V3
+;;; REGARDLESS of size; only other composites use the X8 indirect
+;;; result-area pointer.
 
 (defun arm64-linux::record-type-returns-structure-as-first-arg (rtype)
   (when (and rtype
@@ -88,8 +170,11 @@
       (when (typep ftype 'foreign-record-type)
         (ensure-foreign-type-bits ftype)
         ;;; ARM64-DEVIATION: > 128 bits (16 bytes) triggers X8 indirect
-        ;;; return per AAPCS64 §6.9.  PPC64 source returns T unconditionally.
-        (> (foreign-type-bits ftype) 128)))))
+        ;;; return per AAPCS64 §6.9 — unless the type is an HFA/HVA,
+        ;;; which is returned in v0..v3 whatever its size.  PPC64 source
+        ;;; returns T unconditionally.
+        (and (> (foreign-type-bits ftype) 128)
+             (not (arm64-linux::hfa-type-info ftype)))))))
 
 
 ;;;-----------------------------------------------------------------------
@@ -114,16 +199,58 @@
 ;;;
 ;;; The result-side foreign-record-type handling (lines 48-52 in PPC64
 ;;; source) — "implicit first arg = result-form, return-type becomes
-;;; :void" — applies identically to AAPCS64 ONLY when the struct is
-;;; > 128 bits (size threshold from record-type-returns-structure-as-first-arg
-;;; above).  For smaller structs, AAPCS64 returns them in X0/X1 and the
-;;; coercion machinery handles the unpack — but expand-ff-call's contract
-;;; with the higher-level macro is shaped by what
-;;; record-type-returns-structure-as-first-arg said, so this code path
-;;; is only entered for > 128-bit return values (consistent).
+;;; :void" — applies to AAPCS64 ONLY when the struct is > 128 bits AND
+;;; not an HFA (the record-type-returns-structure-as-first-arg answer).
+;;; HFAs (returned in v0..v3) and <= 128-bit composites (returned in
+;;; x0/x1) are captured with the :registers regbuf protocol instead:
+;;; .SPffcall-return-registers saves {x0-x7 @ 0..56, d0-d7 @ 64..120}
+;;; into the buffer, and struct-from-regbuf-values copies the right
+;;; slots into the caller's result structure.  Model:
+;;; x8664::expand-ff-call (x8664-backend.lisp) and PPC64-Darwin's
+;;; darwin64::struct-from-regbuf-values (lib/ffi-darwinppc64.lisp).
+
+;;; Generate code to set the fields of a structure R of record type
+;;; RTYPE from the register values captured in REGBUF by
+;;; .SPffcall-return-registers ({x0..x7 @ 0..56, d0..d7 @ 64..120},
+;;; spentry-E-ffi.s).
+(defun arm64-linux::struct-from-regbuf-values (r rtype regbuf)
+  (let* ((bits (ensure-foreign-type-bits rtype))
+         (fp-area 64))                  ;d0 save slot; d<i> at 64 + 8i
+    (multiple-value-bind (hfa-base hfa-count)
+        (arm64-linux::hfa-type-info rtype)
+      (collect ((forms))
+        (cond
+          ;; HFA: member i came back in v<i> (AAPCS64 §6.9).  Each
+          ;; d-save slot holds the full 64-bit register; on
+          ;; little-endian the single-float payload sits at the slot
+          ;; base (same LE reasoning as the callback generator below).
+          ((eq hfa-base :double-float)
+           (dotimes (i hfa-count)
+             (forms `(setf (%get-double-float ,r ,(* 8 i))
+                      (%get-double-float ,regbuf ,(+ fp-area (* 8 i)))))))
+          ((eq hfa-base :single-float)
+           (dotimes (i hfa-count)
+             (forms `(setf (%get-single-float ,r ,(* 4 i))
+                      (%get-single-float ,regbuf ,(+ fp-area (* 8 i)))))))
+          ;; Non-HFA <= 16 bytes: returned in x0/x1 (§6.9 via C.12);
+          ;; copy 32 bits at a time to avoid consing (the darwinppc64/
+          ;; x8664 struct-from-regbuf-values idiom).
+          (t
+           (do* ((b 0 (+ b 32))
+                 (w 0 (+ w 4)))
+                ((>= b bits))
+             (declare (fixnum b w))
+             (forms `(setf (%get-unsigned-long ,r ,w)
+                      (%get-unsigned-long ,regbuf ,w))))))
+        `(progn ,@(forms))))))
 
 (defun arm64-linux::expand-ff-call (callform args &key (arg-coerce #'null-coerce-foreign-arg) (result-coerce #'null-coerce-foreign-result))
-  (let* ((result-type-spec (or (car (last args)) :void)))
+  (let* ((result-type-spec (or (car (last args)) :void))
+         (regbuf nil)
+         (result-temp nil)
+         (result-form nil)
+         (struct-result-type nil)
+         (structure-arg-temp nil))
     (multiple-value-bind (result-type error)
         (ignore-errors (parse-foreign-type result-type-spec))
       (if error
@@ -133,56 +260,129 @@
         (when (eq (car args) :monitor-exception-ports)
           (argforms (pop args)))
         (when (typep result-type 'foreign-record-type)
-          ;;; Reached only for > 128-bit returns (per AAPCS64 §6.9, gated
-          ;;; by arm64-linux::record-type-returns-structure-as-first-arg).
-          ;;; Caller-allocated result buffer is passed as the first :address
-          ;;; arg; AAPCS64 wiring puts it in X8 at the call boundary.
-          (setq result-type *void-foreign-type*
+          (setq result-form (pop args)
+                struct-result-type result-type
+                result-type *void-foreign-type*
                 result-type-spec :void)
-          (argforms :address)
-          (argforms (pop args)))
+          (if (arm64-linux::record-type-returns-structure-as-first-arg
+               struct-result-type)
+            ;;; > 16 bytes and not an HFA: caller-allocated result
+            ;;; buffer, passed by reference.  KNOWN GAP: AAPCS64 §6.9
+            ;;; wants this pointer in X8; the c-frame/.SPffcall protocol
+            ;;; has no X8 slot yet, so it is passed as the first :address
+            ;;; arg and lands in X0 (pre-existing behavior, unchanged;
+            ;;; comms/HFA-DETECTION-16m71.md §10).
+            (progn
+              (argforms :address)
+              (argforms result-form))
+            ;;; HFA (any size) or non-HFA <= 16 bytes: returned in
+            ;;; registers (v0..v3 / x0-x1); capture them via
+            ;;; .SPffcall-return-registers into a 128-byte regbuf.
+            (progn
+              (setq regbuf (gensym)
+                    result-temp (gensym))
+              (argforms :registers)
+              (argforms regbuf))))
         (unless (evenp (length args))
           (error "~s should be an even-length list of alternating foreign types and values" args))
-        (do* ((args args (cddr args)))
-             ((null args))
-          (let* ((arg-type-spec (car args))
-                 (arg-value-form (cadr args)))
-            (if (or (member arg-type-spec *foreign-representation-type-keywords*
-                            :test #'eq)
-                    (typep arg-type-spec 'unsigned-byte))
-              (progn
-                (argforms arg-type-spec)
-                (argforms arg-value-form))
-              (let* ((ftype (parse-foreign-type arg-type-spec)))
-                (if (typep ftype 'foreign-record-type)
-                  (let* ((bits (ensure-foreign-type-bits ftype)))
-                    (cond
-                      ;;; ARM64-DEVIATION: <=64 bit struct passed
-                      ;;; left-justified (raw value, no ash).  PPC64
-                      ;;; source right-justified via (ash _ (- bits 64)).
-                      ((<= bits 64)
-                       (argforms :unsigned-doubleword)
-                       (argforms `(%%get-unsigned-longlong ,arg-value-form 0)))
-                      ;;; ARM64-DEVIATION: 65-128 bit struct passed as
-                      ;;; 2 doublewords in GPRs (X<n>..X<n+1>).  Matches
-                      ;;; the PPC64 source for the same size range but
-                      ;;; only applies up to 128 bits on AAPCS64.
-                      ((<= bits 128)
-                       (argforms (ceiling bits 64))
-                       (argforms arg-value-form))
-                      ;;; ARM64-DEVIATION: > 128 bit struct passed by
-                      ;;; reference (caller allocates copy, callee reads
-                      ;;; through pointer).  PPC64 source would emit
-                      ;;; (ceiling bits 64) doublewords here — AAPCS64
-                      ;;; never does that.
-                      (t
-                       (argforms :address)
-                       (argforms arg-value-form))))
-                  (progn
-                    (argforms (foreign-type-to-representation-type ftype))
-                    (argforms (funcall arg-coerce arg-type-spec arg-value-form))))))))
+        (flet ((struct-arg-temp ()
+                 (or structure-arg-temp
+                     (setq structure-arg-temp (gensym)))))
+          (do* ((args args (cddr args)))
+               ((null args))
+            (let* ((arg-type-spec (car args))
+                   (arg-value-form (cadr args)))
+              (if (or (member arg-type-spec *foreign-representation-type-keywords*
+                              :test #'eq)
+                      (typep arg-type-spec 'unsigned-byte))
+                (progn
+                  (argforms arg-type-spec)
+                  (argforms arg-value-form))
+                (let* ((ftype (parse-foreign-type arg-type-spec)))
+                  (if (typep ftype 'foreign-record-type)
+                    (let* ((bits (ensure-foreign-type-bits ftype)))
+                      (multiple-value-bind (hfa-base hfa-count)
+                          (arm64-linux::hfa-type-info ftype)
+                        (cond
+                          ;;; ARM64-DEVIATION: HFA/HVA passed in one V
+                          ;;; register per member (AAPCS64 C.2), by
+                          ;;; decomposing into scalar float argforms —
+                          ;;; the darwinppc64 "constituent elements as
+                          ;;; scalars" model.  The arg-value-form is
+                          ;;; evaluated ONCE into a dynamic-extent temp;
+                          ;;; member i is read at its natural offset.
+                          ;;; If the members would overflow v0-v7, C.3
+                          ;;; sends the WHOLE aggregate to the stack —
+                          ;;; unratified, and refused loudly by the
+                          ;;; backend/%ff-call exactly as >8 scalar FP
+                          ;;; args are.
+                          (hfa-base
+                           (let* ((temp (struct-arg-temp))
+                                  (single-p (eq hfa-base :single-float))
+                                  (accessor (if single-p
+                                              '%get-single-float
+                                              '%get-double-float))
+                                  (memsize (if single-p 4 8)))
+                             (dotimes (i hfa-count)
+                               (argforms hfa-base)
+                               (argforms
+                                `(,accessor
+                                  ,(if (eql i 0)
+                                     `(%setf-macptr ,temp ,arg-value-form)
+                                     temp)
+                                  ,(* i memsize))))))
+                          ;;; ARM64-DEVIATION: <=64 bit non-HFA struct
+                          ;;; passed left-justified (raw value, no ash).
+                          ;;; PPC64 source right-justified via
+                          ;;; (ash _ (- bits 64)).
+                          ((<= bits 64)
+                           (argforms :unsigned-doubleword)
+                           (argforms `(%%get-unsigned-longlong ,arg-value-form 0)))
+                          ;;; ARM64-DEVIATION: 65-128 bit non-HFA struct
+                          ;;; passed as 2 doublewords in consecutive GPRs
+                          ;;; (AAPCS64 C.12), decomposed here into two
+                          ;;; :unsigned-doubleword argforms through the
+                          ;;; same evaluate-once temp.  (An integer
+                          ;;; word-count argspec would say the same
+                          ;;; thing, but the arm642 codegen has no case
+                          ;;; for integer argspecs, so the decomposed
+                          ;;; form is the one that compiles everywhere.)
+                          ((<= bits 128)
+                           (let* ((temp (struct-arg-temp)))
+                             (argforms :unsigned-doubleword)
+                             (argforms `(%%get-unsigned-longlong
+                                         (%setf-macptr ,temp ,arg-value-form) 0))
+                             (argforms :unsigned-doubleword)
+                             (argforms `(%%get-unsigned-longlong ,temp 8))))
+                          ;;; ARM64-DEVIATION: > 128 bit non-HFA struct
+                          ;;; passed by reference (caller allocates copy,
+                          ;;; callee reads through pointer; AAPCS64 B.4).
+                          ;;; PPC64 source would emit (ceiling bits 64)
+                          ;;; doublewords here — AAPCS64 never does that.
+                          (t
+                           (argforms :address)
+                           (argforms arg-value-form)))))
+                    (progn
+                      (argforms (foreign-type-to-representation-type ftype))
+                      (argforms (funcall arg-coerce arg-type-spec arg-value-form)))))))))
         (argforms (foreign-type-to-representation-type result-type))
-        (funcall result-coerce result-type-spec `(,@callform ,@(argforms)))))))
+        (let* ((call (funcall result-coerce result-type-spec
+                              `(,@callform ,@(argforms)))))
+          (when structure-arg-temp
+            (setq call `(let* ((,structure-arg-temp (%null-ptr)))
+                          (declare (dynamic-extent ,structure-arg-temp)
+                                   (type macptr ,structure-arg-temp))
+                          ,call)))
+          (if regbuf
+            `(let* ((,result-temp (%null-ptr)))
+               (declare (dynamic-extent ,result-temp)
+                        (type macptr ,result-temp))
+               (%setf-macptr ,result-temp ,result-form)
+               (with-ffcall-results (,regbuf)
+                 ,call
+                 ,(arm64-linux::struct-from-regbuf-values
+                   result-temp struct-result-type regbuf)))
+            call))))))
 
 
 ;;;-----------------------------------------------------------------------

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -439,9 +439,22 @@
                (unless fp-regs-form
                  (setq fp-regs-form `(%inc-ptr ,stack-ptr ,arm64::callback-frame.fp-save-offset)))))
         (when (typep rtype 'foreign-record-type)
-          (setq argvars (cons struct-result-name argvars)
-                argspecs (cons :address argspecs)
-                rtype *void-foreign-type*))
+          (if (arm64-linux::record-type-returns-structure-as-first-arg rtype)
+            ;; >16 B non-HFA: caller-allocated result area, written
+            ;; through a pointer.  (PowerOpen line-port shape: pointer as
+            ;; implicit first arg.)
+            (setq argvars (cons struct-result-name argvars)
+                  argspecs (cons :address argspecs)
+                  rtype *void-foreign-type*)
+            ;; HFA (any size) or non-HFA <= 16 B: returned in REGISTERS
+            ;; (v0..v3 / x0-x1) -- no pointer exists.  RLET a local
+            ;; struct as the body's STRUCT-RETURN-ARG;
+            ;; generate-callback-return-value below copies it into the
+            ;; trampoline's register reload slots on exit.  Model:
+            ;; x8664::generate-callback-bindings (x8664-backend.lisp).
+            ;; rtype stays the record type so the return-value generator
+            ;; can dispatch on it.
+            (rlets (list struct-result-name (foreign-record-type-name rtype)))))
         (when (typep rtype 'foreign-float-type)
           (set-fp-regs-form))
         (do* ((argvars argvars (cdr argvars))
@@ -457,16 +470,53 @@
           (let* ((name (car argvars))
                  (spec (car argspecs))
                  (argtype (parse-foreign-type spec))
-                 (bits (ensure-foreign-type-bits argtype)))
-            (if (and (typep argtype 'foreign-record-type)
-                     (<= bits 64))
-              (progn
-                (when name (rlets (list name (foreign-record-type-name argtype))))
-                ;; ARM64-DEVIATION (LE): copy the slot verbatim — the value
-                ;; is low-justified in its doubleword.
-                (when name (inits `(setf (%%get-unsigned-longlong ,name 0)
-                                    (%%get-unsigned-longlong ,stack-ptr ,offset)))))
-              (let* ((access-form
+                 (bits (ensure-foreign-type-bits argtype))
+                 (hfa-base nil)
+                 (hfa-count nil))
+            (when (typep argtype 'foreign-record-type)
+              (multiple-value-setq (hfa-base hfa-count)
+                (arm64-linux::hfa-type-info argtype)))
+            (cond
+              ;; HFA/HVA argument: it arrived in one V register per
+              ;; member (AAPCS64 C.2), NOT in the GPR save area the
+              ;; size-dispatched record cases below read.  The trampoline
+              ;; saved d0-d7 at CBF-64..-8, so member i of an HFA whose
+              ;; first member landed at NSRN n reads from the fp save
+              ;; area at 8*(n+i); the arg consumes NO gpr/stack slot
+              ;; (delta 0).  LE: a single-float member's payload sits at
+              ;; its d-save slot's BASE (same reasoning as the scalar
+              ;; single-float case below).  An HFA that would overflow
+              ;; v0-v7 goes WHOLLY to the stack (C.3) -- stack-passed
+              ;; args are not ratified on this port, so refuse loudly at
+              ;; definition time, the same policy as the call-out
+              ;; direction's refusals.
+              (hfa-base
+               (unless (<= (+ fp-arg-num hfa-count) 8)
+                 (error "HFA argument ~s would overflow v0-v7 (AAPCS64 ~
+                         C.3 stack case); stack-passed callback ~
+                         arguments are not yet supported"
+                        (unparse-foreign-type argtype)))
+               (let* ((nsrn fp-arg-num)
+                      (single-p (eq hfa-base :single-float))
+                      (accessor (if single-p '%get-single-float '%get-double-float))
+                      (memsize (if single-p 4 8)))
+                 (incf fp-arg-num hfa-count)
+                 (setq delta 0)
+                 (set-fp-regs-form)
+                 (when name
+                   (rlets (list name (foreign-record-type-name argtype)))
+                   (dotimes (i hfa-count)
+                     (inits `(setf (,accessor ,name ,(* i memsize))
+                              (,accessor ,fp-args-ptr ,(* 8 (+ nsrn i)))))))))
+              ((and (typep argtype 'foreign-record-type)
+                    (<= bits 64))
+               (when name (rlets (list name (foreign-record-type-name argtype))))
+               ;; ARM64-DEVIATION (LE): copy the slot verbatim — the value
+               ;; is low-justified in its doubleword.
+               (when name (inits `(setf (%%get-unsigned-longlong ,name 0)
+                                   (%%get-unsigned-longlong ,stack-ptr ,offset)))))
+              (t
+               (let* ((access-form
                       `(,(cond
                           ((typep argtype 'foreign-single-float-type)
                            (when (< (incf fp-arg-num) 9)
@@ -522,19 +572,23 @@
                         ,(if use-fp-args fp-args-ptr stack-ptr)
                         ,(if use-fp-args (* 8 (1- fp-arg-num))
                              `(+ ,offset ,bias)))))
-                (when name (lets (list name access-form)))
-                (when use-fp-args (set-fp-regs-form))))))))))
+                 (when name (lets (list name access-form)))
+                 (when use-fp-args (set-fp-regs-form)))))))))))
 
 
 ;;;-----------------------------------------------------------------------
 ;;; (4) generate-callback-return-value
 ;;;-----------------------------------------------------------------------
 ;;; PPC64 LINE-PORT (vendor/ccl/lib/ffi-linuxppc64.lisp:180-199).
-;;; All structures are "returned" via the implicit first argument; the
-;;; binding generator already translated the return type to :void then.
-;;; The kernel trampoline reloads x0/x1 from CBF+0/+8 and d0 from CBF-64
-;;; on exit, so the value is written into the argument save area
-;;; (exactly PPC's gp_save reuse).
+;;; >16-byte non-HFA structures are "returned" via a result-area pointer;
+;;; the binding generator already translated the return type to :void
+;;; then.  The kernel trampoline reloads x0/x1 from CBF+0/+8 and d0-d3
+;;; from CBF-64..-40 on exit, so scalar values are written into the
+;;; argument save area (exactly PPC's gp_save reuse), and register-
+;;; returned records (HFA / non-HFA <= 16 B -- return-type is then the
+;;; RECORD type and STRUCT-RETURN-ARG the rlet'd local the body filled)
+;;; are copied member-by-member into the same reload slots.  Model:
+;;; x8664::generate-callback-return-value (x8664-backend.lisp).
 ;;;
 ;;; ARM64-DEVIATION: a :single-float result is written as FLOAT BITS
 ;;; (%get-single-float setf, low 32 bits of the d0 reload slot) — the C
@@ -542,19 +596,49 @@
 ;;; wrote a double because PowerOpen returns singles double-extended in
 ;;; f1; AAPCS64 does not.
 (defun arm64-linux::generate-callback-return-value (stack-ptr fp-args-ptr result return-type struct-return-arg)
-  (declare (ignore struct-return-arg))
   (unless (eq return-type *void-foreign-type*)
-    (let* ((return-type-keyword (foreign-type-to-representation-type return-type)))
-      (case return-type-keyword
-        (:single-float
-         `(setf (%get-single-float ,fp-args-ptr 0) ,result))
-        (:double-float
-         `(setf (%get-double-float ,fp-args-ptr 0) ,result))
-        (:address
-         `(setf (%get-ptr ,stack-ptr 0) ,result))
-        (:signed-doubleword
-         `(setf (%%get-signed-longlong ,stack-ptr 0) ,result))
-        (:unsigned-doubleword
-         `(setf (%%get-unsigned-longlong ,stack-ptr 0) ,result))
-        (t
-         `(setf (%%get-signed-longlong ,stack-ptr 0) ,result))))))
+    (if (typep return-type 'foreign-record-type)
+      ;; Reached only for HFA or non-HFA <= 16 B records (>16 B non-HFA
+      ;; was mapped to :void by generate-callback-bindings).  The body's
+      ;; value is meaningless (x8664 ignores it too); the record is in
+      ;; STRUCT-RETURN-ARG.
+      ;;   HFA: member i -> the d<i> save slot at CBF-64+8i (AAPCS64 6.9
+      ;;   returns HFAs in v0..v3, one register per member; LE: a
+      ;;   single-float member's payload sits at the slot base).
+      ;;   non-HFA <= 16 B: the x0/x1 reload slots at CBF+0/+8.
+      (let* ((bits (ensure-foreign-type-bits return-type)))
+        (multiple-value-bind (hfa-base hfa-count)
+            (arm64-linux::hfa-type-info return-type)
+          (collect ((forms))
+            (cond
+              ((eq hfa-base :double-float)
+               (dotimes (i hfa-count)
+                 (forms `(setf (%get-double-float ,stack-ptr
+                                ,(+ arm64::callback-frame.fp-save-offset (* 8 i)))
+                          (%get-double-float ,struct-return-arg ,(* 8 i))))))
+              ((eq hfa-base :single-float)
+               (dotimes (i hfa-count)
+                 (forms `(setf (%get-single-float ,stack-ptr
+                                ,(+ arm64::callback-frame.fp-save-offset (* 8 i)))
+                          (%get-single-float ,struct-return-arg ,(* 4 i))))))
+              (t
+               (forms `(setf (%%get-unsigned-longlong ,stack-ptr 0)
+                        (%%get-unsigned-longlong ,struct-return-arg 0)))
+               (when (> bits 64)
+                 (forms `(setf (%%get-unsigned-longlong ,stack-ptr 8)
+                          (%%get-unsigned-longlong ,struct-return-arg 8))))))
+            `(progn ,@(forms)))))
+      (let* ((return-type-keyword (foreign-type-to-representation-type return-type)))
+        (case return-type-keyword
+          (:single-float
+           `(setf (%get-single-float ,fp-args-ptr 0) ,result))
+          (:double-float
+           `(setf (%get-double-float ,fp-args-ptr 0) ,result))
+          (:address
+           `(setf (%get-ptr ,stack-ptr 0) ,result))
+          (:signed-doubleword
+           `(setf (%%get-signed-longlong ,stack-ptr 0) ,result))
+          (:unsigned-doubleword
+           `(setf (%%get-unsigned-longlong ,stack-ptr 0) ,result))
+          (t
+           `(setf (%%get-signed-longlong ,stack-ptr 0) ,result)))))))

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -59,10 +59,10 @@
 ;;;   - Size <= 16 bytes, not HFA: returned in X0/X1; captured via the
 ;;;     same regbuf, copied from the GPR half.
 ;;;   - Size > 16 bytes, not HFA: caller allocates buffer, passes pointer
-;;;     in X8; function writes through X8 and returns void.  KNOWN GAP:
-;;;     the c-frame/.SPffcall protocol has no X8 slot yet, so the buffer
-;;;     pointer currently lands in X0 (unchanged pre-existing behavior;
-;;;     see comms/HFA-DETECTION-16m71.md §10).
+;;;     in X8; function writes through X8 and returns void.  Passed under
+;;;     the :indirect-result argspec (consumes no argument slot);
+;;;     .SPffcall-indirect-result (spentry-E-ffi.s) loads the buffer
+;;;     address into x8 immediately before the call.
 
 (in-package "CCL")
 
@@ -76,6 +76,18 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (unless (find-package "ARM64-LINUX")
     (make-package "ARM64-LINUX" :use '("CL" "CCL"))))
+
+;;; :indirect-result is the argspec under which expand-ff-call below hands
+;;; the >16-byte non-HFA record-return buffer to the backend (AAPCS64 6.9
+;;; wants its ADDRESS in x8 at the call).  nx1-ff-call-internal has its own
+;;; arm for it, but a CROSS-COMPILATION HOST runs whatever nx1 is baked
+;;; into ITS image -- possibly a released CCL that predates the keyword.
+;;; This file IS loaded into any host that targets linuxarm64 (it defines
+;;; the target FTD), so extending the whitelist here makes the old host's
+;;; GENERIC argspec arm pass the keyword through to the arm64 backend,
+;;; with no host rebuild required.
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (pushnew :indirect-result *arg-spec-keywords*))
 
 
 ;;;-----------------------------------------------------------------------
@@ -267,13 +279,13 @@
           (if (arm64-linux::record-type-returns-structure-as-first-arg
                struct-result-type)
             ;;; > 16 bytes and not an HFA: caller-allocated result
-            ;;; buffer, passed by reference.  KNOWN GAP: AAPCS64 §6.9
-            ;;; wants this pointer in X8; the c-frame/.SPffcall protocol
-            ;;; has no X8 slot yet, so it is passed as the first :address
-            ;;; arg and lands in X0 (pre-existing behavior, unchanged;
-            ;;; comms/HFA-DETECTION-16m71.md §10).
+            ;;; buffer whose address AAPCS64 §6.9 wants in X8, not in an
+            ;;; argument register.  :indirect-result consumes no C slot;
+            ;;; the codegen/interpreted paths route the call through
+            ;;; .SPffcall-indirect-result, which loads the macptr's
+            ;;; address into x8 just before the call (spentry-E-ffi.s).
             (progn
-              (argforms :address)
+              (argforms :indirect-result)
               (argforms result-form))
             ;;; HFA (any size) or non-HFA <= 16 bytes: returned in
             ;;; registers (v0..v3 / x0-x1); capture them via

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -90,7 +90,14 @@
 ;;; GENERIC argspec arm pass the keyword through to the arm64 backend,
 ;;; with no host rebuild required.
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (pushnew :indirect-result *arg-spec-keywords*))
+  (pushnew :indirect-result *arg-spec-keywords*)
+  ;; :stack-doubleword = one raw 8-byte slot in the NSAA stack-arg
+  ;; block, never a register: one word of an AAPCS64 C.13 memory copy
+  ;; of a composite the ABI sends WHOLLY to the stack (an HFA that
+  ;; cannot fit v0-v7, C.3; a 2-doubleword record with one GPR left,
+  ;; C.10/C.11).  Emitted only by expand-ff-call below; the same
+  ;; old-host rationale as :indirect-result applies.
+  (pushnew :stack-doubleword *arg-spec-keywords*))
 
 
 ;;;-----------------------------------------------------------------------
@@ -348,38 +355,73 @@
                           ;;; scalars" model.  The arg-value-form is
                           ;;; evaluated ONCE into a dynamic-extent temp;
                           ;;; member i is read at its natural offset.
-                          ;;; If the members would overflow v0-v7, C.3
-                          ;;; sends the WHOLE aggregate to the stack
-                          ;;; with natural member packing — a shape the
-                          ;;; member-wise decomposition cannot express
-                          ;;; (and must never SPLIT), so it is refused
-                          ;;; here with the running counts.  Scalar FP
-                          ;;; overflow, by contrast, is supported (NSAA
-                          ;;; stack block).
+                          ;;; If the members would NOT all fit in v0-v7,
+                          ;;; C.3 sends the WHOLE aggregate to the stack
+                          ;;; (never a register/stack split) AND sets
+                          ;;; NSRN := 8 — see the stack branch below.
                           (hfa-base
-                           (unless (<= (+ nfpr-args hfa-count) 8)
-                             (error "HFA argument ~s needs ~d SIMD register~:p ~
-                                     but only ~d remain: AAPCS64 C.3 sends the ~
-                                     whole aggregate to the stack with natural ~
-                                     member packing, which this port does not ~
-                                     yet support"
-                                    arg-type-spec hfa-count
-                                    (max 0 (- 8 nfpr-args))))
-                           (incf nfpr-args hfa-count)
-                           (let* ((temp (struct-arg-temp))
-                                  (single-p (eq hfa-base :single-float))
-                                  (accessor (if single-p
-                                              '%get-single-float
-                                              '%get-double-float))
-                                  (memsize (if single-p 4 8)))
-                             (dotimes (i hfa-count)
-                               (argforms hfa-base)
-                               (argforms
-                                `(,accessor
-                                  ,(if (eql i 0)
-                                     `(%setf-macptr ,temp ,arg-value-form)
-                                     temp)
-                                  ,(* i memsize))))))
+                           (if (> (+ nfpr-args hfa-count) 8)
+                             ;; C.3: NSRN := 8; size rounded up to a
+                             ;; multiple of 8; the aggregate is copied to
+                             ;; the NSAA with NATURAL member packing (a
+                             ;; float member is 4 bytes here — which is
+                             ;; why this cannot be expressed as scalar
+                             ;; :single-float argforms; C.5 widens those
+                             ;; to 8-byte slots).
+                             ;; The dummy :double-float argforms below ARE
+                             ;; C.3's register waste: v-registers the
+                             ;; callee's prototype ignores.  They also
+                             ;; keep the BACKEND's FP counter in lockstep
+                             ;; with this one, so later scalar FP args
+                             ;; flow through its existing NSAA overflow
+                             ;; arm (C.1 can never fire again).
+                             ;; ARM64-DEVIATION vs the x86-64 donor
+                             ;; (x8664-backend.lisp expand-ff-call):
+                             ;; SysV's MEMORY class burns nothing; C.3's
+                             ;; burn is AAPCS64-specific.  PPC64 has no
+                             ;; analog (PowerOpen always has a memory
+                             ;; slot per parameter).
+                             (progn
+                               (dotimes (i (- 8 nfpr-args))
+                                 (declare (ignorable i))
+                                 (argforms :double-float)
+                                 (argforms 0.0d0))
+                               (setq nfpr-args 8)
+                               ;; C.13 memory copy: ceil(size/8) raw NSAA
+                               ;; words through the evaluate-once temp.
+                               ;; A <=4-byte tail is read narrow so we
+                               ;; never read more than 3 bytes past the
+                               ;; object; the slot's high bytes are C.3
+                               ;; round-up padding, unspecified.
+                               (let* ((temp (struct-arg-temp))
+                                      (nbytes (ceiling bits 8)))
+                                 (do* ((off 0 (+ off 8)))
+                                      ((>= off nbytes))
+                                   (argforms :stack-doubleword)
+                                   (argforms
+                                    (let* ((base (if (eql off 0)
+                                                   `(%setf-macptr ,temp ,arg-value-form)
+                                                   temp)))
+                                      (if (<= (- nbytes off) 4)
+                                        `(%get-unsigned-long ,base ,off)
+                                        `(%%get-unsigned-longlong ,base ,off)))))))
+                             ;; C.2: enough SIMD registers — one member
+                             ;; per v-register, as before.
+                             (let* ((temp (struct-arg-temp))
+                                    (single-p (eq hfa-base :single-float))
+                                    (accessor (if single-p
+                                                '%get-single-float
+                                                '%get-double-float))
+                                    (memsize (if single-p 4 8)))
+                               (incf nfpr-args hfa-count)
+                               (dotimes (i hfa-count)
+                                 (argforms hfa-base)
+                                 (argforms
+                                  `(,accessor
+                                    ,(if (eql i 0)
+                                       `(%setf-macptr ,temp ,arg-value-form)
+                                       temp)
+                                    ,(* i memsize)))))))
                           ;;; ARM64-DEVIATION: <=64 bit non-HFA struct
                           ;;; passed left-justified (raw value, no ash).
                           ;;; PPC64 source right-justified via
@@ -397,29 +439,49 @@
                           ;;; thing, but the arm642 codegen has no case
                           ;;; for integer argspecs, so the decomposed
                           ;;; form is the one that compiles everywhere.)
-                          ;;; With EXACTLY one GPR left the decomposition
-                          ;;; would SPLIT the record across x7 and the
-                          ;;; stack; AAPCS64 C.10/C.11 send it wholly to
-                          ;;; the stack instead, so that one shape is
-                          ;;; refused.  With 0 GPRs left both words land
-                          ;;; in consecutive NSAA slots, which IS the
-                          ;;; C.15 whole-record stack copy — fine.
+                          ;;; C.10 when both doublewords fit the remaining
+                          ;;; GPRs; otherwise C.11: NGRN := 8 — with one
+                          ;;; register left it is WASTED (never a
+                          ;;; register/stack split) — then C.12/C.13 copy
+                          ;;; the whole record to the stack.  The dummy
+                          ;;; argform below IS C.11's wasted x7 (dead
+                          ;;; content per the callee's prototype) and
+                          ;;; keeps the backend's GPR counter in lockstep,
+                          ;;; so later scalar int args flow through its
+                          ;;; existing NSAA overflow arm.
+                          ;;; ARM64-DEVIATION vs the x86-64 donor: SysV's
+                          ;;; MEMORY class burns nothing (x8664-backend
+                          ;;; expand-ff-call); the burn is AAPCS64 C.11.
                           ((<= bits 128)
-                           (when (eql ngpr-words 7)
-                             (error "16-byte record argument ~s with exactly ~
-                                     one integer register remaining: AAPCS64 ~
-                                     C.10/C.11 send the whole record to the ~
-                                     stack rather than splitting it, which ~
-                                     this port does not yet support at that ~
-                                     position; reorder the argument or pad"
+                           (when (> (foreign-type-alignment ftype) 64)
+                             (error "record argument ~s has 16-byte ~
+                                     alignment; AAPCS64 C.8/C.12 16-byte ~
+                                     register/NSAA alignment is not ~
+                                     modeled by this port yet"
                                     arg-type-spec))
-                           (incf ngpr-words 2)
-                           (let* ((temp (struct-arg-temp)))
-                             (argforms :unsigned-doubleword)
-                             (argforms `(%%get-unsigned-longlong
-                                         (%setf-macptr ,temp ,arg-value-form) 0))
-                             (argforms :unsigned-doubleword)
-                             (argforms `(%%get-unsigned-longlong ,temp 8))))
+                           (if (<= (+ ngpr-words 2) 8)
+                             (progn        ; C.10: two consecutive GPRs
+                               (incf ngpr-words 2)
+                               (let* ((temp (struct-arg-temp)))
+                                 (argforms :unsigned-doubleword)
+                                 (argforms `(%%get-unsigned-longlong
+                                             (%setf-macptr ,temp ,arg-value-form) 0))
+                                 (argforms :unsigned-doubleword)
+                                 (argforms `(%%get-unsigned-longlong ,temp 8))))
+                             (progn        ; C.11 + C.13
+                               (when (< ngpr-words 8)
+                                 (argforms :unsigned-doubleword)
+                                 (argforms 0))
+                               (setq ngpr-words 8)
+                               (let* ((temp (struct-arg-temp))
+                                      (nbytes (ceiling bits 8)))
+                                 (argforms :stack-doubleword)
+                                 (argforms `(%%get-unsigned-longlong
+                                             (%setf-macptr ,temp ,arg-value-form) 0))
+                                 (argforms :stack-doubleword)
+                                 (argforms (if (<= (- nbytes 8) 4)
+                                             `(%get-unsigned-long ,temp 8)
+                                             `(%%get-unsigned-longlong ,temp 8)))))))
                           ;;; ARM64-DEVIATION: > 128 bit non-HFA struct
                           ;;; passed by reference (caller allocates copy,
                           ;;; callee reads through pointer; AAPCS64 B.4).

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -40,9 +40,12 @@
 ;;;     otherwise the WHOLE aggregate goes to the stack (C.3/C.4) —
 ;;;     never to GPRs, never by reference.  Detected by hfa-type-info
 ;;;     below and passed by decomposing into scalar member argforms
-;;;     (the darwinppc64 model, lib/ffi-darwinppc64.lisp); the C.3
-;;;     stack case is refused loudly, exactly as >8 scalar FP args are
-;;;     (no stack args until the stack-arg frame layout is ratified).
+;;;     (the darwinppc64 model, lib/ffi-darwinppc64.lisp).  Scalar args
+;;;     of either class beyond the 8 registers go to the NSAA stack
+;;;     block in source order (implemented; see arm642-aapcs64-ff-call
+;;;     and the SP step in the ffcall spentries), but the C.3
+;;;     WHOLE-AGGREGATE stack case cannot be expressed by member-wise
+;;;     decomposition and is refused loudly in expand-ff-call.
 ;;;   - Composite size <= 16 bytes (128 bits), not HFA: passed in GPRs
 ;;;     (X0..X7 as 1-2 doublewords, left-justified — NOT right-justified
 ;;;     like PowerOpen).
@@ -262,7 +265,23 @@
          (result-temp nil)
          (result-form nil)
          (struct-result-type nil)
-         (structure-arg-temp nil))
+         (structure-arg-temp nil)
+         ;; Running AAPCS64 register-class counts, advanced in source
+         ;; order by the arg loop below, so the DECOMPOSED composite
+         ;; cases can refuse the register/stack STRADDLE shapes at
+         ;; macroexpansion time.  Scalar overflow is supported (args 9+
+         ;; of either class go to the NSAA stack block), but AAPCS64
+         ;; never splits ONE composite across registers and stack: an
+         ;; HFA whose members do not all fit in v0-v7 goes wholly to the
+         ;; stack (C.3, with natural member packing the member-wise
+         ;; decomposition cannot express), and a 2-doubleword record
+         ;; with exactly one GPR left goes wholly to the stack (C.11).
+         ;; Both shapes used to be masked by the backend's blanket >8
+         ;; refusals; with stack args implemented they are refused HERE,
+         ;; precisely, and everything else flows.
+         (ngpr-words 0)
+         (nfpr-args 0))
+    (declare (fixnum ngpr-words nfpr-args))
     (multiple-value-bind (result-type error)
         (ignore-errors (parse-foreign-type result-type-spec))
       (if error
@@ -308,6 +327,12 @@
                               :test #'eq)
                       (typep arg-type-spec 'unsigned-byte))
                 (progn
+                  (case arg-type-spec
+                    ((:single-float :double-float) (incf nfpr-args))
+                    ((:registers :indirect-result :void))
+                    (t (incf ngpr-words (if (typep arg-type-spec 'unsigned-byte)
+                                          arg-type-spec
+                                          1))))
                   (argforms arg-type-spec)
                   (argforms arg-value-form))
                 (let* ((ftype (parse-foreign-type arg-type-spec)))
@@ -324,11 +349,23 @@
                           ;;; evaluated ONCE into a dynamic-extent temp;
                           ;;; member i is read at its natural offset.
                           ;;; If the members would overflow v0-v7, C.3
-                          ;;; sends the WHOLE aggregate to the stack —
-                          ;;; unratified, and refused loudly by the
-                          ;;; backend/%ff-call exactly as >8 scalar FP
-                          ;;; args are.
+                          ;;; sends the WHOLE aggregate to the stack
+                          ;;; with natural member packing — a shape the
+                          ;;; member-wise decomposition cannot express
+                          ;;; (and must never SPLIT), so it is refused
+                          ;;; here with the running counts.  Scalar FP
+                          ;;; overflow, by contrast, is supported (NSAA
+                          ;;; stack block).
                           (hfa-base
+                           (unless (<= (+ nfpr-args hfa-count) 8)
+                             (error "HFA argument ~s needs ~d SIMD register~:p ~
+                                     but only ~d remain: AAPCS64 C.3 sends the ~
+                                     whole aggregate to the stack with natural ~
+                                     member packing, which this port does not ~
+                                     yet support"
+                                    arg-type-spec hfa-count
+                                    (max 0 (- 8 nfpr-args))))
+                           (incf nfpr-args hfa-count)
                            (let* ((temp (struct-arg-temp))
                                   (single-p (eq hfa-base :single-float))
                                   (accessor (if single-p
@@ -348,6 +385,7 @@
                           ;;; PPC64 source right-justified via
                           ;;; (ash _ (- bits 64)).
                           ((<= bits 64)
+                           (incf ngpr-words)
                            (argforms :unsigned-doubleword)
                            (argforms `(%%get-unsigned-longlong ,arg-value-form 0)))
                           ;;; ARM64-DEVIATION: 65-128 bit non-HFA struct
@@ -359,7 +397,23 @@
                           ;;; thing, but the arm642 codegen has no case
                           ;;; for integer argspecs, so the decomposed
                           ;;; form is the one that compiles everywhere.)
+                          ;;; With EXACTLY one GPR left the decomposition
+                          ;;; would SPLIT the record across x7 and the
+                          ;;; stack; AAPCS64 C.10/C.11 send it wholly to
+                          ;;; the stack instead, so that one shape is
+                          ;;; refused.  With 0 GPRs left both words land
+                          ;;; in consecutive NSAA slots, which IS the
+                          ;;; C.15 whole-record stack copy — fine.
                           ((<= bits 128)
+                           (when (eql ngpr-words 7)
+                             (error "16-byte record argument ~s with exactly ~
+                                     one integer register remaining: AAPCS64 ~
+                                     C.10/C.11 send the whole record to the ~
+                                     stack rather than splitting it, which ~
+                                     this port does not yet support at that ~
+                                     position; reorder the argument or pad"
+                                    arg-type-spec))
+                           (incf ngpr-words 2)
                            (let* ((temp (struct-arg-temp)))
                              (argforms :unsigned-doubleword)
                              (argforms `(%%get-unsigned-longlong
@@ -372,10 +426,14 @@
                           ;;; PPC64 source would emit (ceiling bits 64)
                           ;;; doublewords here — AAPCS64 never does that.
                           (t
+                           (incf ngpr-words)
                            (argforms :address)
                            (argforms arg-value-form)))))
-                    (progn
-                      (argforms (foreign-type-to-representation-type ftype))
+                    (let* ((rep (foreign-type-to-representation-type ftype)))
+                      (case rep
+                        ((:single-float :double-float) (incf nfpr-args))
+                        (t (incf ngpr-words)))
+                      (argforms rep)
                       (argforms (funcall arg-coerce arg-type-spec arg-value-form)))))))))
         (argforms (foreign-type-to-representation-type result-type))
         (let* ((call (funcall result-coerce result-type-spec

--- a/lib/ffi-linuxarm64.lisp
+++ b/lib/ffi-linuxarm64.lisp
@@ -404,7 +404,8 @@
 ;;; the A1 callback-frame contract (arm64-arch.lisp callback-frame.*;
 ;;; built by _spentry(eabi_callback), lisp-kernel/arm64-spentry.s).
 ;;; stack-ptr = CBF: x0..x7 saves at +0..56, the C caller's stack args
-;;; CONTIGUOUS at +64, d0..d7 saves at -64..-8, saved LR at -152.
+;;; CONTIGUOUS at +64, d0..d7 saves at -64..-8, saved LR at -152,
+;;; incoming x8 (indirect result-area pointer, AAPCS64 6.9) at -248.
 ;;;
 ;;; ARM64-DEVIATIONs from the PPC64 source:
 ;;;  - 8 FP arg regs (d0..d7), not PowerOpen's 13 (f1..f13).
@@ -418,14 +419,17 @@
 ;;;    base: plain %get-single-float (PPC read a double and rounded via
 ;;;    %get-single-float-from-double-ptr — PowerOpen carries singles
 ;;;    double-extended; AAPCS64 does not).
-;;;  - records: <=64 bits arrive in one GPR slot, read low-justified
-;;;    (no BE (ash _ (- 64 bits)) re-justify); 65..128 bits inline in
-;;;    two slots (%inc-ptr, delta 16); >128 bits arrive BY REFERENCE in
-;;;    one GPR (AAPCS64 B.4) — read the pointer.  (PowerOpen passed any
-;;;    record inline at full size.)  KNOWN GAP, documented: a 9..16-byte
-;;;    record with exactly one GPR left goes wholly to the stack under
-;;;    AAPCS64 (no register/stack split); this generator would read it
-;;;    one slot early.  No boot-path callback has such a signature.
+;;;  - records: HFAs/HVAs (any size, 1-4 members) arrive in V registers,
+;;;    one per member, read from the fp save area (C.2 -- see the
+;;;    HFA-BASE case below); other records: <=64 bits arrive in one GPR
+;;;    slot, read low-justified (no BE (ash _ (- 64 bits)) re-justify);
+;;;    65..128 bits inline in two slots (%inc-ptr, delta 16); >128 bits
+;;;    arrive BY REFERENCE in one GPR (AAPCS64 B.4) — read the pointer.
+;;;    (PowerOpen passed any record inline at full size.)  KNOWN GAP,
+;;;    documented: a 9..16-byte record with exactly one GPR left goes
+;;;    wholly to the stack under AAPCS64 (no register/stack split); this
+;;;    generator would read it one slot early.  No boot-path callback
+;;;    has such a signature.
 ;;;  - fp-regs-form is frame arithmetic (%inc-ptr CBF -64), not PPC's
 ;;;    deref of a pointer the trampoline stored into its frame.
 (defun arm64-linux::generate-callback-bindings (stack-ptr fp-args-ptr argvars argspecs result-spec struct-result-name)
@@ -441,11 +445,16 @@
         (when (typep rtype 'foreign-record-type)
           (if (arm64-linux::record-type-returns-structure-as-first-arg rtype)
             ;; >16 B non-HFA: caller-allocated result area, written
-            ;; through a pointer.  (PowerOpen line-port shape: pointer as
-            ;; implicit first arg.)
-            (setq argvars (cons struct-result-name argvars)
-                  argspecs (cons :address argspecs)
-                  rtype *void-foreign-type*)
+            ;; through the pointer the C caller passed in X8 (AAPCS64
+            ;; 6.9) -- NOT as an implicit first argument (the PowerOpen
+            ;; shape this file line-ported).  The trampoline captured
+            ;; the incoming x8 at CBF-248; bind the struct-return name
+            ;; to it WITHOUT shifting the real arguments.
+            (progn
+              (lets (list struct-result-name
+                          `(%get-ptr ,stack-ptr
+                            ,arm64::callback-frame.x8-save-offset)))
+              (setq rtype *void-foreign-type*))
             ;; HFA (any size) or non-HFA <= 16 B: returned in REGISTERS
             ;; (v0..v3 / x0-x1) -- no pointer exists.  RLET a local
             ;; struct as the body's STRUCT-RETURN-ARG;

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -6705,19 +6705,27 @@ endsp callbackX
  * and into which it writes the C result.
  *
  * PROPOSED-CONVENTION CALLBACK-IDX (RATIFY): the make-callback trampoline
- * stub enters here with the UNBOXED callback index in arg_w=x8 (16m14:
- * fixed a =x9 typo here — the code below reads arg_w, which is x8; the
- * level-1/arm64-callback-support.lisp generator stamps x8) (PPC uses
- * r11; any AAPCS64 caller-saved scratch works - the trampoline generator
- * is a lisp-side deliverable that must match).
+ * stub enters here with the UNBOXED callback index in arg_y=x10 (PPC uses
+ * r11; any AAPCS64 caller-saved scratch works - the trampoline generator,
+ * level-1/arm64-callback-support.lisp, is a lisp-side deliverable that
+ * must match).  x8 is NOT usable for the index: AAPCS64 6.9 delivers the
+ * indirect result-area pointer there when the callback returns a >16-byte
+ * non-HFA record, so the incoming x8 is live argument material -- it is
+ * captured below (via save2, which survives the get_tcr C call) into the
+ * padding word of the foreign-sp stash, at CBF-248
+ * (arm64-arch.lisp callback-frame.x8-save-offset), where the lisp glue
+ * reads it as the struct-return pointer.  (The index lived in x8 until
+ * 16m71 and silently clobbered that pointer.)
  *
  * PROPOSED frame contract (RATIFY - lisp-side callback glue must match;
  * boot-validated shape from our v2 tree): x0..x7 are pushed so the x0 slot
  * abuts the incoming sp; CBF = &x0save.  The C caller's stack args then
  * sit contiguously at CBF+64 (the PowerOpen single-linear-offset property,
- * reproduced).  d0..d7 saves at CBF-64..-8.  The GPR result is reloaded
- * from CBF+0/+8, the FPR result from CBF-64.  CBF is 16-aligned, so it is
- * its own fixnum boxing.
+ * reproduced).  d0..d7 saves at CBF-64..-8; incoming x8 at CBF-248.  The
+ * GPR result is reloaded from CBF+0/+8, the FPR result from CBF-64..-40
+ * (d0-d3: an HFA return of up to 4 members, AAPCS64 6.9; a scalar FP
+ * result only populates d0's slot).  CBF is 16-aligned, so it is its own
+ * fixnum boxing.
  *
  * ARM64-DEVIATION (vs PPC64 poweropen_callback):
  *   - callee-saved set = x19-x28 + fp/lr and d8-d15 (+FPCR/FPSR pair), NOT
@@ -6759,18 +6767,24 @@ spentry callback
         mrs imm0, fpcr
         mrs imm1, fpsr
         stp imm0, imm1, [sp, #-16]!
-        /* Stash index + CBF in just-saved callee-saved regs: they must
-           survive the get_tcr C call (x9-x17 are caller-saved, and a
-           linker veneer may clobber x16/x17). */
-        mov save0, arg_w
-        mov save1, arg_x
+        /* Stash index + CBF + incoming x8 in just-saved callee-saved
+           regs: they must survive the get_tcr C call (x9-x17 are
+           caller-saved, and a linker veneer may clobber x16/x17).  x8 is
+           the AAPCS64 indirect result-area pointer when the callback
+           returns a >16-byte non-HFA record -- garbage otherwise, and
+           harmless to carry. */
+        mov save0, arg_y                        /* callback index (x10)  */
+        mov save1, arg_x                        /* CBF                   */
+        mov save2, arg_w                        /* incoming x8           */
         /* Recover the thread context (ppc:5114-5124 get_tcr(1)). */
         mov x0, #1
         bl get_tcr
         mov rcontext, x0
-        /* Stash the exact foreign sp for the return path. */
+        /* Stash the exact foreign sp for the return path, pairing it
+           with the incoming x8 (slot CBF-248 =
+           callback-frame.x8-save-offset; was an xzr padding word). */
         mov imm0, sp
-        stp imm0, xzr, [sp, #-16]!
+        stp imm0, save2, [sp, #-16]!
         /* Restore lisp context (ppc:5127-5147). */
         ldr vsp, [rcontext, #tcr.save_vsp]
         ldr tsp, [rcontext, #tcr.save_tsp]
@@ -6830,9 +6844,11 @@ spentry callback
         ldr nfn, [fname, #symbol.fcell]
         ldr temp4, [nfn, #_function.codevector]
         blr temp4
-        /* Lisp wrote the result into CBF+0/+8 / CBF-64 (glue contract).
-           CBF is recomputed below from the restored sp (fixed layout);
-           first publish lisp state back to the tcr (ppc:5159-5169). */
+        /* Lisp wrote the result into CBF+0/+8 / CBF-64..-40 (glue
+           contract; a >16-byte non-HFA record went through the pointer
+           captured at CBF-248 instead).  CBF is recomputed below from
+           the restored sp (fixed layout); first publish lisp state back
+           to the tcr (ppc:5159-5169). */
         str allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5166-5169     */
         str allocbase, [rcontext, #tcr.save_allocbase]
         str vsp,       [rcontext, #tcr.save_vsp]
@@ -6860,7 +6876,12 @@ spentry callback
         add imm2, sp, #(6*16 + 4*16)            /* imm2 = CBF                */
         ldr x0, [imm2]                          /* GPR result (ppc:5213-5214)*/
         ldr x1, [imm2, #8]
-        ldur d0, [imm2, #-64]                   /* FPR result                */
+        /* FPR result: d0-d3 from the fp save slots -- an HFA return
+           occupies up to four V registers, one member each (AAPCS64
+           6.9); a scalar FP result only means d0, and for any non-FP
+           return all four are dead scratch the C caller ignores. */
+        ldp d0, d1, [imm2, #-64]
+        ldp d2, d3, [imm2, #-48]
         /* Restore callee-saved GPRs (ppc:5179-5197) and pop the arg-save
            areas (ppc:5212); x0/x1/d0 carry the result (ppc:5225 blr). */
         ldp x29, lr,  [sp], #16

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -6580,6 +6580,113 @@ spentry ffcall_return_registers
         ret
 endsp ffcall_return_registers
 
+/* Just like ffcall, but the record-by-value result is >16 bytes and not
+ * an HFA, so AAPCS64 (6.9) wants the caller-allocated result buffer's
+ * address in x8 (the indirect result-area register) at the call.  The
+ * buffer's MACPTR rides in arg_y (exactly as ffcall_return_registers'
+ * regbuf does); its address is loaded into x8 alongside the x0-x7
+ * argument loads.  x8 needs no channel through the c_frame: the plain
+ * ffcall body never touches arg_w=x8 between entry and the blr, and the
+ * common return path re-nils it.  No PPC analog: PowerOpen (and SysV)
+ * pass the hidden result pointer as the FIRST integer argument; AAPCS64
+ * alone dedicates x8. */
+spentry ffcall_indirect_result
+        str fn, [vsp, #-node_size]!
+        str save3, [vsp, #-node_size]!
+        mov save3, sp
+        /* Boundary lisp_frame park + header shrink -- byte-identical to
+         * `spentry ffcall' (arm64-spentry.s), whose comments are the
+         * canonical note. */
+        ldr imm0, [sp, #c_frame.header]
+        lsr imm1, imm0, #num_subtag_bits        /* element count = words-1 */
+        sub imm1, imm1, #3
+        mov imm2, sp                            /* add-shifted with Rn=sp is */
+        add imm2, imm2, imm1, lsl #node_shift   /* an encoding trap */
+        mov imm1, #lisp_frame_marker
+        str imm1, [imm2, #lisp_frame.marker]
+        str vsp, [imm2, #lisp_frame.savevsp]
+        str fn,  [imm2, #lisp_frame.savefn]
+        str lr,  [imm2, #lisp_frame.savelr]
+        sub imm0, imm0, #(4 << num_subtag_bits)
+        str imm0, [sp, #c_frame.header]
+        /* Unbox the entry point into temp4 (canonical note: `spentry
+           ffcall', arm64-spentry.s; the bare-tst trap is 16m5l). */
+        and imm2, arg_z, #fulltagmask
+        cmp imm2, #fulltag_misc
+        b.ne 8f
+        ldurb w2, [arg_z, #misc_subtag_offset]
+        cmp imm2, #subtag_macptr
+        b.ne 8f
+        ldur temp4, [arg_z, #macptr.address]
+        b 9f
+8:      mov temp4, arg_z        // fixnum-locative / raw code address
+9:
+        /* Publish lisp state to the TCR for the GC, then go foreign. */
+        str vsp, [rcontext, #tcr.save_vsp]
+        str tsp, [rcontext, #tcr.save_tsp]
+        str allocptr, [rcontext, #tcr.save_allocptr]
+        str allocbase, [rcontext, #tcr.save_allocbase]
+        /* Load the outgoing GPR args; keep SP at the frame head (stack
+         * args refused loud in the codegen -- see `spentry ffcall'). */
+        ldp x0, x1, [sp, #c_frame.params]
+        ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
+        ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
+        ldp x6, x7, [sp, #(c_frame.params + 6*node_size)]
+        /* THE VARIANT'S ONE ADDITION: indirect result-area pointer.
+         * arg_y is still live (nothing above touches it) and x8 is dead
+         * from here to the blr; the callee writes the record through x8
+         * and returns void. */
+        ldur x8, [arg_y, #macptr.address]
+        /* Boundary bookkeeping + valence, identical to `spentry ffcall'
+         * (arm64-spentry.s) -- see the protocol note at the top of this
+         * file.  temp0, not imm0: imm0 is x0, now an outgoing argument. */
+        ldr temp0, [rcontext, #tcr.last_lisp_frame]
+        str temp0, [sp, #c_frame.params]
+        mov temp0, sp
+        str temp0, [rcontext, #tcr.last_lisp_frame]
+        mov temp0, #TCR_STATE_FOREIGN
+        str temp0, [rcontext, #tcr.valence]
+        /* FPSR capture window -- canonical note: `spentry ffcall'. */
+        msr fpsr, xzr
+        blr temp4
+        /* ---- common return path (= `spentry ffcall') ---- */
+        mrs imm1, fpsr
+        str imm1, [rcontext, #tcr.foreign_fpsr]
+        msr fpsr, xzr
+        /* A GC may have run while we were foreign. */
+        ldr allocptr, [rcontext, #tcr.save_allocptr]
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        /* lr from the boundary lisp_frame; sp from the SAVED SP word, not
+         * the header at offset 0 (16m30).  Count already shrunk by 4, so
+         * reserved_base = save3 + node_size*(count+1).  imm1/imm2 only. */
+        ldr imm1, [save3, #c_frame.header]
+        lsr imm1, imm1, #num_subtag_bits
+        add imm1, imm1, #1
+        add imm2, save3, imm1, lsl #node_shift
+        ldr lr, [imm2, #lisp_frame.savelr]
+        ldr imm1, [save3, #c_frame.savedsp]
+        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
+        ldr imm2, [save3, #c_frame.params]
+        str imm2, [rcontext, #tcr.last_lisp_frame]
+        mov sp, imm1
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        mov arg_w, rnil
+        mov arg_x, rnil
+        mov arg_y, rnil
+        mov arg_z, rnil
+        mov temp0, rnil
+        mov temp1, rnil
+        mov temp2, rnil
+        mov temp3, rnil
+        mov temp4, rnil
+        mov temp5, rnil
+        mov nargs, xzr
+        str xzr, [rcontext, #tcr.valence]   // TCR_STATE_LISP
+        check_pending_interrupt
+        ret
+endsp ffcall_indirect_result
+
 /* Deprecated "swap exception handling info" variant.  TRAP-ONLY ON PPC64
  * TOO: ppc-spentry.s:3526-3527 is just `.long 0x7c800008` (debug trap). */
 spentry ffcallX
@@ -7313,4 +7420,5 @@ C(sptab):
         .quad _SPcallbuiltin3 // 129 SPcallbuiltin3 (PROPOSED extension, 16m5f)
         .quad _SPlexpr_entry // 130 SPlexpr_entry (PROPOSED extension, 16m5f)
         .quad _SPnmkunwind // 131 SPnmkunwind (PROPOSED extension, 16m5f)
+        .quad _SPffcall_indirect_result // 132 SPffcall_indirect_result (PROPOSED extension, 16m71)
 C(sptab_end):

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -123,8 +123,9 @@ endsp makeu64
  *   lr    = return address in the compiled caller.
  *
  * Exit: C integer result in x0 (= imm0), FP result in d0; the c_frame
- * is popped (sp restored from its backlink); no node register holds
- * C garbage.
+ * is popped (sp lands on the saved previous SP by dropping the
+ * boundary lisp_frame reserved at the frame top); no node register
+ * holds C garbage.
  *
  * Register notes: x19-x28 (save0-3, rnil, tsp, vsp, allocptr,
  * allocbase, rcontext) are AAPCS64 callee-saved, so the pinned lisp
@@ -154,10 +155,23 @@ endsp makeu64
  * this spentry owns is the right seam.
  */
 spentry ffcall
+        /* Spill fn AND all four boxed NVRs to the vstack (the protocol the
+         * spentry-E-ffi.s header always prescribed: "save0-3 are still
+         * vpushed so the GC can SEE them while the thread is foreign").
+         * tcr.save_vsp is published below this spill, so a foreign-era GC
+         * keeps and RELOCATES these five values; they are reloaded -- with
+         * any relocation applied -- after the call.  A conforming callee
+         * preserves x19-x22, but preservation is not FORWARDING: a lisp
+         * value that stays only in an NVR register across the call misses
+         * any GC relocation.  save0/save1 (and, in the siblings, save2/
+         * save3) also carry raw kernel state across the call from here on:
+         * 8/16-aligned stack addresses, which mark_xp/forward_xp read as
+         * fixnums (no-op roots) whenever we are suspended in lisp valence. */
         str fn, [vsp, #-node_size]!
-        /* save3 carries the frame base across the call (callee-saved);
-         * its lisp value is parked next to fn. */
         str save3, [vsp, #-node_size]!
+        str save2, [vsp, #-node_size]!
+        str save1, [vsp, #-node_size]!
+        str save0, [vsp, #-node_size]!
         mov save3, sp
         /* ---- THE BOUNDARY LISP FRAME (16m30; canonical note, the two
          * siblings in spentry-E-ffi.s point here) ----
@@ -192,10 +206,34 @@ spentry ffcall
         mov imm1, #lisp_frame_marker
         str imm1, [imm2, #lisp_frame.marker]
         str vsp, [imm2, #lisp_frame.savevsp]
-        str fn,  [imm2, #lisp_frame.savefn]
-        str lr,  [imm2, #lisp_frame.savelr]
+        /* Build order is the alloc-c-frame contract (the design note at
+         * arm64-vinsns.lisp ALLOC-C-FRAME spells it out): a slot that is
+         * still COVERED by the u64-vector header is invisible to the GC,
+         * so a real fn/lr stored here before the count shrink goes STALE
+         * if a GC moves the caller in that window -- the register and
+         * vstack copies are forwarded, the covered slot is not, and the
+         * return path reads savelr back from this frame.  So: harmless
+         * zeros while covered, publish, THEN stp the real fn/lr into the
+         * frame the GC now walks and forwards.  marker/savevsp may be
+         * prestored: a constant and a never-relocated stack address. */
+        stp xzr, xzr, [imm2, #lisp_frame.savefn]
         sub imm0, imm0, #(4 << num_subtag_bits) /* publish the 4 words */
         str imm0, [sp, #c_frame.header]
+        stp fn, lr, [imm2, #lisp_frame.savefn]
+        /* Hoist everything the return path will need out of the frame head
+         * [sp, sp+80) into callee-saved registers: at the blr, SP steps
+         * over header+savedsp+params, putting that region below the
+         * callee's incoming SP, where the callee's own frame (or any
+         * signal frame) clobbers it.
+         *   save1 = the boundary lisp_frame published above (sp is
+         *           restored to it after the call; the previous SP is
+         *           save1 + lisp_frame.size by construction --
+         *           arm642-c-frame-words reserves the 4 boundary words
+         *           directly below the saved previous SP)
+         *   save0 = the enclosing foreign boundary (previously parked in
+         *           param word 0; that park dies with the region) */
+        mov save1, imm2
+        ldr save0, [rcontext, #tcr.last_lisp_frame]
         /* Unbox the entry point into temp4 (x16 = IP0). */
         /* PPC-faithful discrimination (ppc:1802-1814 extract_typecode):
          * macptr iff fulltag_misc AND header subtag == subtag_macptr;
@@ -223,30 +261,29 @@ spentry ffcall
         ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
         ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
         ldp x6, x7, [sp, #(c_frame.params + 6*node_size)]
-        /* AAPCS64, no stack args (<=8 GPR/<=8 FP, enforced loud in the
-         * w13 codegen): keep SP at the frame head -- the callee's stack
-         * grows BELOW its incoming SP, so popping the frame here hands
-         * the saved lr/backlink to the callee as scratch (16m5c crash:
-         * return jumped into the c_frame).  Stack-arg layout = ratify
-         * item (frame head must move above the param area). */
-        /* Record the lisp<->foreign boundary for the GC (16m41; protocol note
-         * in spentry-E-ffi.s).  The walk must start at the c_frame base: word
-         * 0 there is the frame's own ivector header, whose (already shrunk)
-         * count strides exactly onto the boundary lisp_frame built above.
-         * Park the enclosing boundary in param word 0 -- dead now that the
-         * args are loaded, INSIDE the c_frame ivector so the GC never scans
-         * it, and above SP so the callee cannot touch it.
+        /* Record the lisp<->foreign boundary for the GC (16m41 protocol,
+         * re-pointed for stack args): the boundary is now the PUBLISHED
+         * boundary lisp_frame itself -- mark_cstack_area classifies a walk
+         * that STARTS on lisp_frame_marker, exactly as it already does for
+         * the syscall sibling's post-pop boundary -- because the old start
+         * point, the c_frame base, dies once SP steps over it at the blr.
+         * Everything below the boundary is foreign to the GC while the
+         * callee runs, which was already the status of the raw, never-
+         * scanned param/stack-arg words when the ivector cover held them.
          *
-         * ORDER MATTERS, and it is why the arg loads moved above the valence
-         * store: the boundary must be in place BEFORE this thread advertises
-         * foreign valence, or a GC in the window reads a stale boundary and
-         * walks the wrong region (ARM-family ff-call stores it first for the
-         * same reason).  temp0 is scratch: the return path re-nils every temp,
-         * and it is not an AAPCS64 argument register the way imm0 is. */
-        ldr temp0, [rcontext, #tcr.last_lisp_frame]
-        str temp0, [sp, #c_frame.params]
-        mov temp0, sp
-        str temp0, [rcontext, #tcr.last_lisp_frame]
+         * ORDER (one store per step; auditable per instruction boundary):
+         *   1. boundary store BEFORE the valence store (16m41): a GC that
+         *      suspends us FOREIGN must find the new boundary; while we
+         *      are still LISP the walk starts at context SP and this word
+         *      is ignored, so storing it early is inert.
+         *   2. valence store BEFORE the SP step: while LISP the walk
+         *      starts at SP, which must still name the self-describing
+         *      frame head (ivector header striding onto the boundary
+         *      frame); once FOREIGN the walk starts at the boundary and
+         *      SP is free to move.
+         * temp0 is scratch: the return path re-nils every temp, and it is
+         * not an AAPCS64 argument register the way imm0 is. */
+        str save1, [rcontext, #tcr.last_lisp_frame]
         mov temp0, #TCR_STATE_FOREIGN
         str temp0, [rcontext, #tcr.valence]
         /* Open the capture window: discard lisp-side cumulative flags so
@@ -255,37 +292,52 @@ spentry ffcall
          * PSTATE.NZCV is a separate register in AArch64, so this cannot
          * disturb the condition flags. */
         msr fpsr, xzr
+        /* ARM64-DEVIATION: step SP over header+savedsp+params[0..7] so the
+         * callee sees its stack arguments AT [SP], per AAPCS64 5.4.2 (the
+         * single NSAA area the codegen marshals at param words 8..; +80 is
+         * the same c_frame.size + 8 words the syscall sibling steps by).
+         * PPC64 never moves SP here -- PowerOpen stack params live in the
+         * CALLER's frame at positive offsets from the caller's SP; x86-64
+         * is the shape donor (_SPffcall's ffcall_setup pops the frame head
+         * plus 6 GPR words so rsp == &param[6] at the call).  The frame
+         * base is 16-aligned and 80 = 5*16, so SP is 16-byte aligned at
+         * the blr as AAPCS64 requires.  From this instruction on, the
+         * region [old SP, old SP+80) belongs to the callee/signals; every
+         * value the return path needs was hoisted to save0/save1 above. */
+        add sp, sp, #(c_frame.size + 8*node_size)
         blr temp4
-        /* Back.  x0/d0 hold the results; imm1/imm2 are scratch. */
+        /* Back.  x0/d0 hold the results.  [save3, save3+80) is DEAD -- it
+         * sat below the callee's incoming SP -- so nothing on this path may
+         * read the c_frame head: the return runs entirely from the save0/
+         * save1 hoist.  x0/d0 are never touched: imm1/imm2 scratch only. */
         mrs imm1, fpsr
         str imm1, [rcontext, #tcr.foreign_fpsr]
         msr fpsr, xzr
-        /* A GC may have run while we were foreign. */
-        ldr allocptr, [rcontext, #tcr.save_allocptr]
-        ldr allocbase, [rcontext, #tcr.save_allocbase]
-        /* Recover lr from the boundary lisp_frame and sp from the SAVED SP
-         * word -- not from offset 0, which is the header (16m30, see the
-         * entry note).  The count has already been shrunk by 4, so
-         * reserved_base = save3 + node_size*(count + 1).  x0/d0 hold the
-         * results: imm1/imm2 only, never imm0.
-         * SUBPRIM-POPS is the w13 contract: the caller's epilogue runs with
-         * sp back at its own lisp frame (confirmed against the emitted
-         * MAKE-GCABLE-MACPTR epilogue, which pops a 32-byte frame at sp). */
-        ldr imm1, [save3, #c_frame.header]
-        lsr imm1, imm1, #num_subtag_bits
-        add imm1, imm1, #1
-        add imm2, save3, imm1, lsl #node_shift
-        ldr lr, [imm2, #lisp_frame.savelr]
-        ldr imm1, [save3, #c_frame.savedsp]
-        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
-        ldr imm2, [save3, #c_frame.params]
-        str imm2, [rcontext, #tcr.last_lisp_frame]
-        mov sp, imm1
-        ldr save3, [vsp], #node_size
-        ldr fn, [vsp], #node_size
-        /* Clear C garbage out of the volatile node registers, then --
-         * and only then -- declare lisp valence: the GC must never see
-         * a stale pointer in a node register of a lisp-valence thread. */
+        /* Retreat SP onto the boundary lisp_frame (it sat at/above the
+         * callee's incoming SP, so it is intact, and the foreign-era GC has
+         * been walking AND FORWARDING its slots).  This is PPC64's shape:
+         * poweropen_ffcall likewise returns onto the boundary frame, reads
+         * savelr/savefn from it after the valence flip, then discards it.
+         * The saved previous SP is not needed: the frame top IS the
+         * previous SP (arm642-c-frame-words reserves these 4 words directly
+         * below it), so the discard below lands sp exactly there --
+         * SUBPRIM-POPS, the w13 contract. */
+        mov sp, save1
+        /* Make EVERY node register GC-valid, then -- and only then -- flip
+         * to lisp valence; every reload moves BELOW the flip (donor order:
+         * ppc-spentry.s poweropen_ffcall tail and the x86-64 ffcall tail
+         * both zero/nil the node set, flip, then pop).  Popping an NVR
+         * while still FOREIGN was a stale-register window: a GC after the
+         * pop forwards the vstack slot but never the register.  After the
+         * flip the suspended context IS this thread's GC image --
+         * mark_xp/forward_xp cover the registers, and the still-unpopped
+         * slots stay inside the context-vsp scan -- so each pop reads a
+         * forwarded slot into a forwarded register file.  save0 (a raw
+         * cstack address) stays live across the flip: it reads as a fixnum,
+         * so it is GC-valid without being nil'd.  allocptr/allocbase cross
+         * the flip as VOID_ALLOCPTR (PPC's li allocptr,-dnode_size idiom):
+         * their pre-call register values are stale if a foreign-era GC ran,
+         * and normalize_tcr treats VOID as "no allocation in flight". */
         mov arg_w, rnil
         mov arg_x, rnil
         mov arg_y, rnil
@@ -297,7 +349,41 @@ spentry ffcall
         mov temp4, rnil
         mov temp5, rnil
         mov nargs, xzr
+        mov fn, rnil
+        mov save1, xzr
+        mov save2, xzr
+        mov save3, xzr
+        mov allocptr, #-dnode_size          // VOID_ALLOCPTR
+        mov allocbase, #-dnode_size
         str xzr, [rcontext, #tcr.valence]   // TCR_STATE_LISP
+        /* Hand the enclosing foreign boundary back.  Post-flip on purpose:
+         * while we were foreign the boundary had to keep naming OUR
+         * lisp_frame (handing it back early would have cut the caller's
+         * frames out of the foreign walk); now that valence is LISP the
+         * walk starts at context SP and this word is dormant until the
+         * next foreign transition.  A signal/uuo in the window saves and
+         * re-points it itself (exit_signal_handler restores), so lisp run
+         * under an interrupt here still nests correctly. */
+        str save0, [rcontext, #tcr.last_lisp_frame]
+        /* lr from the frame AT [sp], AFTER the flip: from the flip onward
+         * the GC forwards the context's LR/PC, and until the flip it
+         * forwarded the frame slot we read from -- no instruction boundary
+         * where a relocated caller leaves a stale return pc.  (The old
+         * pre-flip read had exactly that hole, foreign-GC-after-read.) */
+        ldr lr, [sp, #lisp_frame.savelr]
+        /* Reload the NVRs from their (possibly forwarded) vstack slots and
+         * the allocation pointers from the TCR -- a foreign-era GC leaves
+         * VOID_ALLOCPTR there, which forces a fresh segment at the next
+         * allocation, as intended. */
+        ldr save0, [vsp], #node_size
+        ldr save1, [vsp], #node_size
+        ldr save2, [vsp], #node_size
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        ldr allocptr, [rcontext, #tcr.save_allocptr]
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        /* Drop the 32-byte boundary frame: sp = the saved previous SP. */
+        add sp, sp, #lisp_frame.size
         /* Take any interrupt that was DEFERRED while we held foreign valence
          * (ppc:1691 check_pending_interrupt(cr1), at the same seam: after the
          * valence store, immediately before returning to lisp).  16m57 ROOT:
@@ -6457,8 +6543,16 @@ _ends
  * at the return; save2 carries the buffer address across the call
  * (callee-saved), parked on the vstack like save3/fn. */
 spentry ffcall_return_registers
+        /* fn + all four boxed NVRs, exactly as `spentry ffcall'
+         * (arm64-spentry.s -- the CANONICAL NOTE for this whole body): the
+         * vstack copies are what the GC forwards while we are foreign; the
+         * registers carry raw kernel state (and the result buffer) across
+         * the call and are reloaded, relocations applied, after it. */
         str fn, [vsp, #-node_size]!             /* ppc:1799 vpush_saveregs   */
         str save3, [vsp, #-node_size]!
+        str save2, [vsp, #-node_size]!
+        str save1, [vsp, #-node_size]!
+        str save0, [vsp, #-node_size]!
         mov save3, sp
         /* Park lr in the boundary lisp_frame his alloc-c-frame RESERVED at the
          * frame top, and publish it by shrinking the header count by 4.  The
@@ -6473,12 +6567,18 @@ spentry ffcall_return_registers
         mov imm1, #lisp_frame_marker
         str imm1, [imm2, #lisp_frame.marker]
         str vsp, [imm2, #lisp_frame.savevsp]
-        str fn,  [imm2, #lisp_frame.savefn]
-        str lr,  [imm2, #lisp_frame.savelr]
+        /* Zeros while covered, publish, THEN the real fn/lr -- the
+         * alloc-c-frame build contract; rationale at the canonical note. */
+        stp xzr, xzr, [imm2, #lisp_frame.savefn]
         sub imm0, imm0, #(4 << num_subtag_bits)
         str imm0, [sp, #c_frame.header]
-        /* Buffer address -> save2 (PPC uses save7, ppc:1800). */
-        str save2, [vsp, #-node_size]!
+        stp fn, lr, [imm2, #lisp_frame.savefn]
+        /* Cross-call hoist (canonical note): the frame head [sp, sp+80)
+         * dies once SP steps over it at the blr. */
+        mov save1, imm2                         /* boundary lisp_frame       */
+        ldr save0, [rcontext, #tcr.last_lisp_frame] /* enclosing boundary    */
+        /* Buffer address -> save2 (PPC uses save7, ppc:1800); its lisp
+         * value is already in the 5-slot vstack spill above. */
         ldur save2, [arg_y, #macptr.address]
         /* Unbox the entry point into temp4 (ppc:1802-1814
            extract_typecode): macptr iff fulltag_misc AND header subtag
@@ -6501,35 +6601,28 @@ spentry ffcall_return_registers
         str tsp, [rcontext, #tcr.save_tsp]
         str allocptr, [rcontext, #tcr.save_allocptr]
         str allocbase, [rcontext, #tcr.save_allocbase]
-        /* Load the outgoing GPR args and pop the frame head + param
-           words so stack args sit exactly at SP (ppc:1836-1843).
-           Above the valence store since 16m41: see the ordering note in
-           `spentry ffcall' (arm64-spentry.s) -- the boundary has to be
-           recorded before this thread advertises foreign valence, and the
-           park slot is only dead once the args are loaded. */
+        /* Load the outgoing GPR args (ppc:1836-1843); the SP step that
+           puts the NSAA stack args at [SP] comes after the valence flip,
+           per the ordering note in `spentry ffcall' (arm64-spentry.s). */
         ldp x0, x1, [sp, #c_frame.params]
         ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
         ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
         ldp x6, x7, [sp, #(c_frame.params + 6*node_size)]
-        /* AAPCS64, no stack args (<=8 GPR/<=8 FP, enforced loud in the
-         * w13 codegen): keep SP at the frame head -- the callee's stack
-         * grows BELOW its incoming SP, so popping the frame here hands
-         * the saved lr/backlink to the callee as scratch (16m5c crash in
-         * the _SPffcall twin: return jumped into the c_frame).  Stack-arg
-         * layout = ratify item (frame head must move above params). */
-        /* Boundary bookkeeping + valence, identical to `spentry ffcall' in
-         * arm64-spentry.s -- see the protocol note at the top of this file.
+        /* Boundary bookkeeping + valence + SP step, identical to `spentry
+         * ffcall' in arm64-spentry.s (the ordering rationale lives there):
+         * boundary = the published lisp_frame, stored before the valence
+         * flip; after the flip SP steps over the doomed frame head, putting
+         * the NSAA stack args at [SP] for the callee.
          * temp0, not imm0: imm0 is x0, now an outgoing argument. */
-        ldr temp0, [rcontext, #tcr.last_lisp_frame]
-        str temp0, [sp, #c_frame.params]
-        mov temp0, sp
-        str temp0, [rcontext, #tcr.last_lisp_frame]
+        str save1, [rcontext, #tcr.last_lisp_frame]
         mov temp0, #TCR_STATE_FOREIGN
         str temp0, [rcontext, #tcr.valence]
         /* Open the FPSR capture window -- FPSR is cumulative, so clearing it
            only on the way back publishes every flag raised since the PREVIOUS
            ff-call.  Canonical note: `spentry ffcall' in arm64-spentry.s. */
         msr fpsr, xzr
+        add sp, sp, #(c_frame.size + 8*node_size) /* ARM64-DEVIATION: NSAA
+                          stack args at [SP]; canonical note in ffcall */
         blr temp4                               /* ppc:1849 bctrl            */
         /* Store every AAPCS64 result register into the buffer
            (ppc:1851-1871 stores r3-r10/f1-f13). */
@@ -6541,29 +6634,13 @@ spentry ffcall_return_registers
         stp d2, d3, [save2, #((8*node_size) + 2*8)]
         stp d4, d5, [save2, #((8*node_size) + 4*8)]
         stp d6, d7, [save2, #((8*node_size) + 6*8)]
-        /* ---- common return path (= patch-0003 ffcall) ---- */
+        /* ---- common return path (= `spentry ffcall', arm64-spentry.s;
+         * the per-boundary GC audit lives there).  The frame head
+         * [save3, save3+80) is DEAD; run entirely from the hoist. ---- */
         mrs imm1, fpsr
         str imm1, [rcontext, #tcr.foreign_fpsr]
         msr fpsr, xzr
-        /* A GC may have run while we were foreign. */
-        ldr allocptr, [rcontext, #tcr.save_allocptr]
-        ldr allocbase, [rcontext, #tcr.save_allocbase]
-        /* lr from the boundary lisp_frame; sp from the SAVED SP word, not the
-         * header at offset 0 (16m30).  Count is already shrunk by 4, so
-         * reserved_base = save3 + node_size*(count+1).  imm1/imm2 only. */
-        ldr imm1, [save3, #c_frame.header]
-        lsr imm1, imm1, #num_subtag_bits
-        add imm1, imm1, #1
-        add imm2, save3, imm1, lsl #node_shift
-        ldr lr, [imm2, #lisp_frame.savelr]
-        ldr imm1, [save3, #c_frame.savedsp]
-        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
-        ldr imm2, [save3, #c_frame.params]
-        str imm2, [rcontext, #tcr.last_lisp_frame]
-        mov sp, imm1
-        ldr save2, [vsp], #node_size
-        ldr save3, [vsp], #node_size
-        ldr fn, [vsp], #node_size
+        mov sp, save1                       /* retreat onto the boundary frame */
         mov arg_w, rnil
         mov arg_x, rnil
         mov arg_y, rnil
@@ -6575,7 +6652,23 @@ spentry ffcall_return_registers
         mov temp4, rnil
         mov temp5, rnil
         mov nargs, xzr
+        mov fn, rnil
+        mov save1, xzr
+        mov save2, xzr
+        mov save3, xzr
+        mov allocptr, #-dnode_size          // VOID_ALLOCPTR (ppc idiom)
+        mov allocbase, #-dnode_size
         str xzr, [rcontext, #tcr.valence]   // TCR_STATE_LISP
+        str save0, [rcontext, #tcr.last_lisp_frame] /* enclosing boundary back */
+        ldr lr, [sp, #lisp_frame.savelr]    /* post-flip: GC-forwarded */
+        ldr save0, [vsp], #node_size
+        ldr save1, [vsp], #node_size
+        ldr save2, [vsp], #node_size
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        ldr allocptr, [rcontext, #tcr.save_allocptr]
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        add sp, sp, #lisp_frame.size        /* drop the frame: sp = prev SP */
         check_pending_interrupt
         ret
 endsp ffcall_return_registers
@@ -6591,12 +6684,18 @@ endsp ffcall_return_registers
  * pass the hidden result pointer as the FIRST integer argument; AAPCS64
  * alone dedicates x8. */
 spentry ffcall_indirect_result
+        /* fn + all four boxed NVRs -- byte-identical to `spentry ffcall'
+         * (arm64-spentry.s), whose comments are the canonical note. */
         str fn, [vsp, #-node_size]!
         str save3, [vsp, #-node_size]!
+        str save2, [vsp, #-node_size]!
+        str save1, [vsp, #-node_size]!
+        str save0, [vsp, #-node_size]!
         mov save3, sp
-        /* Boundary lisp_frame park + header shrink -- byte-identical to
-         * `spentry ffcall' (arm64-spentry.s), whose comments are the
-         * canonical note. */
+        /* Boundary lisp_frame build (zeros while covered, publish, then
+         * the real fn/lr) + cross-call hoist -- byte-identical to `spentry
+         * ffcall' (arm64-spentry.s), whose comments are the canonical
+         * note. */
         ldr imm0, [sp, #c_frame.header]
         lsr imm1, imm0, #num_subtag_bits        /* element count = words-1 */
         sub imm1, imm1, #3
@@ -6605,10 +6704,12 @@ spentry ffcall_indirect_result
         mov imm1, #lisp_frame_marker
         str imm1, [imm2, #lisp_frame.marker]
         str vsp, [imm2, #lisp_frame.savevsp]
-        str fn,  [imm2, #lisp_frame.savefn]
-        str lr,  [imm2, #lisp_frame.savelr]
+        stp xzr, xzr, [imm2, #lisp_frame.savefn]
         sub imm0, imm0, #(4 << num_subtag_bits)
         str imm0, [sp, #c_frame.header]
+        stp fn, lr, [imm2, #lisp_frame.savefn]
+        mov save1, imm2                         /* boundary lisp_frame       */
+        ldr save0, [rcontext, #tcr.last_lisp_frame] /* enclosing boundary    */
         /* Unbox the entry point into temp4 (canonical note: `spentry
            ffcall', arm64-spentry.s; the bare-tst trap is 16m5l). */
         and imm2, arg_z, #fulltagmask
@@ -6626,8 +6727,9 @@ spentry ffcall_indirect_result
         str tsp, [rcontext, #tcr.save_tsp]
         str allocptr, [rcontext, #tcr.save_allocptr]
         str allocbase, [rcontext, #tcr.save_allocbase]
-        /* Load the outgoing GPR args; keep SP at the frame head (stack
-         * args refused loud in the codegen -- see `spentry ffcall'). */
+        /* Load the outgoing GPR args; the SP step that exposes the NSAA
+         * stack args at [SP] comes after the valence flip, per the
+         * ordering note in `spentry ffcall' (arm64-spentry.s). */
         ldp x0, x1, [sp, #c_frame.params]
         ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
         ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
@@ -6637,40 +6739,24 @@ spentry ffcall_indirect_result
          * from here to the blr; the callee writes the record through x8
          * and returns void. */
         ldur x8, [arg_y, #macptr.address]
-        /* Boundary bookkeeping + valence, identical to `spentry ffcall'
-         * (arm64-spentry.s) -- see the protocol note at the top of this
-         * file.  temp0, not imm0: imm0 is x0, now an outgoing argument. */
-        ldr temp0, [rcontext, #tcr.last_lisp_frame]
-        str temp0, [sp, #c_frame.params]
-        mov temp0, sp
-        str temp0, [rcontext, #tcr.last_lisp_frame]
+        /* Boundary bookkeeping + valence + SP step, identical to `spentry
+         * ffcall' (arm64-spentry.s) -- the ordering rationale lives there.
+         * temp0, not imm0: imm0 is x0, now an outgoing argument. */
+        str save1, [rcontext, #tcr.last_lisp_frame]
         mov temp0, #TCR_STATE_FOREIGN
         str temp0, [rcontext, #tcr.valence]
         /* FPSR capture window -- canonical note: `spentry ffcall'. */
         msr fpsr, xzr
+        add sp, sp, #(c_frame.size + 8*node_size) /* ARM64-DEVIATION: NSAA
+                          stack args at [SP]; canonical note in ffcall */
         blr temp4
-        /* ---- common return path (= `spentry ffcall') ---- */
+        /* ---- common return path (= `spentry ffcall', arm64-spentry.s;
+         * the per-boundary GC audit lives there).  The frame head
+         * [save3, save3+80) is DEAD; run entirely from the hoist. ---- */
         mrs imm1, fpsr
         str imm1, [rcontext, #tcr.foreign_fpsr]
         msr fpsr, xzr
-        /* A GC may have run while we were foreign. */
-        ldr allocptr, [rcontext, #tcr.save_allocptr]
-        ldr allocbase, [rcontext, #tcr.save_allocbase]
-        /* lr from the boundary lisp_frame; sp from the SAVED SP word, not
-         * the header at offset 0 (16m30).  Count already shrunk by 4, so
-         * reserved_base = save3 + node_size*(count+1).  imm1/imm2 only. */
-        ldr imm1, [save3, #c_frame.header]
-        lsr imm1, imm1, #num_subtag_bits
-        add imm1, imm1, #1
-        add imm2, save3, imm1, lsl #node_shift
-        ldr lr, [imm2, #lisp_frame.savelr]
-        ldr imm1, [save3, #c_frame.savedsp]
-        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
-        ldr imm2, [save3, #c_frame.params]
-        str imm2, [rcontext, #tcr.last_lisp_frame]
-        mov sp, imm1
-        ldr save3, [vsp], #node_size
-        ldr fn, [vsp], #node_size
+        mov sp, save1                       /* retreat onto the boundary frame */
         mov arg_w, rnil
         mov arg_x, rnil
         mov arg_y, rnil
@@ -6682,7 +6768,23 @@ spentry ffcall_indirect_result
         mov temp4, rnil
         mov temp5, rnil
         mov nargs, xzr
+        mov fn, rnil
+        mov save1, xzr
+        mov save2, xzr
+        mov save3, xzr
+        mov allocptr, #-dnode_size          // VOID_ALLOCPTR (ppc idiom)
+        mov allocbase, #-dnode_size
         str xzr, [rcontext, #tcr.valence]   // TCR_STATE_LISP
+        str save0, [rcontext, #tcr.last_lisp_frame] /* enclosing boundary back */
+        ldr lr, [sp, #lisp_frame.savelr]    /* post-flip: GC-forwarded */
+        ldr save0, [vsp], #node_size
+        ldr save1, [vsp], #node_size
+        ldr save2, [vsp], #node_size
+        ldr save3, [vsp], #node_size
+        ldr fn, [vsp], #node_size
+        ldr allocptr, [rcontext, #tcr.save_allocptr]
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        add sp, sp, #lisp_frame.size        /* drop the frame: sp = prev SP */
         check_pending_interrupt
         ret
 endsp ffcall_indirect_result
@@ -6928,10 +7030,16 @@ spentry syscall
         mov imm1, #lisp_frame_marker
         str imm1, [imm2, #lisp_frame.marker]
         str vsp, [imm2, #lisp_frame.savevsp]
-        str fn,  [imm2, #lisp_frame.savefn]
-        str lr,  [imm2, #lisp_frame.savelr]
+        /* Zeros while covered, publish, THEN the real fn/lr (the
+         * alloc-c-frame build contract; rationale at the canonical note in
+         * `spentry ffcall', arm64-spentry.s): a covered slot is invisible
+         * to the GC, so a real fn/lr stored pre-publish goes stale if a GC
+         * moves the caller in the window -- and this path reads savelr
+         * back after the svc. */
+        stp xzr, xzr, [imm2, #lisp_frame.savefn]
         sub imm0, imm0, #(4 << num_subtag_bits)
         str imm0, [sp, #c_frame.header]
+        stp fn, lr, [imm2, #lisp_frame.savefn]
         /* Publish lisp state to the TCR for the GC, then go foreign
            (ppc:5405-5422). */
         str vsp, [rcontext, #tcr.save_vsp]


### PR DESCRIPTION
Eight commits completing the AAPCS64 side of the linuxarm64 FFI: record returns,
HFA/HVA classification, the callback direction, foreign-call **stack arguments**,
and the unboxed-`u64` operators the FFI paths need. Based on `arm64` at 933c9276.

Independent of #571 — the two branches merge cleanly in either order. I have
verified this branch also merges cleanly into `arm64` as it stands today (i.e.
with #571 in), so there is nothing to rebase.

### The commits

1. **interpreted `%FF-CALL`** — so a toplevel `EXTERNAL-CALL` works at all. Until
   this, `%ff-call` only existed as a compiled path.
2. **HFA/HVA classification + register-returned records** — the AAPCS64 rules for
   which aggregates come back in `v0`-`v3` / `x0`-`x1` rather than through memory.
3. **`>16`-byte non-HFA record returns in `x8`** — the AAPCS64 indirect result
   pointer, plus the `.SPffcall-indirect-result` entry.
4. **callback HFA arguments and register-returned records** — the lib-only half.
5. **callback kernel half** — reload `d0`-`d3`, capture the incoming `x8`, and
   move the callback index off `x8` so it survives.
6. **natural (unboxed `u64`) arithmetic and shift operators** — closes four
   operator gaps the paths above hit.
7. **stack arguments in foreign calls** — one NSAA area, both register classes.
8. **whole-composite stack arguments (C.3 / C.11)** and NSAA in the interpreted
   `%ff-call`.

Commits 7 and 8 are new since you last saw this branch; they are appended, so
1-6 are the same commits with the same shas. The rest of this description is
about them.

### 7. Stack arguments: the compiler was already right; `.SPffcall` was not

More than 8 GPR arguments (or more than 8 FP arguments) was not slow or subtly
wrong, it was **refused**:

```
CCL::COMPILER-BUG: aapcs64-ff-call: more than 8 GPR args (12)
                   -- stack-arg frame layout not ratified
```

That refusal is honest, because the codegen alone could not make such a call
work. But it is only half the story, and the half that was missing is small.

**The counting pass already did the AAPCS64 assignment.** Pass 1 already counts
overflow arguments into `nother-words`, `nother-words` is already included in
`single-words`/`total-words` so the c-frame is already sized for them, and pass 2
already stores arguments 9..N at param words 8, 9, 10… That block is already
contiguous, ascending, left-to-right, 8-byte slots, and 16-byte aligned. It is
already a valid NSAA.

**The one defect was that the callee never saw it.** `.SPffcall` kept SP at the
frame head across the `blr`, so a callee looking for its stack arguments at
`[SP]` read the c-frame's `u64`-vector header.

The fix is to step SP over `header + savedsp + params[0..7]` — `c_frame.size +
8*node_size`, the constant `.SPsyscall` in this same kernel already steps by —
immediately before the `blr`, so the overflow block sits **at** `[SP]` per
AAPCS64 5.4.2.

Cross-port, in the order I look:

* **PPC64 has no answer to copy, because it has no such problem.** In PowerOpen
  the stack parameters live in the *caller's* frame at a positive offset from
  the caller's SP, so `poweropen_ffcall` never has to move SP onto them.
* **x86-64 is the exact analog** and does exactly this. `_SPffcall` in
  `x86-spentry64.s` skips the header and frame-pointer words, pops the six GPR
  words, and calls with `rsp == &param[6]`; it survives the callee clobbering
  everything below the new `rsp` by keeping the one thing it still needs — the
  previous foreign SP — in callee-saved `%rbp`.

Everything the return path used to re-read from the frame head is therefore
hoisted into callee-saved registers before the call, because that whole region
is below the callee's incoming SP and dies there: `save1` holds the boundary
`lisp_frame`, `save0` the enclosing foreign boundary (whose park in param word 0
disappears entirely). `tcr.last_lisp_frame` now points at the published boundary
`lisp_frame` itself, which `mark_cstack_area` already accepts as a walk start
since it classifies a frame that begins with the marker.

Applied to all three variants: `.SPffcall`, `.SPffcall_return_registers`, and
`.SPffcall_indirect_result` (commit 3's).

### GC atomicity, again — three windows in the same seams

While auditing the new sequences instruction boundary by instruction boundary I
found three pre-existing windows of exactly the class you caught in #571 (one
instruction makes the *push* atomic, not the *frame*):

1. **The boundary `lisp_frame` was built with the real `fn`/`lr` stored while the
   frame was still covered by the `u64`-vector header** — where the GC can
   neither see nor forward them. A GC that moves the caller in that window leaves
   a stale `savefn`/`savelr` which the return path then reads back. The
   `ALLOC-C-FRAME` design comment already prescribes the right order (zeros while
   covered, publish via the count shrink, only then store the real `fn`/`lr`); the
   assembly never implemented it. Now it does, at all four sites — the three
   `ffcall` variants and `syscall`.
2. **The return path popped the NVRs and reloaded `allocptr`/`allocbase` while
   still at foreign valence**, where a GC forwards the vstack slot and the TCR
   slot but never the register. The tail now follows the order PPC64 and x86-64
   agree on: make every node register GC-valid, flip valence to lisp, *then* pop
   the (possibly forwarded) slots; `allocptr`/`allocbase` cross the flip as
   `VOID_ALLOCPTR` and are reloaded from the TCR after.
3. All four boxed NVRs are now spilled to the vstack across the call, before the
   boundary frame's `savevsp` is written, so the GC keeps and relocates them.

None of these three is caused by the stack-argument work; the SP move would have
widened (1) and (2), so they are fixed rather than inherited.

`.SPsyscall` gets fix 1 only. Its own tail still pops `save3`/`fn` before the
valence flip — the same window as (2) — which I have deliberately left alone
here: it is pre-existing, it is not widened by anything in this branch, and
`svc` does not clobber the user stack, so its SP/park scheme is safe as it
stands. Worth a separate look, and I am happy to send that separately.

One comment fix rides along: `arm642.lisp`'s header block documented the frame
as `[GP save 8][FP save 8][stack args M]`, which is not the layout — the
single/double-float staging area is *above* the stack arguments and is
variable-size. The comment now describes what the code does.

### 8. AAPCS64 never splits a composite across registers and the stack

Removing the blanket refusals exposed two shapes that the refusals had been
keeping honest, and both would otherwise have compiled to something silently
wrong:

* **An HFA whose members do not all fit in `v0`-`v7`** (C.2 fails): C.3 sends
  the **whole** aggregate to the stack, with natural member packing, and sets
  `NSRN := 8` so every later scalar FP argument stacks too. Member-wise
  `:single-float` decomposition cannot express this: a stacked float member is 4
  bytes, while C.5 widens a scalar single to an 8-byte slot.
* **A 2-doubleword record with exactly one GPR left** (C.10 fails): C.11 wastes
  the odd register — no argument may straddle the register file and the stack —
  and sets `NGRN := 8`, then C.12/C.13 copy the whole record to the NSAA.

Both are expressed in `expand-ff-call` with its running per-class counts: dummy
register-class argforms burn the registers the ABI wastes (dead content per the
callee's prototype, and they keep the backend's own counters in lockstep so
later scalars flow through the overflow arms from commit 7 untouched), and the
aggregate payload is emitted as `ceil(size/8)` words of a new backend argspec
`:stack-doubleword` — one raw 8-byte NSAA slot, never a register. That is C.13's
memory copy, bit for bit. A tail of 4 bytes or fewer is read narrow so the copy
never reads past the object. Composites with 16-byte alignment (C.8/C.12) are
refused precisely rather than silently mis-slotted.

**The burn is the AAPCS64-specific part**, and it is where I deviate from the
x86-64 donor rather than follow it: SysV's MEMORY class burns no registers, so
`x8664-backend.lisp`'s otherwise identical running-counter shape has nothing
equivalent. PPC64 has no analog at all, since PowerOpen reserves a memory slot
per parameter. Noted in the comments.

The interpreted `%ff-call` marshals NSAA arguments too now — one shared stack
offset past the 8 GPR words, advanced in source order, frame sized
`(+ 8 nstack)`. The stock x86-64 `%ff-call` in `x86-def.lisp` is the line donor,
re-counted for AAPCS64.

#### A latent defect this made live

The interpreted `%ff-call` used to pass a constant frame size, so
`alloc-variable-c-frame` had **never been emitted in this port's history**.
Sizing the frame `(+ 8 nstack)` reached it, and it did not work:

* its wired `prevsp` temp was declared `(:imm imm1)`, a mode
  `allocate-temporary-vreg` has no entry for, so the cross-build died at xload
  with `:IMM is not (MEMBER :CRF :U8 … :LISP …)`;
* with that corrected, the vinsn's **unwired** `size` temp was allocated `x1` —
  the same register its **wired** `prevsp` temp claims — so `mov prevsp,sp`
  clobbered the just-computed size and `sub sp,sp,size` zeroed SP. Observed
  directly in a boot core: `sp == 0` at the faulting `stp`.

Fixed by wiring all three temps `:u64` to `imm0`/`imm1`/`imm2`, which leaves the
`imm0`/`imm1` `stp` encoding `pc_luser_xp` pattern-matches unchanged. The
general hazard is worth knowing about independently of this branch: the temp
allocator does not exclude a wired temp's register from the unwired pool, so any
template mixing wired and unwired temps can collide.

Separately, and pre-existing: the *compiled* `%ff-call` special form accepts
integer word-count argument specs through `nx1` that `arm642` has no case for,
and dies with `Unknown gpr mode name: NIL`. `expand-ff-call` never emits them,
so it is reachable only from hand-written `%ff-call` forms. Not touched here.

### Why this mattered in practice

An aarch64 Oracle client driven through CCL's FFI needs functions taking 12, 11
and 10 integer arguments. They were not slow or subtly wrong — they were
un-callable, and one of them defines an output variable, so no query could run
at all. That is what prompted commit 7.

### Testing

A dedicated test with a C fixture, 21 cases, each argument carrying a distinct
bit so a wrong slot names itself: the 12/11/10-integer shapes; 9 and 10 doubles;
an `int,double,int` interleave that kills any per-class marshaller; GPR overflow
under live FP registers; a stacked single-float (C.5 widening); a pure-FP
single/double NSAA mix; 12-integer calls under forced GC; the C.3 and C.11
aggregate cases; the interpreted-`%ff-call` cases; and two negative controls
(an HFA that fits, a 16-byte record that fits).

* **Watched red first, by message and not merely by failure.** Before commit 7:
  10/10 fail, every one in `COMPILE` with the exact refusal text. Before commit
  8: 9 of 21 fail, the five aggregate cases with the expander's exact refusal
  texts and the four interpreted cases with `%ff-call`'s, while the other 12 —
  including both negative controls — pass in the same run.
* **Checked against stock x86-64 CCL as the oracle**: the same test file and
  fixture pass `21/0` there, so the test is testing the ABI and not this port.
* **Green after**: `21/0`, on both the bootstrap and the purified image.
* **Cross-build** `rc0=0 rc1=0 rc2=0`; **ANSI `21679/0`** and **`ccl.lsp`
  `243/0`** on Graviton with the new pair, `EXIT:0`. Both the image and the
  kernel md5 moved, so the change demonstrably reached the binaries.

The caveat I flagged for #571 still applies and applies more here: ANSI does not
reach FFI, callbacks, or the GC-atomicity paths by construction, so `21679/0` is
not coverage evidence for this branch. The 21-case test and the red controls are.

### One non-arm64 file, deliberately

`compiler/nx1.lisp` gets a nine-line change in commit 3. The existing check
special-cases `:registers` — the x8664/darwinppc64 result-register capture buffer
— and rejects duplicates. AAPCS64 needs a second spelling, `:indirect-result`,
for the same conceptual thing (the record result), so the check becomes a
`memq` over both and the error message names whichever keyword was duplicated.
No existing behaviour changes: `:registers` alone still behaves identically.

If you would rather that hunk arrived separately, say so and I will split it out.
Same offer for commits 7 and 8 if you would rather review the kernel SP change
on its own.
