### PR TITLE
arm64: force the walk-dynamic-area alloc trap with an all-ones allocbase

### DIFF
--- a/level-0/ARM64/arm64-utils.lisp
+++ b/level-0/ARM64/arm64-utils.lisp
@@ -157,10 +157,8 @@
 ;;;
 ;;; Like walk-static-area but objects may be consed while walking:
 ;;; terminate at a freshly-allocated sentinel cons.  The sentinel is
-;;; allocated by FORCING the allocation trap (allocbase set to all ones
-;;; so the no-trap branch cannot be taken) — the kernel completes
-;;; the allocation exactly as PPC's tdlt-always-traps idiom did; the
-;;; allocation request is conveyed by allocptr's fulltag (cons).
+;;; allocated by forcing the allocation trap (allocbase set to all ones
+;;; so the no-trap branch cannot be taken).
 ;;; PPC's cr0 (tenured-area zero test, ppc:381) stays live across the
 ;;; sentinel allocation; our alloc protocol contains a cmp, so the
 ;;; selection is resolved FIRST with csel — same value, earlier point.
@@ -182,32 +180,18 @@
     (ref-global imm0 tenured-area)      ; ppc:380
     (cmp imm0 (:$ 0))                   ; ppc:381 (cmpdi cr0)
     (csel a imm0 a (:? ne))             ; ppc:390-391 (if :ne (mr a imm0)) — moved up
-    ;;; ARM64-DEVIATION: allocbase := all ones, not ppc:382-384's constant
-    ;;; #x8000_0000_0000 - 16.  The intent is the same -- put allocbase out
-    ;;; of reach so the skip branch below cannot be taken and the trap
-    ;;; always fires -- but ppc:386 is `tdlt', trap-if-SIGNED-less-than,
-    ;;; while the arm64 sequence skips on an UNSIGNED compare.  allocptr
-    ;;; here is very often VOID_ALLOCPTR (lisp-kernel/gc.h:125,
-    ;;; (LispObj)(-dnode_size) = #xfffffffffffffff0): a gc leaves every tcr
-    ;;; in that state (lisp-kernel/arm64-exceptions.c:897) and
-    ;;; heap-utilization gcs immediately before it walks.  Unsigned,
-    ;;; #xffffffffffffffe3 IS above #x00007ffffffffff0, so the branch is
-    ;;; taken, no sentinel cons is allocated, and the walk -- whose only
-    ;;; terminator is that sentinel -- runs off the end of the heap and
-    ;;; faults.  Nothing is unsigned-above all ones, so this traps for any
-    ;;; allocptr and the canonical alloc sequence below needs no change.
-    (movn allocbase (:$ 0))             ; allocbase := #xffffffffffffffff
-    ;; tagged-cons allocptr, then the canonical alloc-trap protocol.
-    (sub allocptr allocptr (:$ (- arm64::cons.size arm64::fulltag-cons))) ; ppc:385 (la)
-    (cmp allocptr allocbase)            ; ppc:386 (tdlt allocptr allocbase) …
-    (b.hi @no-trap)                     ; … canonical Misc_Alloc shape: skip iff
-                                        ; allocptr strictly above allocbase (the
-                                        ; b.hi pc_luser_xp recognizes; here the
-                                        ; forced-high allocbase makes it always trap)
+    ;; Force the uuo-alloc-trap by setting allocbase to all ones so
+    ;; that the b.hi will never be taken (nothing is unsigned-higher
+    ;; than all ones).  This gets us a fresh segment, and the cons
+    ;; cell will be guaranteed freshly-allocated.
+    (movn allocbase (:$ 0))             ;all ones
+    (sub allocptr allocptr (:$ (- arm64::cons.size arm64::fulltag-cons)))
+    (cmp allocptr allocbase)
+    (b.hi @no-trap)
     (uuo-alloc-trap)
     @no-trap
-    (mov sentinel allocptr)             ; ppc:387 (mr)
-    (bic allocptr allocptr (:$ arm64::fulltagmask)) ; ppc:388 (clrrdi ntagbits)
+    (mov sentinel allocptr)
+    (bic allocptr allocptr (:$ arm64::fulltagmask))
     (mov fun f)                         ; ppc:389 (mr)
     (ldr imm5 (:@ a (:$ arm64::area.low))) ; ppc:392 (ld imm5 …)
     @loop

--- a/level-0/ARM64/arm64-utils.lisp
+++ b/level-0/ARM64/arm64-utils.lisp
@@ -157,8 +157,8 @@
 ;;;
 ;;; Like walk-static-area but objects may be consed while walking:
 ;;; terminate at a freshly-allocated sentinel cons.  The sentinel is
-;;; allocated by FORCING the allocation trap (allocbase set to a huge
-;;; value so the no-trap branch is never taken) — the kernel completes
+;;; allocated by FORCING the allocation trap (allocbase set to all ones
+;;; so the no-trap branch cannot be taken) — the kernel completes
 ;;; the allocation exactly as PPC's tdlt-always-traps idiom did; the
 ;;; allocation request is conveyed by allocptr's fulltag (cons).
 ;;; PPC's cr0 (tenured-area zero test, ppc:381) stays live across the
@@ -182,9 +182,21 @@
     (ref-global imm0 tenured-area)      ; ppc:380
     (cmp imm0 (:$ 0))                   ; ppc:381 (cmpdi cr0)
     (csel a imm0 a (:? ne))             ; ppc:390-391 (if :ne (mr a imm0)) — moved up
-    ;; allocbase := #x8000_0000_0000 - 16 so the trap below always fires.
-    (movz allocbase (:$ #x8000 :lsl 32)) ; ppc:382-383 (lwi #x8000; sldi 32)
-    (sub allocbase allocbase (:$ 16))   ; ppc:384 (subi allocbase allocbase 16)
+    ;;; ARM64-DEVIATION: allocbase := all ones, not ppc:382-384's constant
+    ;;; #x8000_0000_0000 - 16.  The intent is the same -- put allocbase out
+    ;;; of reach so the skip branch below cannot be taken and the trap
+    ;;; always fires -- but ppc:386 is `tdlt', trap-if-SIGNED-less-than,
+    ;;; while the arm64 sequence skips on an UNSIGNED compare.  allocptr
+    ;;; here is very often VOID_ALLOCPTR (lisp-kernel/gc.h:125,
+    ;;; (LispObj)(-dnode_size) = #xfffffffffffffff0): a gc leaves every tcr
+    ;;; in that state (lisp-kernel/arm64-exceptions.c:897) and
+    ;;; heap-utilization gcs immediately before it walks.  Unsigned,
+    ;;; #xffffffffffffffe3 IS above #x00007ffffffffff0, so the branch is
+    ;;; taken, no sentinel cons is allocated, and the walk -- whose only
+    ;;; terminator is that sentinel -- runs off the end of the heap and
+    ;;; faults.  Nothing is unsigned-above all ones, so this traps for any
+    ;;; allocptr and the canonical alloc sequence below needs no change.
+    (movn allocbase (:$ 0))             ; allocbase := #xffffffffffffffff
     ;; tagged-cons allocptr, then the canonical alloc-trap protocol.
     (sub allocptr allocptr (:$ (- arm64::cons.size arm64::fulltag-cons))) ; ppc:385 (la)
     (cmp allocptr allocbase)            ; ppc:386 (tdlt allocptr allocbase) …


### PR DESCRIPTION
`(ccl::heap-utilization)` core-dumps on arm64. It core-dumps every time, on an image that runs the full ANSI suite at 21679/0. ANSI cannot call `heap-utilization`, so the green bar never sees it.

I cite branch `arm64` at `38e598aa` for every line below.

## The defect

`%walk-dynamic-area` (`level-0/ARM64/arm64-utils.lisp:167`) stops its walk at a sentinel cons. It gets that sentinel by forcing the allocation trap. It forces the trap the way ppc64 does (`level-0/PPC/ppc-utils.lisp:382-386`). It loads `allocbase` with the constant `#x8000_0000_0000 - 16`, so that the skip branch cannot be taken.

The constant does not do that on arm64. The two ports test it differently.

- ppc64 tests it with `tdlt`, which traps if `allocptr` is SIGNED less than `allocbase`.
- arm64 has no trap-on-condition instruction. The sequence is `cmp` + skip branch + `uuo-alloc-trap`, and the skip branch is UNSIGNED.

`allocptr` at this site is usually `VOID_ALLOCPTR`, which is negative. `lisp-kernel/gc.h:123-125` gives `PPC64` the value `0x8000000000000000-dnode_size`. It gives every other port, arm64 included, `(LispObj)(-dnode_size)` = `0xfffffffffffffff0`. A GC leaves every TCR in that state (`lisp-kernel/arm64-exceptions.c:897`). `heap-utilization` runs a GC immediately before it walks. So the failing case is the default one.

```
allocptr  = 0xfffffffffffffff0                 VOID_ALLOCPTR
allocptr -= (cons.size - fulltag-cons) = 13
allocptr  = 0xffffffffffffffe3                 signed -29
allocbase = 0x00007ffffffffff0
cmp allocptr, allocbase   ->   N=1  Z=0  C=1  V=0
```

I measured those flags. I did not compute them. I read them out of the live image under gdb, one instruction at a time, at `%walk-dynamic-area` itself.

`C=1` means unsigned greater-or-equal. Both unsigned spellings of the skip branch are taken at these flags. `b.hs` tests `C==1`. `b.hi` tests `C==1 && Z==0`. So `uuo-alloc-trap` never runs, and the code allocates no sentinel cons.

The sentinel is the only terminator this loop has. There is no limit pointer here, unlike `walk-static-area`, which stops at `area.active`. So the walk leaves the dynamic area. It then reads unmapped memory as object headers until it faults. The scan pointer at the fault was `0x3889513b09c0`, about 62 TB, in an image whose objects all live at `0x3020_xxxx_xxxx`.

## What `38e598aa` did and did not do

`38e598aa` does not create this defect, and it does not change the behavior. At `5a8aab57` the skip branch is `b.hs`. At `38e598aa` it is `b.hi`. Both are unsigned, and the processor takes both at the flags above. I measured a core dump with each spelling. The bug is older than both commits.

`38e598aa` is where I found it. I was assessing the two new commits for a pin advance. The fix I already carried for this site conflicted with the new text. Nothing has gone out to anyone.

The comment `38e598aa` adds to the branch states the intent exactly:

```lisp
    (b.hi @no-trap)                     ; … canonical Misc_Alloc shape: skip iff
                                        ; allocptr strictly above allocbase (the
                                        ; b.hi pc_luser_xp recognizes; here the
                                        ; forced-high allocbase makes it always trap)
```

This patch makes the last clause true.

## The fix

Set `allocbase` to all ones instead of to a positive constant.

Nothing is unsigned-strictly-above all ones. Nothing at this site equals it either, because `allocptr` is 3 mod 16 after the `sub`. So the trap fires for every `allocptr`, `VOID_ALLOCPTR` included.

The patch changes the two instructions that build `allocbase`. It changes nothing else. The `cmp`, the branch, the `uuo-alloc-trap` and the `bic` all stay as you wrote them, so the canonical consing sequence stays byte-identical at all 15 sites in the tree.

The constant has two more weaknesses that all ones removes.

1. The constant only holds while every heap address stays below 140 TB.
2. Between the load of `allocbase` and the trap, any other allocation site compares against this `allocbase`. With the constant, such a site skips its own trap. It then allocates at an address the kernel did not give it. With all ones, it traps, and the kernel services it.

## Why not a signed branch

A signed branch also works with the constant. That was my first fix, and I am not sending it. It deviates from your canonical sequence for a reason the setup can remove.

The two answers exclude each other. I state that here so that nobody mixes them later. With an all-ones `allocbase`, the processor takes a signed branch whenever `allocptr` holds a real, positive heap address. That is the state the second and later walks start from, because the first walk refills `allocptr` through its own trap.

| `allocbase` | `allocptr` | `b.hs` / `b.hi` skip? | `b.ge` skip? |
|---|---|---|---|
| `0x00007ffffffffff0` | `0xffffffffffffffe3` (void) | yes, the bug | no |
| `0x00007ffffffffff0` | `0x000030200000fff3` (live) | no | no |
| `0xffffffffffffffff` | `0xffffffffffffffe3` (void) | no | no |
| `0xffffffffffffffff` | `0x000030200000fff3` (live) | no | yes, a bug |

## About `IS_BRANCH_AROUND_ALLOC_TRAP`

I want to be exact here. I read this macro as a constraint at first, and today it is not one.

`lisp-kernel/arm64-exceptions.c:272` defines `IS_BRANCH_AROUND_ALLOC_TRAP(i)` as `((i) == 0x54000048)`, the encoding of `b.hi .+8`. On the `arm64` branch that macro is defined and never called. The two callers are `lisp-kernel/arm-exceptions.c:110` and `:1639`, which are ARM32. On arm64, `pc_luser_xp` calls `allocptr_displacement(xp)`. That function requires the PC to sit at the `udf` and reads `program_counter[-3]` for the `sub` (`arm64-exceptions.c:350-366`). It never examines the branch. `IS_ALLOC_TRAP` is the positive control for the grep: `arm64-exceptions.c` defines it at `:274` and uses it at `:355` and `:1250`.

I say this to show why the fix did not have to keep `b.hi`. I do not claim the macro is pointless. This patch keeps `b.hi` anyway, so the invariant holds whether or not arm64 starts to use it.

## Evidence

Red and green are one instruction apart. Same branch, same pin `5a8aab57`, same patch series, same host compiler image, same kernel.

| | RED | GREEN |
|---|---|---|
| `allocbase` setup | `movz #x8000 lsl 32` / `sub 16` | `movn allocbase, #0` |
| skip branch | `b.hi`, as `38e598aa` | `b.hi`, as `38e598aa` |
| image md5 | `b01f62abe3077e13d7abab861ad24127` | `5ce3369387d0666f8aa56fbba3e0bcad` |
| kernel md5 | `bcdc65de3da3b8073aca1bffa6f42b59` | `bcdc65de3da3b8073aca1bffa6f42b59` |
| heap-walk probe | `EXIT:139`, SIGSEGV, 3 of 19 checks reached | `:FAILED 0`, 19 of 19 pass, `EXIT:0` |

One kernel ran both images, because the patch touches no `lisp-kernel/` file.

The patched tree also runs the two suites clean. Load context `:TOPLEVEL`, `*test-verbose*` NIL:

```
STAGE-11-RUN-FULL-ANSI   :LOAD-CONTEXT :TOPLEVEL :RT-VERBOSE NIL
                         :TOTAL 21679  :FAILED 0
STAGE-12-RUN-CCL-TESTS   :TOTAL 243    :FAILED 0
```

`(disassemble 'ccl::%walk-dynamic-area)` inside each image is the artifact-level proof. A changed md5 shows that something moved. The disassembly shows what.

```
RED    image b01f62abe3077e13d7abab861ad24127
  (mov allocbase (:$ #x800000000000))              ; D2D0001B
  (sub allocbase allocbase (:$ 16))                ; D100437B
  (sub allocptr allocptr (:$ 13))                  ; D100375A
  (cmp allocptr allocbase)                         ; EB1B035F
  (b.hi L72)                                       ; 54000048
  (uuo-alloc-trap)                                 ; 00000004
  (and allocptr allocptr (:$ #xFFFFFFFFFFFFFFF0))  ; 927CEF5A

GREEN  image 5ce3369387d0666f8aa56fbba3e0bcad
  (mov allocbase (:$ #xFFFFFFFFFFFFFFFF))          ; 9280001B
  (sub allocptr allocptr (:$ 13))                  ; D100375A
  (cmp allocptr allocbase)                         ; EB1B035F
  (b.hi L68)                                       ; 54000048
  (uuo-alloc-trap)                                 ; 00000004
  (and allocptr allocptr (:$ #xFFFFFFFFFFFFFFF0))  ; 927CEF5A
```

Two encodings carry the point. The branch word is `0x54000048` in both images, which is the exact constant `IS_BRANCH_AROUND_ALLOC_TRAP` tests. The tag clear is `0x927CEF5A` in both, which is the exact constant `IS_CLR_ALLOCPTR_TAG` tests (`arm64-exceptions.c:292-294`). A signed branch would have moved the first word to `0x5400004A`.

The probe holds 19 checks around `(ccl::heap-utilization)`, `%map-areas` and `collect-heap-utilization`. It passes on stock x86-64 CCL 1.12.2, so it tests the port and not the extension. Its discriminator is a compiled `(gc)` followed by `(%map-areas … :dynamic)`. That is the shape `collect-heap-utilization-by-typecode` has at `lib/misc.lisp:1143-1144`. An interpreted `(gc)` and walk does NOT reproduce the fault, because the evaluator conses in between, and the first cons refills `allocptr` with a real address.

## Verification boundary

I built and ran this on Linux arm64, Graviton4. The disassembly above comes out of each image, so it describes the binary and not the source tree.

I have no ppc64 machine. Everything in the next section is read, not run.

## A question about ppc64

ppc64 gives `VOID_ALLOCPTR` the value `0x8000000000000000 - dnode_size` = `0x7ffffffffffffff0` (`lisp-kernel/gc.h:116-117`, `master` at `21173b12`). That is a large POSITIVE signed value. `level-0/PPC/ppc-utils.lisp:382-386` then forces the trap with `allocbase` = `0x00007ffffffffff0`, which is smaller. `tdlt` traps if `allocptr` is signed less than `allocbase`, and `0x7fffffffffffffe3` is not less than `0x00007ffffffffff0`.

Does `%walk-dynamic-area` reach that state on ppc64? Or does something there refill `allocptr` before the walk? I cannot test it.
