### PR TITLE
print: the crash printer truncates a uvector element count

### DIFF
--- a/lisp-kernel/arm_print.c
+++ b/lisp-kernel/arm_print.c
@@ -318,9 +318,8 @@ void
 sprint_gvector(LispObj o, int depth)
 {
   LispObj header = header_of(o);
-  unsigned 
-    elements = header_element_count(header),
-    subtag = header_subtag(header);
+  natural elements = header_element_count(header);
+  unsigned subtag = header_subtag(header);
     
   switch(subtag) {
   case subtag_function:
@@ -342,7 +341,7 @@ sprint_gvector(LispObj o, int depth)
    
   case subtag_simple_vector:
     {
-      int i;
+      natural i;
       add_c_string("#(");
       for(i = 1; i <= elements; i++) {
         if (i > 1) {
@@ -364,9 +363,8 @@ void
 sprint_ivector(LispObj o)
 {
   LispObj header = header_of(o);
-  unsigned 
-    elements = header_element_count(header),
-    subtag = header_subtag(header);
+  natural elements = header_element_count(header);
+  unsigned subtag = header_subtag(header);
     
   switch(subtag) {
   case subtag_simple_base_string:

--- a/lisp-kernel/ppc_print.c
+++ b/lisp-kernel/ppc_print.c
@@ -318,9 +318,8 @@ void
 sprint_gvector(LispObj o, int depth)
 {
   LispObj header = header_of(o);
-  unsigned 
-    elements = header_element_count(header),
-    subtag = header_subtag(header);
+  natural elements = header_element_count(header);
+  unsigned subtag = header_subtag(header);
     
   switch(subtag) {
   case subtag_function:
@@ -342,7 +341,7 @@ sprint_gvector(LispObj o, int depth)
    
   case subtag_simple_vector:
     {
-      int i;
+      natural i;
       add_c_string("#(");
       for(i = 1; i <= elements; i++) {
         if (i > 1) {
@@ -364,9 +363,8 @@ void
 sprint_ivector(LispObj o)
 {
   LispObj header = header_of(o);
-  unsigned 
-    elements = header_element_count(header),
-    subtag = header_subtag(header);
+  natural elements = header_element_count(header);
+  unsigned subtag = header_subtag(header);
     
   switch(subtag) {
   case subtag_simple_base_string:

--- a/lisp-kernel/x86_print.c
+++ b/lisp-kernel/x86_print.c
@@ -443,9 +443,8 @@ void
 sprint_gvector(LispObj o, int depth)
 {
   LispObj header = header_of(o);
-  unsigned 
-    elements = header_element_count(header),
-    subtag = header_subtag(header);
+  natural elements = header_element_count(header);
+  unsigned subtag = header_subtag(header);
     
   switch(subtag) {
   case subtag_function:
@@ -467,7 +466,7 @@ sprint_gvector(LispObj o, int depth)
    
   case subtag_simple_vector:
     {
-      int i;
+      natural i;
       add_c_string("#(");
       for(i = 1; i <= elements; i++) {
         if (i > 1) {
@@ -507,9 +506,8 @@ void
 sprint_ivector(LispObj o)
 {
   LispObj header = header_of(o);
-  unsigned 
-    elements = header_element_count(header),
-    subtag = header_subtag(header);
+  natural elements = header_element_count(header);
+  unsigned subtag = header_subtag(header);
     
   switch(subtag) {
   case subtag_simple_base_string:


### PR DESCRIPTION
`sprint_gvector` and `sprint_ivector` read a 64-bit element count into a 32-bit local. `sprint_gvector` then walks the count with an `int`. Both faults are 64-bit only, and both need a very large vector. This is a type correction, not a fault that anyone has reported.

I cite `master` at `21173b12`. `lisp-kernel/x86_print.c`, `lisp-kernel/ppc_print.c` and `lisp-kernel/arm_print.c` are byte-identical on the `arm64` branch at `5a8aab57`. The patch applies to both.

## The count

`macros.h:38` is

```c
#define header_element_count(h) ((h) >> num_subtag_bits)
```

on a `LispObj`, which is `uint64_t` when `WORD_SIZE == 64` (`lisptypes.h:22-23`). Six sites store that result in a 32-bit local.

| file | line | function |
|---|---|---|
| `x86_print.c` | `:446` | `sprint_gvector` |
| `x86_print.c` | `:509` | `sprint_ivector` |
| `ppc_print.c` | `:321` | `sprint_gvector` |
| `ppc_print.c` | `:366` | `sprint_ivector` |
| `arm_print.c` | `:321` | `sprint_gvector` |
| `arm_print.c` | `:366` | `sprint_ivector` |

The assignment loses the count, before anything uses it. The truncated value then goes to `sprint_random_vector`, whose parameter is already `natural`. That widening on the way in is what hides the loss.

These two functions are the only places in each file that narrow the count. Every other consumer already spells it `natural`.

| consumer | `x86_print.c` | `ppc_print.c` | `arm_print.c` |
|---|---|---|---|
| `sprint_string` | `:61` | `:58` | `:58` |
| `sprint_random_vector` | `:289` | `:229` | `:229` |
| `sprint_function` | `:337` | `:270` | `:270` |

## The loop counter

```c
x86_print.c:469   int i;   ... for(i = 1; i <= elements; i++)
ppc_print.c:344   int i;
arm_print.c:344   int i;
```

The comparison promotes `i` to the type of `elements`. The loop is safe today only because `elements` is already 32 bits. To widen `elements` alone would move the fault, not remove it. `i++` at `INT_MAX` is undefined, and `deref(o, i)` with a wrapped `i` indexes backwards. The two changes belong together.

## What the patch is matched against

`lisp-kernel/arm64-print.c` on the `arm64` branch at `5a8aab57` already writes the declaration the way this patch writes it, in both functions:

```c
arm64-print.c:293-294   natural elements = header_element_count(header);
                        unsigned subtag = header_subtag(header);
arm64-print.c:349-350   the same two lines
```

So this is not a new opinion about the right spelling. That spelling is already in the newest of these four files. The patch applies it to the three that predate it. `subtag` stays `unsigned`, as it is there.

`arm64-print.c:313` still declares the same loop counter `int`. That file exists only on the `arm64` branch, so it is not in this patch. I will send it against that branch rather than mix two branches in one change.

## Verification boundary

**I have no ppc32, ppc64 or ARM32 machine. This patch touches all three of those kernels as well as x86. I did not watch any of the six declarations truncate anything.**

Established: the widths, from `macros.h:38` and `lisptypes.h:22-29`. The six sites, read out of the three files. The target spelling, taken from `arm64-print.c` rather than invented.

Not established: any statement about behavior. To reach either fault, the crash-time printer must print a simple-vector with more than 2^31 elements, 16 GB and up, inside a kernel debugger session. I do not expect anyone to have seen it. I report it as a type error that survives because nothing exercises it.
