### PR TITLE
arm64: the crash printer walks a uvector with an int

### DIFF
--- a/lisp-kernel/arm64-print.c
+++ b/lisp-kernel/arm64-print.c
@@ -310,7 +310,7 @@ sprint_gvector(LispObj o, int depth)
     break;
   case subtag_simple_vector:
     {
-      int i;
+      natural i;
       add_c_string("#(");
       for (i = 1; i <= elements; i++) {
         if (i > 1) {


### PR DESCRIPTION
`lisp-kernel/arm64-print.c:313` declares the simple-vector loop counter `int` while the element count next to it is `natural`. This is the `arm64`-branch half of the change in PR #580, which corrects the same loop counter in `x86_print.c`, `ppc_print.c` and `arm_print.c` on `master`. PR #580 says this site exists and follows separately.

I cite the `arm64` branch at `5a8aab57`. `lisp-kernel/arm64-print.c` is byte-identical at `5a8aab57` and at `38e598aa`, so the patch applies to both.

## The site

```c
arm64-print.c:293   natural elements = header_element_count(header);
arm64-print.c:313   int i;
arm64-print.c:315   for (i = 1; i <= elements; i++) {
arm64-print.c:319     sprint_lisp_object(deref(o, i), depth);
```

`header_element_count` is `((h) >> num_subtag_bits)` on a `LispObj`, which is `uint64_t` when `WORD_SIZE == 64` (`macros.h:38`, `lisptypes.h:22-23`).

The comparison promotes `i` to `natural`, so the count survives. The counter does not. At `INT_MAX` the increment is undefined, and `deref(o, i)` with a wrapped `i` indexes backwards.

The three `master` files in PR #580 also narrow the count itself. `arm64-print.c` does not. It already spells the count `natural` in both `sprint_gvector` and `sprint_ivector`, so the loop counter is the only site left here.

`:313` is the only narrowed counter in the file. `:43` already declares `natural i`.

## What the build shows

I built the `arm64` kernel twice on a Graviton4 host, from the same tree, with GCC at `-g -O2 -fno-strict-aliasing`. The only difference between the two builds is this patch.

| build | kernel md5 |
|---|---|
| without the patch | `ff18123975c555a0ab699ad642d949f3` |
| with the patch | `befaa9d216675b34a885f40ff27fccb5` |

A second build with the patch reproduced `befaa9d2...` byte for byte, so the difference is the patch and not build variance.

**The machine code does not change.** The `.text` section is identical in both kernels (`03f7d6a4aad62e49e9890fca25e91408`, 96732 bytes). Only `.debug_line` and `.debug_loclists` move.

The disassembly shows why. GCC lowers the loop to a 64-bit pointer walk and `i` does not survive:

```
cbz  x20, <end>              ; elements == 0
add  x20, x19, x20, lsl #3   ; end = base + elements*8
add  x19, x19, #0x8
```

GCC may do this because it can assume the signed increment never wraps. The loop is correct today because of that assumption, not because of the code. Another compiler, another optimization level, or a sanitizer build does not owe us the same lowering. `natural i` makes the loop correct on its own terms.

## Non-regression

Same host, image `3c69335d4973f8fe9f5078b06dc6a195`, kernel `befaa9d216675b34a885f40ff27fccb5`, `*rt-verbose*` NIL, tests loaded at toplevel:

```
ANSI     :TOTAL 21679  :FAILED 0
ccl.lsp  :TOTAL 243    :FAILED 0
```

The kernel without the patch gives the same two numbers, which is what a byte-identical `.text` predicts.

## Verification boundary

I built and ran this on linuxarm64 only. I did not reach the fault. To reach it, the crash-time printer must print a simple-vector with more than 2^31 elements, 16 GB and up, inside a kernel debugger session. I report a type error that survives because nothing exercises it, not a fault with a reproduction behind it.
