### PR TITLE
arm64: .SPsyscall's return path reloads lisp registers at foreign valence

### DIFF
--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -268,9 +268,9 @@ spentry ffcall
         /* Record the lisp<->foreign boundary for the GC (16m41 protocol,
          * re-pointed for stack args): the boundary is now the PUBLISHED
          * boundary lisp_frame itself -- mark_cstack_area classifies a walk
-         * that STARTS on lisp_frame_marker, exactly as it already does for
-         * the syscall sibling's post-pop boundary -- because the old start
-         * point, the c_frame base, dies once SP steps over it at the blr.
+         * that STARTS on lisp_frame_marker, which is what the syscall
+         * sibling also hands it -- because the old start point, the c_frame
+         * base, dies once SP steps over it at the blr.
          * Everything below the boundary is foreign to the GC while the
          * callee runs, which was already the status of the raw, never-
          * scanned param/stack-arg words when the ivector cover held them.
@@ -292,8 +292,10 @@ spentry ffcall
         str temp0, [rcontext, #tcr.valence]
         /* ARM64-DEVIATION: step SP over header+savedsp+params[0..7] so the
          * callee sees its stack arguments AT [SP], per AAPCS64 5.4.2 (the
-         * single NSAA area the codegen marshals at param words 8..; +80 is
-         * the same c_frame.size + 8 words the syscall sibling steps by).
+         * single NSAA area the codegen marshals at param words 8..; +80 =
+         * c_frame.size + the 8 GPR param words).  The syscall sibling does
+         * NOT do this: `svc' takes no stack arguments, so it leaves SP at
+         * the frame head and its c_frame stays live above SP throughout.
          * PPC64 never moves SP here -- PowerOpen stack params live in the
          * CALLER's frame at positive offsets from the caller's SP; x86-64
          * is the shape donor (_SPffcall's ffcall_setup pops the frame head
@@ -6955,8 +6957,19 @@ endsp callback
  * lisp<->foreign transition) with the AArch64 Linux syscall sequence
  * in the middle instead of a call. */
 spentry syscall
+        /* fn + all four boxed NVRs, exactly as `spentry ffcall'
+         * (arm64-spentry.s -- the CANONICAL NOTE for this whole body), and for
+         * the same reason: the vstack copies are what the GC forwards while
+         * this thread is foreign.  The kernel preserves x19-x22 across the
+         * trap, but preservation is not FORWARDING -- a lisp value that
+         * survives only in an NVR misses any relocation a foreign-era GC
+         * applied.  PPC64 vpush_saveregs()es all eight of its save regs here
+         * (ppc:5404) for exactly this; two of five was an arm64 shortfall. */
         str fn, [vsp, #-node_size]!             /* ppc:5404 vpush_saveregs   */
         str save3, [vsp, #-node_size]!
+        str save2, [vsp, #-node_size]!
+        str save1, [vsp, #-node_size]!
+        str save0, [vsp, #-node_size]!
         mov save3, sp
         /* Park lr in the boundary lisp_frame his alloc-c-frame RESERVED at the
          * frame top, and publish it by shrinking the header count by 4.  The
@@ -6981,6 +6994,12 @@ spentry syscall
         sub imm0, imm0, #(4 << num_subtag_bits)
         str imm0, [sp, #c_frame.header]
         stp fn, lr, [imm2, #lisp_frame.savefn]
+        /* Cross-trap hoist (canonical note: `spentry ffcall'): everything the
+         * return path needs, in callee-saved registers, so that path never
+         * reads the c_frame head -- and never reads BELOW SP, which is what
+         * the old return path did. */
+        mov save1, imm2                         /* boundary lisp_frame       */
+        ldr save0, [rcontext, #tcr.last_lisp_frame] /* enclosing boundary    */
         /* Publish lisp state to the TCR for the GC, then go foreign
            (ppc:5405-5422). */
         str vsp, [rcontext, #tcr.save_vsp]
@@ -6994,40 +7013,40 @@ spentry syscall
         ldp x0, x1, [sp, #c_frame.params]
         ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
         ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
-        /* 16m41 PARITY (this spentry goes foreign exactly like ffcall and was
-         * missing the same bookkeeping): park the enclosing boundary in the
-         * now-dead param word 0, then record the boundary and only then
-         * advertise foreign valence.  Unlike ffcall this frame is POPPED
-         * before the trap, so the boundary is taken AFTER the pop and names
-         * live stack -- the caller's own region, since the c_frame (still
-         * intact below SP, which is what the return path already relies on)
-         * has nothing the GC needs. */
-        ldr temp0, [rcontext, #tcr.last_lisp_frame]
-        str temp0, [sp, #c_frame.params]
-        add sp, sp, #(c_frame.size + 8*node_size)
-        mov temp0, sp
-        str temp0, [rcontext, #tcr.last_lisp_frame]
+        /* Boundary bookkeeping + valence, identical to `spentry ffcall' in
+         * arm64-spentry.s (the ordering rationale lives there): the boundary
+         * is the PUBLISHED boundary lisp_frame, stored BEFORE the valence
+         * flip so a GC that suspends us foreign finds it.
+         *
+         * ARM64-DEVIATION vs the three ff-call siblings: there is NO SP step
+         * here.  They step SP over the frame head so the callee sees its NSAA
+         * stack arguments at [SP] (AAPCS64 5.4.2); a Linux/AArch64 syscall has
+         * no stack arguments at all -- x8 is the number and x0-x5 are the <=6
+         * integer arguments -- so the step would expose nothing.  Leaving SP
+         * at the frame head keeps the whole c_frame ABOVE SP for the duration
+         * of the trap, and removes every below-SP read the old return path
+         * relied on.  It also drops an unstated assumption: the old code took
+         * `sp + c_frame.size + 8*node_size' to BE the boundary lisp_frame,
+         * which only holds while the frame has exactly 8 param words; save1
+         * is the address the header count actually strides to. */
+        str save1, [rcontext, #tcr.last_lisp_frame]
         mov temp0, #TCR_STATE_FOREIGN
         str temp0, [rcontext, #tcr.valence]
         svc #0                                  /* ppc:5433 sc               */
-        /* ---- return path (x0 = raw result / -errno) (ppc:5455-5489) ---- */
-        ldr allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5470-5472     */
-        ldr allocbase, [rcontext, #tcr.save_allocbase]
-        /* lr from the boundary lisp_frame; sp from the SAVED SP word, not the
-         * header at offset 0 (16m30).  Count is already shrunk by 4, so
-         * reserved_base = save3 + node_size*(count+1).  imm1/imm2 only. */
-        ldr imm1, [save3, #c_frame.header]
-        lsr imm1, imm1, #num_subtag_bits
-        add imm1, imm1, #1
-        add imm2, save3, imm1, lsl #node_shift
-        ldr lr, [imm2, #lisp_frame.savelr]
-        ldr imm1, [save3, #c_frame.savedsp]
-        /* Hand the enclosing foreign boundary back BEFORE sp moves (16m41). */
-        ldr imm2, [save3, #c_frame.params]
-        str imm2, [rcontext, #tcr.last_lisp_frame]
-        mov sp, imm1
-        ldr save3, [vsp], #node_size
-        ldr fn, [vsp], #node_size
+        /* ---- return path (x0 = raw result / -errno) (ppc:5455-5489) ----
+         * Order is PPC64's, instruction for instruction: make every node
+         * register GC-valid, flip to lisp valence, and only THEN reload
+         * anything a foreign-era GC may have moved.  ppc:5478-5487 flips
+         * tcr.valence and then does vpop_saveregs / ldr savelr / ldr savefn /
+         * discard_lisp_frame; x86-spentry64.s:4619 syscall stores
+         * TCR_STATE_LISP and only then pops fn and the rest.  Both ports do
+         * the reloads AFTER the flip because the GC forwards the vstack slot
+         * and the TCR slot but never the register: popping while still
+         * FOREIGN makes a stale node pointer live at the flip, and `fn' --
+         * a function pointer -- is the worst of them.
+         * No scratch register is used at all, so x0 (the result) and imm1-5
+         * are untouched on this path. */
+        mov sp, save1                       /* onto the boundary lisp_frame  */
         mov arg_w, rnil                         /* ppc:5461-5468             */
         mov arg_x, rnil
         mov arg_y, rnil
@@ -7039,7 +7058,25 @@ spentry syscall
         mov temp4, rnil
         mov temp5, rnil
         mov nargs, xzr
+        mov fn, rnil
+        mov save1, xzr
+        mov save2, xzr
+        mov save3, xzr
+        mov allocptr,  #-dnode_size         // VOID_ALLOCPTR (ppc idiom)
+        mov allocbase, #-dnode_size
         str xzr, [rcontext, #tcr.valence]       /* TCR_STATE_LISP; ppc:5481  */
+        /* save0 is a raw cstack address, so it reads as a fixnum and is
+         * GC-valid across the flip without being nil'd. */
+        str save0, [rcontext, #tcr.last_lisp_frame] /* enclosing boundary back */
+        ldr lr, [sp, #lisp_frame.savelr]    /* post-flip: GC-forwarded       */
+        ldr save0, [vsp], #node_size
+        ldr save1, [vsp], #node_size
+        ldr save2, [vsp], #node_size
+        ldr save3, [vsp], #node_size
+        ldr fn,    [vsp], #node_size
+        ldr allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5470-5472     */
+        ldr allocbase, [rcontext, #tcr.save_allocbase]
+        add sp, sp, #lisp_frame.size        /* drop the frame: sp = prev SP  */
         check_pending_interrupt                 /* ppc:5488                  */
         ret                                     /* ppc:5489 blr              */
 endsp syscall


### PR DESCRIPTION
## arm64: `.SPsyscall`'s return path reloads lisp registers at foreign valence

This is the separate patch offered at the end of #572:

> `.SPsyscall` gets fix 1 only. Its own tail still pops `save3`/`fn` before the
> valence flip — the same window as (2) — which I have deliberately left alone
> here: it is pre-existing, it is not widened by anything in this branch […]
> Worth a separate look, and I am happy to send that separately.

### The defect

`spentry syscall` comes back from the `svc` and, while `tcr.valence` still says
`TCR_STATE_FOREIGN`, reloads `allocptr`/`allocbase` from the TCR, reads `lr` back
out of the boundary `lisp_frame`, and pops `save3` and `fn` off the vstack. Only
after all five reloads does it store `TCR_STATE_LISP`.

A GC in that window is another thread's — this thread is foreign, so it is
suspended and walked, not stopped at a safe point. It forwards the vstack slots
and the TCR slots. It does **not** forward this thread's registers: at foreign
valence the collector walks from `tcr.last_lisp_frame`, and `mark_xp`/`forward_xp`
do not cover a foreign context's register file. So every value loaded into a
register *before* the flip keeps its pre-move address, and the flip publishes
those stale addresses as live lisp state. `fn` is the worst of them — a stale
function pointer, which is what the caller returns into.

This is the same shape fixed in the three ff-call bodies in #572 (`spentry
ffcall`, `ffcall_return_registers`, `ffcall_indirect_result`). `.SPsyscall` is
the fourth foreign-transition subprim and the only one still doing it.

### Cross-port: both donors already have the order this adopts

* `ppc-spentry.s` `poweropen_syscall` — `str(imm4,tcr.valence(rcontext))` comes
  **before** `vpop_saveregs`, before `ldr(loc_pc,lisp_frame.savelr(sp))` and
  before `ldr(fn,lisp_frame.savefn(sp))`.
* `x86-spentry64.s` `_spentry(syscall)` — `movq $TCR_STATE_LISP,rcontext(...)`
  comes **before** `pop %fn` and the rest of the pops.

arm64 was the outlier. The return path is rewritten to ppc64's order: retreat SP
onto the boundary `lisp_frame`, make every node register GC-valid (nil the
arg/temp set, nil `fn`, zero the raw-address NVRs, set `allocptr`/`allocbase` to
`VOID_ALLOCPTR`), flip to `TCR_STATE_LISP`, and only then hand back the enclosing
boundary, read `lr` from the frame at `[sp]`, pop the NVRs and reload the
allocation pointers.

### Two related fixes ride along, because they are the same defect

* **The prologue spilled only `fn` and `save3`.** `save0`, `save1` and `save2`
  hold lisp values too, and a value that crosses the foreign window only in an
  NVR is preserved by the kernel but never *forwarded*. All five are now vpushed
  below the `tcr.save_vsp` publish, matching `spentry ffcall` and ppc64's
  `vpush_saveregs`.
* **The pre-`svc` SP step is dropped.** It stepped SP over the whole `c_frame`
  head, which is why every instruction of the old return path read *below* SP
  (`[save3, #c_frame.header]`, `[save3, #c_frame.savedsp]`,
  `[save3, #c_frame.params]`). Its only purpose in the ff-call siblings is to
  place NSAA stack arguments at `[SP]` for the callee, and a Linux/AArch64
  syscall has no stack arguments: `x8` is the syscall number and `x0`-`x5` are
  the at-most-six integer arguments. Leaving SP at the frame head keeps the whole
  `c_frame` above SP for the duration of the trap, and the boundary handed to the
  GC becomes the published boundary `lisp_frame` itself — the address the header
  count strides to — instead of `sp + c_frame.size + 8*node_size`, which is only
  the same address while the frame has exactly eight param words.

Two comments in `spentry ffcall` that described the syscall sibling's old shape
are corrected in the same commit.

### ⚠️ How this was verified — and what the green bar does NOT say

**`.SPsyscall` is unreachable from compiled lisp on arm64.** There is no `.quad`
row for it in the sptab and no `defsubprim .SPsyscall` in `arm64-arch.lisp`, so
nothing compiled can dispatch to it. Nor is anything else wired up to reach it:
the `syscall` vinsn has **no emitter on any port** — `(! syscall)` returns
nothing tree-wide — and there is no lisp-side `syscall` macro or function.

So a full ANSI + `ccl.lsp` run on the rebuilt kernel (**21679/0**, **243/0**) is a
**no-regression** result and **not coverage**. It says the kernel still builds and
boots correctly. It does not say this body ran, because it cannot have. I am
offering this as *correcting a dormant body before anything is wired to it*, not
as a tested fix.

One boundary on that run: it was made before the rebase, on a kernel built from
the earlier base. The patch content did not move. Only its context did.

The mechanism was therefore observed **on the built kernel**, not in the source —
a disassembly lint over the four foreign-transition subprims, asserting that
nothing is reloaded between the transition (`svc`/`blr`) and the
`str xzr,[rcontext,#tcr.valence]`:

| kernel | `_SPsyscall` | the three ff-call bodies |
|---|---|---|
| before this patch | **5 foreign-valence reloads** | clean (fixed in #572) |
| after | clean | clean |

The three ff-call bodies being clean *in the same run* is the control: it shows
the lint can distinguish a fixed body from a broken one, on the same binary, so
the five hits are a finding rather than an artifact of how it reads the file.
The lint is a disassembly check on purpose — the rule is about instruction order
in the shipped binary, and a source grep can be satisfied by text the assembler
reorders or that a later patch re-introduces.

