### PR TITLE
arm64: control-stack overflow is never detected; add the cs-limit probe

### DIFF
--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -33,7 +33,25 @@
   ;; situation and ensure that the stack slots in question contain
   ;; gc-safe content.
   (stp fn lr (:@ sp (:$ 16)))
-  (mov fn nfn))
+  (mov fn nfn)
+  ;; Control-stack overflow probe -- PPC64 ppc64-vinsns.lisp:3471-3472
+  ;;   (ld imm ppc64::tcr.cs-limit ppc64::rcontext)
+  ;;   (tdllt ppc::sp imm)
+  ;; ARM64-DEVIATION: A64 has no trap-on-condition instruction, so the trap
+  ;; is a conditional branch around a udf.  That is the shape
+  ;; .SPsavecontextvsp already uses (spentry-C-bind-catch-throw.s:1669-1671),
+  ;; and b.hs (unsigned higher-or-same) is exactly tdllt's complement.
+  ;; marker-reg is dead once the frame is stored, so no extra temp is needed.
+  ;; The kernel side is already present: arm64-exceptions.c:1596-1637 decodes
+  ;; uuo_interr(error_stack_overflow, Rsp) and runs the PPC yellow-zone logic,
+  ;; restore_soft_stack_limit has its `case Rsp:', and
+  ;; level-1/arm64-error-signal.lisp:145 already reports rb=31 as the control
+  ;; stack.  Until this probe existed, all of that was unreachable.
+  (ldr marker-reg (:@ rcontext (:$ arm64::tcr.cs-limit)))
+  (cmp sp marker-reg)
+  (b.hs :ok)
+  (udf (:$ (:apply arm642-cstack-overflow-uuo)))
+  :ok)
   
 (define-arm64-vinsn (vpush-register :push :node :vsp) (()
                                                        ((reg :lisp)))
@@ -3991,7 +4009,25 @@
   ;; (lib/arm64env.lisp:33), so copy-lexpr-argument's temp is WIRED to
   ;; temp0 (w1).
   (stp xzr temp4 (:@ sp (:$ 16)))
-  (mov fn nfn))
+  (mov fn nfn)
+  ;; Control-stack overflow probe -- PPC64 ppc64-vinsns.lisp:3471-3472
+  ;;   (ld imm ppc64::tcr.cs-limit ppc64::rcontext)
+  ;;   (tdllt ppc::sp imm)
+  ;; ARM64-DEVIATION: A64 has no trap-on-condition instruction, so the trap
+  ;; is a conditional branch around a udf.  That is the shape
+  ;; .SPsavecontextvsp already uses (spentry-C-bind-catch-throw.s:1669-1671),
+  ;; and b.hs (unsigned higher-or-same) is exactly tdllt's complement.
+  ;; marker-reg is dead once the frame is stored, so no extra temp is needed.
+  ;; The kernel side is already present: arm64-exceptions.c:1596-1637 decodes
+  ;; uuo_interr(error_stack_overflow, Rsp) and runs the PPC yellow-zone logic,
+  ;; restore_soft_stack_limit has its `case Rsp:', and
+  ;; level-1/arm64-error-signal.lisp:145 already reports rb=31 as the control
+  ;; stack.  Until this probe existed, all of that was unreachable.
+  (ldr marker-reg (:@ rcontext (:$ arm64::tcr.cs-limit)))
+  (cmp sp marker-reg)
+  (b.hs :ok)
+  (udf (:$ (:apply arm642-cstack-overflow-uuo)))
+  :ok)
 
 ;;; get-complex-double-float -- x8664's 128-bit load; his template
 ;;; table has no Q-form load, so composed exactly like w3a's
@@ -4231,7 +4267,25 @@
   (mov marker-reg (:$ arm64::lisp-frame-marker))
   (stp marker-reg vsp-reg (:@! sp (:$ -32)))
   (stp fn lr (:@ sp (:$ 16)))
-  (mov fn nfn))
+  (mov fn nfn)
+  ;; Control-stack overflow probe -- PPC64 ppc64-vinsns.lisp:3471-3472
+  ;;   (ld imm ppc64::tcr.cs-limit ppc64::rcontext)
+  ;;   (tdllt ppc::sp imm)
+  ;; ARM64-DEVIATION: A64 has no trap-on-condition instruction, so the trap
+  ;; is a conditional branch around a udf.  That is the shape
+  ;; .SPsavecontextvsp already uses (spentry-C-bind-catch-throw.s:1669-1671),
+  ;; and b.hs (unsigned higher-or-same) is exactly tdllt's complement.
+  ;; marker-reg is dead once the frame is stored, so no extra temp is needed.
+  ;; The kernel side is already present: arm64-exceptions.c:1596-1637 decodes
+  ;; uuo_interr(error_stack_overflow, Rsp) and runs the PPC yellow-zone logic,
+  ;; restore_soft_stack_limit has its `case Rsp:', and
+  ;; level-1/arm64-error-signal.lisp:145 already reports rb=31 as the control
+  ;; stack.  Until this probe existed, all of that was unreachable.
+  (ldr marker-reg (:@ rcontext (:$ arm64::tcr.cs-limit)))
+  (cmp sp marker-reg)
+  (b.hs :ok)
+  (udf (:$ (:apply arm642-cstack-overflow-uuo)))
+  :ok)
 
 ;;; call-label -- PPC64 ppc64-vinsns.lisp:2184 verbatim (bl label).
 (define-arm64-vinsn (call-label :call) (()
@@ -4332,7 +4386,25 @@
   (mov marker-reg (:$ arm64::lisp-frame-marker))
   (stp marker-reg vsp-reg (:@! sp (:$ -32)))
   (stp fn lr (:@ sp (:$ 16)))
-  (mov fn nfn))
+  (mov fn nfn)
+  ;; Control-stack overflow probe -- PPC64 ppc64-vinsns.lisp:3471-3472
+  ;;   (ld imm ppc64::tcr.cs-limit ppc64::rcontext)
+  ;;   (tdllt ppc::sp imm)
+  ;; ARM64-DEVIATION: A64 has no trap-on-condition instruction, so the trap
+  ;; is a conditional branch around a udf.  That is the shape
+  ;; .SPsavecontextvsp already uses (spentry-C-bind-catch-throw.s:1669-1671),
+  ;; and b.hs (unsigned higher-or-same) is exactly tdllt's complement.
+  ;; marker-reg is dead once the frame is stored, so no extra temp is needed.
+  ;; The kernel side is already present: arm64-exceptions.c:1596-1637 decodes
+  ;; uuo_interr(error_stack_overflow, Rsp) and runs the PPC yellow-zone logic,
+  ;; restore_soft_stack_limit has its `case Rsp:', and
+  ;; level-1/arm64-error-signal.lisp:145 already reports rb=31 as the control
+  ;; stack.  Until this probe existed, all of that was unreachable.
+  (ldr marker-reg (:@ rcontext (:$ arm64::tcr.cs-limit)))
+  (cmp sp marker-reg)
+  (b.hs :ok)
+  (udf (:$ (:apply arm642-cstack-overflow-uuo)))
+  :ok)
 
 ;;; ============ fitvals ============
 ;;; Gate-37 multiple-value-bind cluster.  PPC64 ppc64-vinsns.lisp:4049

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -70,6 +70,24 @@
                arm64::num-subtag-bits)
           arm64::subtag-u64-vector))
 
+(defun arm642-cstack-overflow-uuo ()
+  ;; The udf immediate for a failed control-stack overflow check, i.e. the
+  ;; emit side of uuo_interr(error_stack_overflow, sp).  Encoding cited from
+  ;; the decoder, not inferred -- lisp-kernel/arm64-exceptions.c:189-196:
+  ;;   UUO_MISC_INFO(imm16)   = (imm16 >> 2) & 0x3fff   (format_misc = bits 1:0 = 0)
+  ;;   UUO_MISC_IS_INTERR(mi) = (mi >> 13) & 1
+  ;;   UUO_INTERR_ERRNUM(mi)  = (mi >> 5) & 0xff
+  ;;   UUO_INTERR_GPR(mi)     = mi & 0x1f
+  ;; The GPR field is 31 (Rsp): AArch64 SP is not one of regs[0..30], so 31 is
+  ;; the stack-register selector (arm64-exceptions.c:108-112), it is what
+  ;; handle_uuo tests (`gpr == Rsp'), and it is the value
+  ;; level-1/arm64-error-signal.lisp:145 already spells as a literal 31 for
+  ;; want of an arm64:: constant.
+  (ash (logior (ash 1 13)
+               (ash arch::error-stack-overflow 5)
+               31)
+       2))
+
 (defmacro with-arm64-p2-declarations (declsform &body body)
   `(let* ((*arm642-tail-allow* *arm642-tail-allow*)
           (*arm642-reckless* *arm642-reckless*)


### PR DESCRIPTION
One commit. `linuxarm64` has **no control-stack overflow detection of any kind**,
so recursion that consumes only control stack kills the process with `SIGSEGV`
instead of signalling a `storage-condition`. Based on `arm64` at 8404d6ba.

```lisp
(defun cs-only () (1+ (cs-only)))
(handler-case (cs-only) (storage-condition (c) :caught))   ; exit 139
```

Stock x86-64 CCL 1.12.2 signals `CCL::STACK-OVERFLOW-CONDITION` for the same
form and `handler-case` catches it.

### Why arm64 has neither mechanism

Every port detects this one of two ways, and arm64 ended up with the half of
each that does nothing:

| port | cstack guard pages (`PROTECT_CSTACK`) | inline `tcr.cs-limit` probe | outcome |
|---|---|---|---|
| ARM32 `linuxarm` | yes (`platform-linuxarm.h`), plus `USE_SIGALTSTACK` | no | detected |
| PPC64 | no | yes (`ppc64-vinsns.lisp`, in all three `save-lisp-context-*`) | detected |
| x86-64 | no | yes (the `stack-probe` lapmacro) | detected |
| **arm64 `linuxarm64`** | **no** | **no** | **hard SIGSEGV** |

The frame-build vinsns follow ARM32's shape (frame push, no probe) while
`platform-linuxarm64.h` follows PPC64's (no guard pages). Each half is
individually defensible; together they leave nothing watching the control stack.
A comment in `arm64-vinsns.lisp` names the gap without connecting it to a
defect — *"no cs-limit stack probe (his canon has none yet)"*.

**Everything downstream of the missing probe is already there and is dead code
today**, which is what makes this a one-commit fix:

* `arm64-exceptions.c` — `handle_uuo`'s `error_stack_overflow` / `gpr == Rsp`
  case, the PPC yellow-zone logic ported whole;
* `arm64-exceptions.c` — `signal_stack_soft_overflow`, and
  `restore_soft_stack_limit`'s `case Rsp:` which lowers `cs_area->softlimit` and
  rewrites `tcr->cs_limit`;
* `level-1/arm64-error-signal.lisp` — `handle-stack-overflow` already maps
  `rb = 31` to the control stack and calls back into `restore-soft-stack-limit`;
* `.SPsavecontextvsp` / `.SPsavecontext0` do carry the probe — but the arm64
  compiler never calls them (`git grep savecontextvsp compiler/ARM64` is empty),
  so those two are dead as well.

`tcr->cs_limit` is initialised and maintained. Nothing ever reads it.

### Observed, not inferred

On a live image, at the first `SIGSEGV`, TCR read through `x28` (the exhausted
stack cannot host an inferior call):

```
sp                      = 0xffffff600000
si_addr                 = 0xffffff5fffe0    (= sp-32, the next frame's pre-index stp)
tcr->cs_limit           = 0xffffffdce000
tcr->cs_area->softlimit = 0xffffffdce000
tcr->cs_area->hardlimit = 0xffffffdb5000
tcr->cs_area->low       = 0xffffffd9c000
tcr->cs_area->softprot  = (protected_area *) 0x0     <- no guard page
tcr->cs_area->hardprot  = (protected_area *) 0x0     <- no guard page
```

SP finished `0x79c000` bytes — 7.6 MB — **below `cs_area->low`**. It crossed
`cs_limit`, then `hardlimit`, then `low`, without a trap, and only faulted on
walking off the mapped thread-stack VMA. The 200 KB soft+hard reserve the
yellow-zone logic depends on does not exist in practice. `continue` re-took the
identical fault at the identical PC: nothing converts it.

The vstack, by contrast, is correctly protected in the same stop
(`vs_area->softprot` is a real 100 KB region), which is the clue to the next
part.

### Why this survived a full ANSI run

`(labels ((f (x) (1+ (f x)))) (f 1))` — the obvious reproducer — **works
correctly**: it signals `STACK-OVERFLOW-CONDITION` and `handler-case` catches
it. So does a global one-argument `defun`.

A recursion with an argument must preserve it across the call, so every level
pushes a vstack word as well as 32 bytes of control stack. **The vstack guard
page fires first**, and that path is fully working, so the control stack is
never the binding constraint. You have to write a recursion with *no* arguments
for the control stack to be the only thing consumed — and then it is immediate.

That is also why `21679/0` says nothing about this: ANSI has no zero-argument
unbounded recursion in it.

### The fix

PPC64's inline probe, in the four frame builders, mirroring its `ld` + `tdllt`:

```lisp
  (ldr marker-reg (:@ rcontext (:$ arm64::tcr.cs-limit)))
  (cmp sp marker-reg)
  (b.hs :no-cstack-overflow)
  (udf (:$ (:apply arm642-cstack-overflow-uuo)))
  :no-cstack-overflow
```

`marker-reg` is dead once the frame is stored, so no extra temp is needed.

**One deviation, tagged as such in the source:** PPC64 traps with a single
conditional-trap instruction (`tdllt`); A64 has no trap-on-condition, so it is a
conditional branch around a `udf`. That is the shape `.SPsavecontextvsp` in this
same kernel already uses, and `b.hs` is exactly `tdllt`'s complement.

The `udf` immediate is derived from the decoder rather than guessed:
`UUO_MISC_INFO(imm16) = (imm16>>2) & 0x3fff`, `IS_INTERR = (mi>>13) & 1`,
`errnum = (mi>>5) & 0xff`, `gpr = mi & 0x1f`; with
`arch::error-stack-overflow` = 5 and `Rsp` = 31 that is `mi = 8383`,
`imm16 = 0x82fc`. The `cmp` takes the `((:rn :x/sp) (:rm :x-ext))` template,
which is why SP is accepted as `Rn` and why no second temp was needed; the
narrower `(:rn :x)` template cannot match SP, so template search falls through
to it.

**Route not taken:** `#define PROTECT_CSTACK 1` for linuxarm64, i.e. ARM32's
answer. It would additionally need `USE_SIGALTSTACK`, an arm64
`setup_sigaltstack`, the `altstack_*` handler wrappers (none exist for arm64),
and a `kSPsoftguard` arm in `do_soft_stack_overflow`, which today only
distinguishes TSP from VSP. Three subsystems instead of one, and the probe is
what PPC64 and x86-64 both do.

### Testing

* **Watched red first**, with the patch withheld from an otherwise identical
  build: 6 assertions pass, then `SIGSEGV`, `EXIT:139`, and 11 assertions are
  never reached. The **kernel md5 is identical** in the red and green halves, so
  the control isolates this compiler change and nothing else; the image md5
  moved, so the fix reached the binary.
* **Green after**: 17/17, `EXIT:0`.
* **Oracle**: the same test file passes 17/17 on stock x86-64 CCL 1.12.2, so it
  is testing the standard rather than this port.
* **No regression**: cross-build `rc0=0 rc1=0 rc2=0`; on Graviton ANSI
  `21679/0` and `ccl.lsp` `243/0`, `EXIT:0`, with the probe in every non-leaf
  prologue.

Emitted code, from the green image, for a zero-argument non-tail recursion:

```
  (mov imm0 (:$ 90))                    ; D2800B40   lisp-frame-marker
  (stp imm0 vsp (:@! sp (:$ -32)))      ; A9BE67E0
  (stp fn lr (:@ sp (:$ 16)))           ; A9017BE7
  (mov fn temp2)                        ; AA0E03E7
  (ldr imm0 (:@ rcontext (:$ 80)))      ; F9402B80   tcr.cs-limit
  (cmp sp (imm0 :uxtx 0))               ; EB2063FF
  (b.cs L48)                            ; 54000042
  (udf (:$ #x82FC))                     ; 000082FC   uuo_interr
L48
```

Offset 80 is `tcr.cs-limit`, the 10th `_node` slot of `_struct tcr`; `b.cs` is
the disassembler's spelling of `b.hs`.

### Cost

Four instructions per non-leaf frame build, which is what PPC64 and x86-64 both
pay. If you would rather have it under a build option, or only in
`save-lisp-context-vsp` and not all four, say which and I will send that instead.
