### PR TITLE
arm64: one catch_frame layout; add csp to the constants header

### DIFF
--- a/lisp-kernel/arm64-constants.h
+++ b/lisp-kernel/arm64-constants.h
@@ -437,6 +437,7 @@ _structf catch_frame
  _node catch_tag                /* #<unbound> -> unwind-protect, else catch */
  _node link                     /* backpointer to previous catch frame */
  _node mvflag                   /* 0 if single-valued catch, else fixnum 1 */
+ _node csp                      /* saved control-stack lisp_frame pointer */
  _node db_link                  /* head of special-binding chain */
  _field regs, 4*node_size       /* save0 through save3 */
  _node xframe                   /* exception frame chain */

--- a/lisp-kernel/spentry-C-bind-catch-throw.s
+++ b/lisp-kernel/spentry-C-bind-catch-throw.s
@@ -159,19 +159,10 @@ _ends
 .set tsp_frame.fixed_overhead, tsp_frame.size
 .set tsp_frame.data_offset, tsp_frame.size
 
-/* catch_frame: PPC64 layout (ppc-constants64.s _structf(catch_frame);
-   ppc-constants64.h:213), but with regs sized to this design's nsaveregs=4
-   (save0..save3) instead of PPC's 8. */
-_structf catch_frame
-  _node catch_tag           /* unbound_marker => unwind-protect, else catch */
-  _node link                /* previous catch frame                         */
-  _node mvflag              /* 0 => single value, fixnum 1 => multiple       */
-  _node csp                 /* saved control-stack lisp_frame pointer        */
-  _node db_link             /* special-binding chain head                    */
-  _field regs, (nsaveregs*node_size)  /* save0..save3                        */
-  _node xframe              /* exception-frame chain                         */
-  _node nfp                 /* numeric/foreign frame pointer                 */
-_endstructf
+/* catch_frame comes from arm64-constants.h: PPC64's layout
+   (ppc-constants64.s _structf(catch_frame); ppc-constants64.h:213), with
+   regs sized to this design's nsaveregs=4 (save0..save3) instead of
+   PPC's 8.  This file used to redefine it locally; keep one copy. */
 
 /*
  * ---------------------------------------------------------------------------
@@ -240,7 +231,7 @@ _endstructf
 .endm
 
 /* save/restore the boxed NVRs into/from a catch frame's regs[] (save0..save3).
-   catch_frame is a fulltag_misc-biased _structf, so .regs = 44 is only
+   catch_frame is a fulltag_misc-biased _structf, so .regs = 36 is only
    4-aligned -- stp/ldp (which need an 8-scaled imm7) cannot be used; single
    str/ldr take any byte offset. */
 .macro save_catch_regs cf


### PR DESCRIPTION
The arm64 branch has two definitions of `_structf catch_frame`, and they do not agree.

`lisp-kernel/arm64-constants.h:436` (at `5a8aab57`) has no `csp` slot. In that copy, `db_link`, `regs`, `xframe` and `nfp` sit one node too low, and `element_count` is 10. `lisp-kernel/spentry-C-bind-catch-throw.s:165` defines its own copy with `csp`, 11 slots. The struct fields are `.set` symbols, so the second definition silently replaces the first inside that file.

The 11-slot layout is the real one. The spentries write and read `csp`: mkcatch stores `sp` there, and throw restores `sp` from it. The C overlay in `arm64-exceptions.c:123` and the Lisp layout in `compiler/ARM64/arm64-arch.lisp:637` both have `csp` at the same slot. Only the header copy differs, and nothing reads it today.

The defect is therefore latent. It fires when any other assembly file names a `catch_frame` field. That file gets the header offsets, which are wrong from `db_link` on, with no diagnostic. The same shadowing pattern is why the disagreement was invisible: the one file that uses the fields also redefines them.

The patch keeps one definition. It adds `csp` to the header in the PPC64 slot order (`ppc-constants64.s`). It deletes the private copy in spentry-C. It also corrects a stale offset in a comment: `catch_frame.regs` is 36, not 44. The assembler symbol value confirms 36.

Verification, on linuxarm64 (Graviton):

1. A probe that assembles against the header alone shows the change: `element_count` 10 -> 11, `db_link` 20 -> 28, `xframe` 60 -> 68, `nfp` 68 -> 76, `size` 88 -> 96.
2. I built the kernel at `5a8aab57` with and without this patch. Every allocated section is byte-identical (`.text` md5 `4f4e5de631d3381982eff7e2c4b4a9c2` in both). Only the build-id note and the symbol table differ. The patch changes no behavior, by construction.
3. The patch also applies clean at `13f73fcd`, the current branch tip, which has the same two definitions.

Note for later: spentry-C also carries local copies of `lisp_frame` and `tsp_frame`. Those agree with the header today, so this patch does not touch them. They are candidates for the same dedup.
