### PR TITLE
arm64: kernel warning flags, two one-line fixes, and four findings

### DIFF
--- a/lisp-kernel/arm64-gc.c
+++ b/lisp-kernel/arm64-gc.c
@@ -444,6 +444,9 @@ check_all_areas(TCR *tcr)                            /* ppc-gc.c:156-204 */
         }
       }
       break;
+
+    default:
+      break;
     }
     a = a->succ;
     code = (a->code);

--- a/lisp-kernel/linuxarm64/Makefile
+++ b/lisp-kernel/linuxarm64/Makefile
@@ -12,7 +12,11 @@ CC = ${CROSS}gcc
 ASFLAGS =
 CDEFINES = -DLINUX -DARM64 -D_REENTRANT -D_GNU_SOURCE -DVC_REVISION=$(VC_REVISION)
 CDEBUG = -g
-COPT = -O2
+# The xp accessor macros in platform-linuxarm64.h type-pun the signal
+# context's __u64 fields through natural * and uint32_t **.  -O2 turns on
+# -fstrict-aliasing, which licenses the compiler to assume that does not
+# happen, so this is a correctness flag and not a warning suppression.
+COPT = -O2 -fno-strict-aliasing
 # Once in a while, -Wformat says something useful.  The odds are against that,
 # however.
 WFORMAT = -Wno-format

--- a/lisp-kernel/linuxarm64/Makefile
+++ b/lisp-kernel/linuxarm64/Makefile
@@ -23,7 +23,7 @@ WFORMAT = -Wno-format
 # -Wswitch reports an enum switch that has silently lost a case.  Kept
 # separate from WFORMAT so that overriding WFORMAT on the command line to
 # audit warnings does not also discard this.
-WARN = -Wswitch
+WARN = -Wswitch -Wno-unused-parameter
 PLATFORM_H = platform-linuxarm64.h
 
 

--- a/lisp-kernel/linuxarm64/Makefile
+++ b/lisp-kernel/linuxarm64/Makefile
@@ -20,6 +20,10 @@ COPT = -O2 -fno-strict-aliasing
 # Once in a while, -Wformat says something useful.  The odds are against that,
 # however.
 WFORMAT = -Wno-format
+# -Wswitch reports an enum switch that has silently lost a case.  Kept
+# separate from WFORMAT so that overriding WFORMAT on the command line to
+# audit warnings does not also discard this.
+WARN = -Wswitch
 PLATFORM_H = platform-linuxarm64.h
 
 
@@ -37,7 +41,7 @@ endif
 .s.o:
 	$(CC) -c -x assembler-with-cpp -I../ $< $(CDEFINES) -o $@
 .c.o:
-	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT)   $(WFORMAT)  -o $@
+	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT)   $(WFORMAT) $(WARN)  -o $@
 
 SPOBJ = pad.o  arm64-spentry.o spentry-A-alloc-numbers.o spentry-B-vectors-misc.o spentry-C-bind-catch-throw.o spentry-D-call-builtins.o spentry-E-ffi.o
 ASMOBJ = arm64-asmutils.o arm64-imports.o

--- a/lisp-kernel/lisp-exceptions.h
+++ b/lisp-kernel/lisp-exceptions.h
@@ -155,7 +155,7 @@ void thread_signal_setup(void);
 void suspend_other_threads(Boolean);
 void resume_other_threads(Boolean);
 void reset_lisp_process(ExceptionInformation *);
-void terminate_lisp(void);
+void terminate_lisp(void) __attribute__((noreturn));
 
 #endif /* __lisp_exceptions_h__ */
 

--- a/lisp-kernel/platform-linuxarm64.h
+++ b/lisp-kernel/platform-linuxarm64.h
@@ -140,7 +140,7 @@ typedef uint32_t opcode, *pc;
 #define xpPC(x) (*((pc*)(&((x)->uc_mcontext.pc))))
 #define set_xpPC(x,new) (xpPC(x) = (pc)(new))
 #define xpLR(x) (*((pc*)(&(xpGPR(x,30)))))  /* x30 = LR */
-#define xpSP(x) (*((natural*)(&((x)->uc_mcontext.sp))))
+#define xpSP(x) ((x)->uc_mcontext.sp)
 #define xpPSR(x) ((x)->uc_mcontext.pstate)
 #define xpFaultAddress(x) ((x)->uc_mcontext.fault_address)
 


### PR DESCRIPTION
# Kernel C warnings: three build-flag changes, two one-line source fixes, and four findings

Five patches. Nothing here changes what the kernel does, with one exception I
flag explicitly: `-fno-strict-aliasing` changes code generation, and it is the
only one of the five I would call a correctness fix.

Everything below was measured on `linuxarm64` with `gcc 11.5.0 20240719` on
aarch64, against a pristine checkout of the branch tip with no other patches
applied. **The default `make` produces zero warnings before and after all five
patches**, so none of this adds noise to a normal build; the counts come from
deliberately asking for `-Wall` and `-Wall -Wextra`.

| | default `make` | `-Wall` | `-Wall -Wextra` |
|---|---|---|---|
| baseline | 0 | 74 | 179 |
| `-fno-strict-aliasing` | 0 | 29 | 134 |
| `default:` arm + `-Wswitch` | 0 | 24 | 129 |
| `noreturn` on `terminate_lisp` | 0 | 24 | 128 |
| cast-free `xpSP` | 0 | 24 | 128 |
| `-Wno-unused-parameter` | 0 | 24 | 50 |

Build-confirmed, not just compiled: with all five applied, the kernel builds
`rc=0`, its md5 changes, and it boots an existing heap image and runs three
GCs, an EGC reconfiguration and several hundred thousand conses of allocation
with bit 2 of `*GC-EVENT-STATUS-BITS*` (`gc_integrity_check_bit`) set — which
is the only way to reach `check_all_areas` at all. Output is identical to the
same test on the unpatched kernel.

## Which is which

Please take these separately if you want to; they are independent apart from
sharing the Makefile.

**One correctness fix.** `-fno-strict-aliasing`. `COPT` is `-O2`, which turns on
`-fstrict-aliasing`, while the `xp` accessors type-pun the signal context: the
aarch64 `sigcontext` fields are `__u64` (`unsigned long long`) and `natural` is
`uint64_t` (`unsigned long`) — same representation, distinct types for aliasing
purposes — and `xpPC` reads a `__u64` field through a `uint32_t **`. That is UB
by the letter of the rules whether or not it ever bites.

I want to be straight about the strength of this one: I traced the
`xp`-touching functions and found **no site** where a store through one of these
types is followed by a load of the same storage through the other inside a
single function, so I am not reporting an observed miscompile. The claim is
narrower — the code is correct by the compiler's forbearance rather than by
construction, and one refactor that co-locates a `set_xpGPR(xp,30,…)` with an
`xpLR(xp)` read would arm it.

**Two signal-to-noise changes.** `-Wswitch` (with the `default:` arm that makes
it silent) and `-Wno-unused-parameter`. Neither affects codegen.

**Two source fixes that are their own justification**, independent of any flag:
the missing `default:` arm in `check_all_areas`, and dropping the pointless cast
in `xpSP`.

## `-fno-strict-aliasing` is really a tree-wide proposal

**No port sets it today** — the string `strict-aliasing` does not occur anywhere
in the tree, and all 17 kernel Makefiles use a bare `COPT`. So this is not an
arm64 gap being brought up to par with its siblings; it is an exposure they all
share.

The idiom is everywhere: `platform-linuxarm.h:33`,
`platform-linuxppc64.h:32-35`, `platform-linuxx8664.h:33`,
`platform-darwinarm64.h:31`. I compiled the **x86-64** kernel from the same tree
with the same compiler to check, and it reports 7 `-Wstrict-aliasing` in
`x86-exceptions.c` and 1 in `lisp-debug.c`, all from `xpGPR`. x86-64's pun is
arguably worse than arm64's: `greg_t` is *signed* `long long` there, punned to
`natural *`.

I am proposing the flag only for `linuxarm64` because that is the one I can
build and test. If you want it on the other sixteen, that is a one-line change
each, and I am happy to write it.

## `check_all_areas`: what I fixed and what I deliberately did not

The switch over `area_code` handles `AREA_DYNAMIC`, `AREA_STATIC`,
`AREA_MANAGED_STATIC`, `AREA_VSTACK` and `AREA_TSTACK`, and has no `default:`.
`x86-gc.c:449` already has the `default: break;` this patch adds. That is the
whole source change, and it is behaviour-preserving — the loop condition is
already `while (code != AREA_VOID)` and the other codes were falling through
the switch silently anyway.

`ppc-gc.c:157-204` has the identical switch with the identical missing arms and
no `default:`, so arm64 inherited this faithfully and the same one-line change
would suit ppc64.

**I did not add the missing area cases.** For the record, having looked at each:

- `AREA_STATIC_CONS` is already covered — both call sites invoke
  `check_static_cons_freelist()` immediately after `check_all_areas`
  (`gc-common.c:1648`, `:1921`).
- `AREA_READONLY` and `AREA_WATCHED` need `check_readonly_range()` and
  `check_tcrs()`, which exist only in `x86-gc.c` (`:197`, `:358`) and
  `arm-gc.c` (`:162`). Neither exists for arm64 or ppc64.
- `AREA_CSTACK` is the interesting one, and it is why I stopped. arm64's GC
  *does* walk the cstack — `mark_cstack_area` (`arm64-gc.c:1307`),
  `forward_cstack_area` (`:1758`), `purify`/`impurify_cstack_area` (`:2522`,
  `:2823`) — and the integrity checker never looks at it, while
  `arm-gc.c:215-217` does. But arm32's arm is a flat
  `check_range(a->active, a->high, true)`, treating every word as a node,
  whereas arm64's `mark_cstack_area` does a frame walk with explicit
  `"UNKNOWN STACK WORD"` reporting (`arm64-gc.c:1359`, `:1365`). A flat node
  scan of an arm64 cstack would fire spurious `Bug()` aborts on raw frame
  words. A correct arm64 CSTACK check needs a frame-walking checker that no
  port has, so I have not guessed at one. **Flagging it rather than fixing it.**

Severity of the gap is low and it is diagnostic, not correctness:
`check_all_areas` runs only when `gc_integrity_check_bit` is set
(`gc-common.c:1645`), so nothing is skipped during a real collection. What is
narrowed is the tool you reach for once you already suspect the GC.

Why `-Wswitch` is worth carrying permanently: it fires five times today, **all
five at this one site and nowhere else in the kernel**, so once the `default:`
arm lands it is a zero-noise, permanently-armed detector for a dispatch that has
quietly lost a case for one target — a class of bug that compiles clean and
loses a value at run time.

One Makefile detail worth a glance: I put the warning flags in a new `WARN`
variable rather than in `WFORMAT`. `WFORMAT` is documented as being about
`-Wformat`, and more practically, anyone auditing warnings runs
`make WFORMAT="-Wno-format -Wall -Wextra"`, which replaces `WFORMAT` wholesale
and would silently discard the very flag being audited. I hit that while
measuring.

## `terminate_lisp`: on the spelling

Both definitions end in `_exit()` (`pmcl-kernel.c:1445-1448` and `:1452-1457`),
so it cannot return, but it is declared plain `void` and gcc says so at the one
call site that depends on it — `case debug_kill: terminate_lisp();` falling into
`default:` at `lisp-debug.c:1604-1605`. Marking the declaration fixes that at
its cause instead of papering over it with a `break`.

I used `__attribute__((noreturn))` rather than C11 `_Noreturn` deliberately,
since `lisp-exceptions.h` is shared by all 17 targets:

- the kernel currently uses **no C11 features at all** — no `_Noreturn`,
  `_Static_assert`, `_Generic` or `_Alignof` anywhere under `lisp-kernel/` — so
  `_Noreturn` would be the first, and it is not available on the older compilers
  some targets still use;
- `__attribute__` is already used in shared headers: `bits.h:41`, `:88`, `:118`,
  `:146` and `arm-exceptions.h:137` all carry `__attribute__((always_inline))`;
- `macros.h:93-96` already neutralizes it for the one non-GCC compiler in the
  set, via `#ifdef VC` / `#define __attribute__(x)`, and `lisp.h:36` includes
  `macros.h` ahead of `lisp-exceptions.h`.

So this adds no new requirement to any target and degrades to nothing where it
must. Say the word if you would rather have `_Noreturn`.

---

# Four findings I am reporting rather than patching

## 1. `SUPPORT_PRAGMA_UNUSED` is dead, tree-wide — and it is where the intent lives

This is the one I most want your opinion on.

`-Wextra` reports 78 `-Wunused-parameter` (`lisp-debug.c` 38,
`arm64-exceptions.c` 19, `pmcl-kernel.c` 5, `arm64-gc.c` 3, `plsym.c` 1,
`plprint.c` 1, `gc-common.c` 1). None is a stub — I checked the cluster that
looked most like one (`arm64-exceptions.c:1112-1223`). `do_hard_stack_overflow`
at `:1112` genuinely needs only `xp`: it calls `reset_lisp_process(xp)` and
returns `-1`, exactly as `ppc-exceptions.c:980-988` does. The signatures are
fixed by the handler dispatch tables, so the parameters cannot be dropped.

**The source already records that intent, and the mechanism is dead.** Those
functions carry

```c
#ifdef SUPPORT_PRAGMA_UNUSED
#pragma unused(area,addr)
#endif
```

and `SUPPORT_PRAGMA_UNUSED` **is not defined anywhere in the tree** — grepping
the whole thing finds 10 `#ifdef` sites (3 in `arm-exceptions.c`, 3 in
`arm64-exceptions.c`, 4 in `ppc-exceptions.c`) and **zero** `#define`s. It is an
MPW/CodeWarrior-era fossil, so every port states "this parameter is deliberately
unused" in a form no compiler in current use will read.

Hence one flag rather than 78 annotations. I have deliberately **not** touched
the `#pragma` blocks — delete them, replace them with `(void)param;` or
`__attribute__((unused))`, or keep them as documentation; it is a tree-wide
question and your call, not something I should decide in an arm64 patch.

## 2. Eleven `-Wsign-compare`, ten of them safe on invariants nobody states

I read all eleven rather than casting them. Ten are safe; the eleventh is a real
narrowing that every port shares.

| site | expression | verdict |
|---|---|---|
| `arm64-exceptions.c:455` | `(a->active - a->low) >= a->threshold` | safe — `area.h`'s own `low <= active <= high` |
| `arm64-exceptions.c:656` | `(a->high - a->active) >= a->threshold` | safe — same, and `resize_dynamic_heap` just raised `high` |
| `gc-common.c:1583`, `:1587` | `(oldfree - gN_area->low) < gN_area->threshold` | safe — generations grow upward inside the dynamic area |
| `gc-common.c:2044`, `:2045` | `(a->high - limit) vs lisp_heap_notify_threshold` | safe — the invariant is built by `:2004-2029` of the same function |
| `image.c:359`, `:515` | `read`/`write` result `!=` expected `size_t` | safe **because** of the conversion: `-1` becomes `SIZE_MAX`, which cannot equal a real byte count, so errors are still detected |
| `plsym.c:69` | `header_element_count(...) == (int)strlen(name)` | safe — `n` is non-negative |
| `arm64-exceptions.c:681` | `selector == GC_TRAP_FUNCTION_IMMEDIATE_GC` | safe, see below |
| `arm64-print.c:315` | `for (int i = 1; i <= elements; i++)` | **latent narrowing** |

`GC_TRAP_FUNCTION_IMMEDIATE_GC` is `(-1)` (`gc.h:142`) and `selector` is a
`LispObj`, so the test is really `selector == UINT64_MAX`. It is correct, and I
am confident because the same declaration and the same comparison appear
verbatim in `ppc-exceptions.c:427-428/491`, `x86-exceptions.c:216/337` and
`arm-exceptions.c:402-403/518`, and immediate GC works on shipping x86-64 and
PPC64. Style note only: `-1` is the sole negative member of a family that is
otherwise `0..130`, and four ports carry a warning for it.

`arm64-print.c:315` is the one whose safety rests on a bound that **does not
hold**: `elements` is `natural`, `i` is `int`, and a simple-vector with more than
`INT_MAX` elements overflows the counter. It needs a ≥16 GB vector printed by the
*kernel* debugger, so I am not claiming it is reachable — and it is not an arm64
gap either: `x86_print.c:470-472`, `ppc_print.c:345-347` and
`arm_print.c:345-347` are character-identical. I left it alone rather than
diverge one printer from the other three.

**The class is worth more than the eleven casts.** Each is safe contingently, on
an invariant that is real but nowhere asserted and never communicated to the
compiler. That is the same shape as a bug we inherited from `ppc-gc.c:2270-2271`,
where `impurify` declares `unsigned n` and `int delta` and passes them into a
`signed_natural` parameter while `PURESPACE_RESERVE` is `0x2000000000` — far past
32 bits. x86-64 and ARM32 have both already fixed that one; PPC64 has not. We
copied PPC64's version into arm64 and only caught it later. I mention it because
it is the same signed/unsigned-boundary-on-an-unstated-invariant pattern, and
because you probably want to know about the `ppc-gc.c` one independently of
anything arm64.

## 3. `a->threshold` is unsigned and comes from Lisp

`arm64-exceptions.c:632-634` assigns `a->threshold`, `g1_area->threshold` and
`g2_area->threshold` from `unbox_fixnum(xpGPR(xp, arg_x/arg_y/arg_z))`, but
`threshold` is `natural` (`area.h:72`). A negative fixnum from Lisp becomes a
near-`UINT64_MAX` threshold, after which the comparisons at
`arm64-exceptions.c:455`, `:656` and `gc-common.c:1583`, `:1587` all evaluate
false forever — the EGC quietly stops promoting, with no diagnostic.

Upstream-wide (identical in `ppc-exceptions.c`, `x86-exceptions.c`,
`arm-exceptions.c`) and gated by Lisp-side validation today, so this is a
report, not a defect claim. It just seems worth a range check on a value that
crosses from Lisp into an unsigned kernel field.

## 4. Two smaller ones

`image.c:352` narrows `h->nsections`, an **`unsigned`** header field
(`image.h:56`), into an `int`, and `:353` then declares a VLA
`openmcl_image_section_header sections[nsections]` sized from it. A corrupt or
hostile image with `nsections > INT_MAX` gives a negative VLA size before any of
the read-error checking above runs. Image-trust territory, no arm64 angle.

`memory.c:205` is the lone bare `-Wextra`: `if (addr > 0)` where `addr` is a
`LogicalAddress`, i.e. an ordered comparison of a pointer against integer zero.
Presumably means `addr != NULL`.

---

## What I am not claiming

- No miscompile was observed from the aliasing violations (see above).
- The 8 `-Wmaybe-uninitialized` in `gc-common.c` are **false positives** — I
  traced all four sites and every warned read is guarded by the same condition
  that performs the sole initializing write; gcc's predicate analysis bails on a
  back-edge PHI. The identical 8 fire on x86-64. Four initializers would silence
  them with no behavioural effect, but that is cosmetic and I have not proposed
  it.
- The 14 `-Wold-style-declaration`, 12 `-Wunused-variable` and 4
  `-Wunused-but-set-variable` are untouched. They are cosmetic, they are
  tree-wide, and x86-64 has a comparable set.
- I am **not** proposing that `-Wall` become the default. 74 warnings on day one
  is a flag people learn to scroll past.
