### PR TITLE
ppc-gc: IMPURIFY narrows a 64-bit displacement to int

### DIFF
--- a/lisp-kernel/ppc-gc.c
+++ b/lisp-kernel/ppc-gc.c
@@ -2048,7 +2048,7 @@ purify(TCR *tcr, signed_natural param)
 }
 
 void
-impurify_locref(LispObj *p, LispObj low, LispObj high, int delta)
+impurify_locref(LispObj *p, LispObj low, LispObj high, signed_natural delta)
 {
   LispObj q = *p;
   
@@ -2067,7 +2067,7 @@ impurify_locref(LispObj *p, LispObj low, LispObj high, int delta)
 
   
 void
-impurify_noderef(LispObj *p, LispObj low, LispObj high, int delta)
+impurify_noderef(LispObj *p, LispObj low, LispObj high, signed_natural delta)
 {
   LispObj q = *p;
   
@@ -2081,7 +2081,7 @@ impurify_noderef(LispObj *p, LispObj low, LispObj high, int delta)
 
 #ifdef PPC
 void
-impurify_cstack_area(area *a, LispObj low, LispObj high, int delta)
+impurify_cstack_area(area *a, LispObj low, LispObj high, signed_natural delta)
 {
   BytePtr
     current,
@@ -2104,7 +2104,7 @@ impurify_cstack_area(area *a, LispObj low, LispObj high, int delta)
 #endif
 
 void
-impurify_xp(ExceptionInformation *xp, LispObj low, LispObj high, int delta)
+impurify_xp(ExceptionInformation *xp, LispObj low, LispObj high, signed_natural delta)
 {
   natural *regs = (natural *) xpGPRvector(xp);
 
@@ -2129,7 +2129,7 @@ impurify_xp(ExceptionInformation *xp, LispObj low, LispObj high, int delta)
 
 
 void
-impurify_range(LispObj *start, LispObj *end, LispObj low, LispObj high, int delta)
+impurify_range(LispObj *start, LispObj *end, LispObj low, LispObj high, signed_natural delta)
 {
   LispObj header;
   unsigned tag;
@@ -2154,7 +2154,7 @@ impurify_range(LispObj *start, LispObj *end, LispObj low, LispObj high, int delt
 
 
 void
-impurify_tcr_tlb(TCR *tcr,  LispObj low, LispObj high, int delta)
+impurify_tcr_tlb(TCR *tcr,  LispObj low, LispObj high, signed_natural delta)
 {
   unsigned n = tcr->tlb_limit;
   LispObj *start = tcr->tlb_pointer, *end = (LispObj *) ((BytePtr)start+n);
@@ -2163,7 +2163,7 @@ impurify_tcr_tlb(TCR *tcr,  LispObj low, LispObj high, int delta)
 }
 
 void
-impurify_tcr_xframes(TCR *tcr, LispObj low, LispObj high, int delta)
+impurify_tcr_xframes(TCR *tcr, LispObj low, LispObj high, signed_natural delta)
 {
   xframe_list *xframes;
   ExceptionInformation *xp;
@@ -2179,7 +2179,7 @@ impurify_tcr_xframes(TCR *tcr, LispObj low, LispObj high, int delta)
 }
 
 void
-impurify_tstack_area(area *a, LispObj low, LispObj high, int delta)
+impurify_tstack_area(area *a, LispObj low, LispObj high, signed_natural delta)
 {
   LispObj
     *current,
@@ -2199,7 +2199,7 @@ impurify_tstack_area(area *a, LispObj low, LispObj high, int delta)
   }
 }
 void
-impurify_vstack_area(area *a, LispObj low, LispObj high, int delta)
+impurify_vstack_area(area *a, LispObj low, LispObj high, signed_natural delta)
 {
   LispObj
     *p = (LispObj *) a->active,
@@ -2214,7 +2214,7 @@ impurify_vstack_area(area *a, LispObj low, LispObj high, int delta)
 
 
 void
-impurify_areas(LispObj low, LispObj high, int delta)
+impurify_areas(LispObj low, LispObj high, signed_natural delta)
 {
   area *next_area;
   area_code code;
@@ -2267,8 +2267,8 @@ impurify(TCR *tcr, signed_natural param)
     area *a = active_dynamic_area;
     BytePtr ro_base = r->low, ro_limit = r->active, oldfree = a->active,
       oldhigh = a->high, newhigh; 
-    unsigned n = ro_limit - ro_base;
-    int delta = oldfree-ro_base;
+    natural n = ro_limit - ro_base;
+    signed_natural delta = oldfree-ro_base;
     TCR *other_tcr;
 
     if (n) {


### PR DESCRIPTION
`impurify` on the PPC kernel computes two 64-bit quantities into 32-bit locals. It then passes one of them to ten helpers that narrow it again. On ppc64 every value above 2 GB is lost.

I cite `master` at `21173b12`. `lisp-kernel/ppc-gc.c` is byte-identical on the `arm64` branch at `5a8aab57` (blob `52db2b39`), so the patch applies to both.

## The two locals

```
lisp-kernel/ppc-gc.c:2270    unsigned n = ro_limit - ro_base;
lisp-kernel/ppc-gc.c:2271    int delta = oldfree-ro_base;
```

`n` is the size of the readonly area. `delta` is the distance the whole area moves. Neither one fits in 32 bits on a 64-bit build:

- `area.h:155` defines `PURESPACE_RESERVE` as `0x2000000000LL`, 128 GB, under `#if (WORD_SIZE==64)`.
- `lisptypes.h:22-25` makes `natural` and `signed_natural` 64-bit there.

`n` is also the length of the `memmove` and of the `munmap`. A readonly area over 4 GB therefore moves the wrong number of bytes. It does not only report a wrong size.

## Why the patch is twelve lines and not two

`delta` goes straight to four helpers. Three of them narrow it on entry.

| call site | callee | its parameter |
|---|---|---|
| `:2288` | `impurify_areas` `:2217` | `int` |
| `:2292` | `impurify_tcr_xframes` `:2166` | `int` |
| `:2293` | `impurify_tcr_tlb` `:2157` | `int` |
| `:2297` | `impurify_gcable_ptrs` `:2250` | `signed_natural` |

Only the last one is right today. `impurify_areas` then passes `delta` to five more helpers. They are `impurify_range`, `impurify_vstack_area`, `impurify_tstack_area`, `impurify_cstack_area` and `impurify_xp`. The chain ends at `impurify_locref` and `impurify_noderef`, which add `delta` to a pointer. All seven declare it `int` as well. A patch to the two locals alone would change nothing at all.

## What the patch is matched against

| file | branch | eleven `delta` parameters | locals |
|---|---|---|---|
| `x86-gc.c` | master `21173b12` | `signed_natural` | restructured, no narrowing |
| `arm64-gc.c` | arm64 `5a8aab57` | `signed_natural` | `natural` / `signed_natural` |
| `ppc-gc.c` | master `21173b12` | `int` on ten of eleven | `unsigned` / `int` |

After the patch, the `impurify` block in `ppc-gc.c` matches `arm64-gc.c` signature for signature. That is the closest comparison available. We ported `arm64-gc.c` from this file, and it still carries the comment `/* ppc-gc.c:2261-2303 */` on the function the patch changes.

I did not use `arm-gc.c` as the model, although it looks like a precedent. It widened the two locals at `arm-gc.c:2085-2086` and left nine helper parameters `int`. That is consistent for ARM32. ARM32 is a 32-bit port, where `signed_natural` is `int32_t` and none of this can bite. If I had read it as a fix, I would have written the two-line patch that does nothing.

## Effect on ppc32

None. On a 32-bit build `lisptypes.h:26-29` makes `natural` `uint32_t` and `signed_natural` `int32_t`. Every changed declaration keeps the width it has today. Only ppc64 behavior moves.

## Verification boundary

**I have no ppc32 machine and no ppc64 machine. This patch has never been compiled or run on the port it fixes.**

Established: type correctness. I read the widths out of `lisptypes.h` and `area.h`, the eleven signatures out of `ppc-gc.c` itself, and the target shape out of two other ports in the same tree.

Not established: any statement about behavior. There is no ppc build and no `impurify` run, and I did not watch a truncation happen. The defect is real by inspection. The fix is unexercised.

I found this by copying it. Our `arm64-gc.c` inherited the narrowing from here, and one look at `x86-gc.c` would have caught it before we did.
