### PR TITLE
x8664: CLASSIFY-RECORD-TYPE's second-eightbyte walk runs off the field list

### DIFF
--- a/compiler/X86/X8664/x8664-backend.lisp
+++ b/compiler/X86/X8664/x8664-backend.lisp
@@ -335,17 +335,43 @@
 ;;; Note that this means that a chunk consisting of two SINGLE-FLOATs would
 ;;; be passed in the low 64 bit of an SSE (xmm) register.
 
+(defun x8664::type-is-of-class-integer (ftype)
+  ;; Return true if FTYPE is of "class" integer, or is an aggregate any
+  ;; of whose members is.  (See the System V AMD64 ABI document for a
+  ;; convoluted definition of "classes".)
+  ;;
+  ;; 3.2.3 "Aggregates and Unions" classifies an ARRAY by its ELEMENT
+  ;; type, which the field walk below cannot express: it recurses field
+  ;; to field, and an array has no fields.  Without an arm here an
+  ;; array-of-integer member reached the OTHERWISE arm and came back
+  ;; NIL, so `struct { int v[2]; }' classified as :FLOAT while the
+  ;; identically laid out `struct { int a; int b; }' correctly gave
+  ;; :INTEGER -- the aggregate was then passed and returned in an SSE
+  ;; register instead of a GPR.
+  ;;
+  ;; Degenerate dimensions are excluded the way arm64's
+  ;; ARM64-LINUX::HFA-ELEMENT-INFO already excludes them, so the two
+  ;; back ends agree about what an array member contributes.
+  (typecase ftype
+    ((or foreign-integer-type foreign-pointer-type) t)
+    (foreign-array-type
+     (let* ((dims (foreign-array-type-dimensions ftype)))
+       (when (and dims
+                  (every #'(lambda (d) (typep d 'unsigned-byte)) dims)
+                  (> (reduce #'* dims) 0))
+         (x8664::type-is-of-class-integer
+          (foreign-array-type-element-type ftype)))))
+    (foreign-record-type (dolist (f (foreign-record-type-fields ftype))
+                           (when (x8664::type-is-of-class-integer
+                                  (foreign-record-field-type f))
+                             (return t))))
+    (otherwise nil)))
+
 (defun x8664::field-is-of-class-integer (field)
   ;; Return true if field is of "class" integer or if it's a record
   ;; type of class integer.  (See the System V AMD64 ABI document for
   ;; a convoluted definition of field "classes".)
-  (let* ((ftype (foreign-record-field-type field)))
-    (typecase ftype
-      ((or foreign-integer-type foreign-pointer-type) t)
-      (foreign-record-type (dolist (f (foreign-record-type-fields ftype))
-                             (when (x8664::field-is-of-class-integer f)
-                               (return t))))
-      (otherwise nil))))
+  (x8664::type-is-of-class-integer (foreign-record-field-type field)))
 
 (defun x8664::classify-8byte (field-list bit-limit)
   ;; CDR down the fields in FIELD-LIST until we find a field of class integer,
@@ -366,14 +392,33 @@
 (defun x8664::classify-record-type (rtype)
   (let* ((nbits (ensure-foreign-type-bits rtype))
          (fields (foreign-record-type-fields rtype)))
-    (cond ((> nbits 128) (values :memory nil))
-          ((<= nbits 64) (values (x8664::classify-8byte fields 64) nil))
-          (t (values (x8664::classify-8byte fields 64)
-               (do* ()
-                    ((or (null fields)
-                         (>= (foreign-record-field-offset (car fields)) 64))
-                     (x8664::classify-8byte fields 128))
-                 (setq fields (cdr fields))))))))
+    ;; The second-eightbyte walk CDRs down the FIELD list looking for the
+    ;; first field that starts at bit 64 or later.  That assumes no field
+    ;; spans the eightbyte boundary -- true of scalars, false of arrays,
+    ;; which are ONE field covering both halves.  For `int v[3]' the walk
+    ;; consumed the only field and handed CLASSIFY-8BYTE an empty list,
+    ;; whose DOLIST result form is :FLOAT: the record classified
+    ;; (:INTEGER :FLOAT) even once the element type was understood.
+    ;;
+    ;; So stop when the current field EXTENDS past bit 64, not only when
+    ;; it STARTS there, leaving a spanning field in the list for the
+    ;; second eightbyte.  Records without a spanning field are
+    ;; unaffected: each of their fields either ends at or before bit 64
+    ;; (walk on, as before) or starts at or after it (walk stops, as
+    ;; before).
+    (flet ((spans-64 (f)
+             (> (+ (foreign-record-field-offset f)
+                   (ensure-foreign-type-bits (foreign-record-field-type f)))
+                64)))
+      (cond ((> nbits 128) (values :memory nil))
+            ((<= nbits 64) (values (x8664::classify-8byte fields 64) nil))
+            (t (values (x8664::classify-8byte fields 64)
+                 (do* ()
+                      ((or (null fields)
+                           (>= (foreign-record-field-offset (car fields)) 64)
+                           (spans-64 (car fields)))
+                       (x8664::classify-8byte fields 128))
+                   (setq fields (cdr fields)))))))))
 
 (defun x8664::struct-from-regbuf-values (r rtype regbuf)
   (multiple-value-bind (first second)

--- a/compiler/X86/X8664/x8664-backend.lisp
+++ b/compiler/X86/X8664/x8664-backend.lisp
@@ -370,7 +370,8 @@
           ((<= nbits 64) (values (x8664::classify-8byte fields 64) nil))
           (t (values (x8664::classify-8byte fields 64)
                (do* ()
-                    ((>= (foreign-record-field-offset (car fields)) 64)
+                    ((or (null fields)
+                         (>= (foreign-record-field-offset (car fields)) 64))
                      (x8664::classify-8byte fields 128))
                  (setq fields (cdr fields))))))))
 


### PR DESCRIPTION
## x8664: `CLASSIFY-RECORD-TYPE`'s second-eightbyte walk runs off the field list

**Defect.** `compiler/X86/X8664/x8664-backend.lisp:371`. For a 65..128-bit
foreign record, `x8664::classify-record-type` CDRs down the field list to the
first field starting at bit 64 or later, and the loop has no end-of-list test:

```lisp
(do* ()
     ((>= (foreign-record-field-offset (car fields)) 64)
      (x8664::classify-8byte fields 128))
  (setq fields (cdr fields)))
```

If no field starts at bit 64 or later, `fields` reaches NIL and the test
evaluates `(foreign-record-field-offset NIL)`.

**Trigger.** Any record longer than 64 bits whose LAST field starts below bit
64 — i.e. whose overhanging member is an array or a nested record, so one field
covers both eightbytes. Smallest case is `struct { float v[3]; }` (96 bits, one
field at offset 0), the ordinary C 3-vector.

**Both reachable sites die at COMPILE time**, so simply loading an otherwise
unremarkable source file kills the lisp with exit 255 and a 300-500 line
backtrace:

- passing such a record by value through `external-call` / `ff-call`;
- taking such a record as a `defcallback` argument.

```
> Error of type TYPE-ERROR: The value NIL is not of the expected type STRUCTURE.
> While executing: X8664::CLASSIFY-RECORD-TYPE, in process listener(1).
```

**Fix** (one line): stop the walk at the end of the list too.

```lisp
((or (null fields)
     (>= (foreign-record-field-offset (car fields)) 64))
 (x8664::classify-8byte fields 128))
```

`x8664::classify-8byte` is `(dolist (field field-list :float) ...)`, so it
already answers `:float` for an empty list — verified in the image, not assumed —
and that is the correct answer here: for `struct { float v[3]; }` the second
eightbyte (bits 64-95, the third float) is SSE under the System V AMD64 psABI.

### Evidence

Stock x86-64 CCL `Version 1.12.2 (v1.12.2) LinuxX8664`, unmodified image
(`known-backends = (:LINUXX8664)`). Red and green in one session, with three
unaffected record shapes carried as controls; only `x8664::classify-record-type`
is redefined between the two halves.

| shape | before | after |
|---|---|---|
| `{float v[3]}` | **TYPE-ERROR** | `first=:FLOAT second=:FLOAT` |
| `{float,float,float}` | `:FLOAT :FLOAT` | `:FLOAT :FLOAT` (unchanged) |
| `{double,double}` | `:FLOAT :FLOAT` | `:FLOAT :FLOAT` (unchanged) |
| `{long,long}` | `:INTEGER :INTEGER` | `:INTEGER :INTEGER` (unchanged) |

```
RED    COMPILE (external-call "f" (:struct {float v[3]}) s :single-float)
         => ERROR TYPE-ERROR: The value NIL is not of the expected type STRUCTURE.
RED    DEFCALLBACK ((:struct {float v[3]}) s :single-float)
         => ERROR TYPE-ERROR: The value NIL is not of the expected type STRUCTURE.
GREEN  both => OK
```

Whole-file loads, `--batch --quiet --no-init`, same image:

```
before: exit 255 (external-call file, 530-line backtrace)
before: exit 255 (defcallback file, 331-line backtrace)
after:  exit 0, LOADED-OK, both
```

### Out of scope, but noticed here

`x8664::field-is-of-class-integer` has no `foreign-array-type` arm, so an
array-of-integer field is not recognised as class INTEGER. That is independent
of this walk and pre-dates it: `struct { int v[2]; }` is 64 bits, never enters
the `do*`, and already classifies `(:float nil)` on stock 1.12.2, where the
field-by-field equivalent `struct { int a; int b; }` correctly gives
`(:integer nil)`.

**You should know what that means for this patch, though:** for the
integer-array shape specifically — `struct { int v[3]; }`, 96 bits, one field at
offset 0 — the two interact. Today it crashes; with this patch it returns
`(:float :float)` where the psABI says `(INTEGER, INTEGER)`. So for that one
shape a loud failure becomes a quiet wrong answer. Every other shape I measured
either was already correct or stays correct.

I did not bundle the `field-is-of-class-integer` fix here because it is a
separate semantic change that also affects the *first* eightbyte and so cannot
be fixed inside this loop, and because I have not put it through the same
red-then-green. Say the word and I will send it as its own patch with the same
evidence.


---

## Appended: `x8664: classify an array member by its element type`

This is the `field-is-of-class-integer` fix offered just above, with the same
red-then-green. One commit on top of the walk fix, and it depends on it: the
`struct { int v[3]; }` shape has to stop crashing before you can see what answer
it gives.

**Two halves of one defect, and both are needed.**

1. `x8664::field-is-of-class-integer` recurses through a record field by field.
   An array has no fields, so an array-of-integer member fell to the `OTHERWISE`
   arm and came back NIL. The psABI classifies an array by its ELEMENT type
   (3.2.3, "Aggregates and Unions"). Observable at 64 bits, where no walk is
   involved at all:

   | shape | first | second |
   |---|---|---|
   | `struct { int v[2]; }` | `:FLOAT` — wrong | NIL |
   | `struct { int a; int b; }` | `:INTEGER` | NIL |

   Identical layout, identical size; only the spelling differs. The aggregate
   was passed and returned in an SSE register where the ABI requires a GPR.

2. The second-eightbyte walk assumes no field spans bit 64 — true of scalars,
   false of arrays, which are one field covering both halves. So fixing (1)
   alone leaves `struct { int v[3]; }` at `(:INTEGER :FLOAT)`: first eightbyte
   right, second still wrong. The walk now stops when a field EXTENDS past bit
   64 rather than only when it STARTS there, leaving the spanning field in the
   list for the second eightbyte.

Records with no spanning field are unaffected: each of their fields either ends
at or before bit 64 (walk on, as before) or starts at or after it (walk stops,
as before).

### Evidence

Same oracle as above — stock x86-64 CCL `1.12.2 LinuxX8664`, unmodified image —
with the walk fix already applied so that it is not what is being observed.
9 cases, **4 red → 0 green**:

| shape | before | after |
|---|---|---|
| `struct { int v[2]; }` | `(:FLOAT NIL)` | `(:INTEGER NIL)` |
| `struct { struct { int v[2]; } }` | `(:FLOAT NIL)` | `(:INTEGER NIL)` |
| `struct { void *v[2]; }` | `(:FLOAT :FLOAT)` | `(:INTEGER :INTEGER)` |
| `struct { int v[3]; }` | `(:FLOAT :FLOAT)` | `(:INTEGER :INTEGER)` |

Controls, unchanged across both halves:

| shape | both | why it is in the set |
|---|---|---|
| `struct { int a; int b; }` | `(:INTEGER NIL)` | the field-list spelling of case 1 |
| `struct { float v[2]; }` | `(:FLOAT NIL)` | an array of float must stay FLOAT |
| `struct { float v[4]; }` | `(:FLOAT :FLOAT)` | **spanning** float array — stays FLOAT through the new walk |
| `struct { int a; int b; long c; }` | `(:INTEGER :INTEGER)` | non-spanning, walk unchanged |
| `struct { double a; double b; }` | `(:FLOAT :FLOAT)` | non-spanning |

Degenerate array dimensions (unspecified, non-literal, or zero) are excluded the
way `ARM64-LINUX::HFA-ELEMENT-INFO` already excludes them, so the two back ends
agree about what an array member contributes.

This is a portable x86-64 defect, present on every x86-64 target and independent
of any port. Our arm64 branch carries it only as a no-regression result
(cross-build `rc0=0 rc1=0 rc2=0`, ANSI `21679/0`, `ccl.lsp` `243/0`); the
evidence that the change is *correct* is the x86-64 red-then-green above.
