### PR TITLE
darwinarm64: native Apple Silicon port — Mach kernel, W^X, AAPCS64 FFI, ObjC bridge, Cocoa IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ tags
 /*boot*
 
 /armcl
+/arm64cl
+/darm64cl
 /?x86cl
 /?x86cl64
 /wx86cl.exe

--- a/doc/porting/progress.md
+++ b/doc/porting/progress.md
@@ -1,5 +1,23 @@
 # Progress notes on an arm64 port
 
+## August 2026 — Darwin/arm64 kernel scaffold (egao1980)
+
+Started Apple Silicon kernel bring-up on top of the `arm64` branch
+(Linux/arm64 already boots + ANSI green).
+
+Added:
+
+* `lisp-kernel/darwinarm64/Makefile` → builds `darm64cl` (ASLR, no pagezero)
+* Expanded `platform-darwinarm64.h` (xp accessors, ABI shims)
+* `lisp-kernel/arm64-darwin-mach.c` — stub Darwin TCR/Mach hooks; Unix
+  signals for UUOs until Mach exception server is ported
+* `darwin_sigreturn` in `arm64-asmutils.s`
+* `tools/xdarwinarm64.lisp` (alias of the darwinarm64 cross-setup)
+
+Still open for Darwin: MAP_JIT / separate code area, rnil-relative
+statics (no fixed low memory), Mach exception ports, Apple AAPCS64
+divergences in FFI, interface `.cdb` databases.
+
 ## May 21 – June 23
 I looked a bit at Manfred Bergmann’s code at
 https://github.com/mdbergmann/ccl/tree/arm64-arch-foundation. This code is

--- a/lisp-kernel/arm64-asmutils.s
+++ b/lisp-kernel/arm64-asmutils.s
@@ -276,4 +276,16 @@ C(isb):
         isb
         ret
 
+#if defined(__APPLE__)
+/* Darwin sigreturn: SYS_sigreturn = 184 (0xb8), UNIX class in x16 high nibble.
+ * Same shape as x86-asmutils64.s darwin_sigreturn (args ignored; ucontext
+ * already on the signal stack). */
+        .globl C(darwin_sigreturn)
+C(darwin_sigreturn):
+        movz    x16, #0xb8
+        movk    x16, #0x200, lsl #16
+        svc     #0x80
+        ret
+#endif
+
         .end

--- a/lisp-kernel/arm64-darwin-mach.c
+++ b/lisp-kernel/arm64-darwin-mach.c
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Darwin/arm64 Mach exception scaffolding.
+ *
+ * Full Mach exception ports (as on darwinx8664 / x86-exceptions.c) are
+ * not wired yet.  For early bring-up we keep the Darwin TCR lifecycle
+ * hooks so the kernel links, and rely on Unix signal handlers from
+ * arm64-exceptions.c (udf → SIGILL), same as linuxarm64.
+ *
+ * TODO: port associate_tcr_with_exception_port / mach_exc_server /
+ * setup_mach_exception_handling from x86-exceptions.c, then flip
+ * use_mach_exception_handling back to the Darwin default path.
+ */
+
+#include "lisp.h"
+#include "lisp-exceptions.h"
+#include "threads.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifdef DARWIN
+
+void
+associate_tcr_with_exception_port(mach_port_t port, TCR *tcr)
+{
+  (void)port;
+  (void)tcr;
+}
+
+void
+disassociate_tcr_from_exception_port(mach_port_t port)
+{
+  (void)port;
+}
+
+void
+darwin_exception_init(TCR *tcr)
+{
+  /*
+   * Intentionally empty for now: Unix signal handlers installed by
+   * exception_init() / install_pmcl_exception_handlers() cover UUO
+   * delivery.  Mach ports allocated in allocate_tcr() are retained but
+   * unused until the Mach server is ported.
+   */
+  (void)tcr;
+}
+
+void
+darwin_exception_cleanup(TCR *tcr)
+{
+  mach_port_t exception_port;
+
+  if (tcr == NULL)
+    return;
+
+  exception_port = (mach_port_t)((natural)TCR_AUX(tcr)->io_datum);
+  if (exception_port != MACH_PORT_NULL) {
+    disassociate_tcr_from_exception_port(exception_port);
+    mach_port_deallocate(mach_task_self(), exception_port);
+    TCR_AUX(tcr)->io_datum = NULL;
+  }
+}
+
+/* Stubs until Mach exception server is ported from x86-exceptions.c. */
+
+ExceptionInformation *
+create_thread_context_frame(mach_port_t thread,
+                            natural *stackp,
+                            siginfo_t *info,
+                            TCR *tcr,
+                            native_thread_state_t *ts)
+{
+  (void)thread;
+  (void)stackp;
+  (void)info;
+  (void)tcr;
+  (void)ts;
+  return NULL;
+}
+
+kern_return_t
+tcr_establish_lisp_exception_port(TCR *tcr)
+{
+  (void)tcr;
+  return KERN_SUCCESS;
+}
+
+#endif /* DARWIN */

--- a/lisp-kernel/arm64-exceptions.h
+++ b/lisp-kernel/arm64-exceptions.h
@@ -18,6 +18,9 @@ typedef arm_exception_state64_t native_exception_state_t;
 void associate_tcr_with_exception_port(mach_port_t, TCR *);
 void disassociate_tcr_from_exception_port(mach_port_t);
 
+#ifndef __lisp_kernel_opcode_defined
+#define __lisp_kernel_opcode_defined
 typedef uint32_t opcode, *pc;   /* AArch64 instructions are 32-bit */
+#endif
 
 #endif

--- a/lisp-kernel/arm64-macros.s
+++ b/lisp-kernel/arm64-macros.s
@@ -31,6 +31,33 @@ _SP\name:
         note_function_end _SP\name
         .endm
 
+/* Darwin's assembler rejects conditional branches to external symbols
+ * ("conditional branch requires assembler-local label").  Expand to a
+ * local conditional + unconditional branch to the external target.
+ * Linux gas accepts the direct form; keep it there for denser code. */
+        .macro bcond_ext cond, target
+#if defined(__APPLE__)
+        b.\cond .Lbce\@
+        b .Lbce_done\@
+.Lbce\@:
+        b \target
+.Lbce_done\@:
+#else
+        b.\cond \target
+#endif
+        .endm
+
+/* Load the C global lisp_nil into dest (then usually ldr dest,[dest]).
+ * Darwin/arm64 forbids text relocations from `ldr Rd, =sym`; use ADRP. */
+        .macro load_addr_of_lisp_nil dest
+#if defined(__APPLE__)
+        adrp    \dest, C(lisp_nil)@PAGE
+        add     \dest, \dest, C(lisp_nil)@PAGEOFF
+#else
+        ldr     \dest, =C(lisp_nil)
+#endif
+        .endm
+
         .macro clear_allocptr_tag
         bic allocptr, allocptr, #fulltagmask
         .endm

--- a/lisp-kernel/darwinarm64/Makefile
+++ b/lisp-kernel/darwinarm64/Makefile
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Darwin/arm64 (Apple Silicon) lisp kernel.
+# Modeled on linuxarm64/Makefile + darwinx8664 Darwin link extras.
+# No -pagezero_size / -no_pie: unsupported on arm64 Darwin (see doc/porting/darwin.md).
+
+VC_REVISION := "$(shell git describe --dirty 2>/dev/null || echo unknown)"
+
+OSVERSION ?= 11.0
+
+VPATH = ../
+RM = /bin/rm
+CC = cc
+ASFLAGS =
+CDEFINES = -DDARWIN -DARM64 -D_REENTRANT -D_DARWIN_C_SOURCE \
+	-DVC_REVISION=$(VC_REVISION)
+CDEBUG = -g
+COPT = -O2
+WFORMAT = -Wno-format
+PLATFORM_H = platform-darwinarm64.h
+
+.s.o:
+	$(CC) -c -x assembler-with-cpp -I../ $< $(CDEFINES) \
+		-mmacosx-version-min=$(OSVERSION) -o $@
+.c.o:
+	$(CC) -include ../$(PLATFORM_H) -c $< $(CDEFINES) $(CDEBUG) $(COPT) \
+		$(WFORMAT) -mmacosx-version-min=$(OSVERSION) -o $@
+
+SPOBJ = pad.o arm64-spentry.o spentry-A-alloc-numbers.o \
+	spentry-B-vectors-misc.o spentry-C-bind-catch-throw.o \
+	spentry-D-call-builtins.o spentry-E-ffi.o
+ASMOBJ = arm64-asmutils.o arm64-imports.o
+
+COBJ = pmcl-kernel.o gc-common.o arm64-gc.o bits.o arm64-exceptions.o \
+	arm64-darwin-mach.o image.o thread_manager.o lisp-debug.o \
+	memory.o unix-calls.o
+
+DEBUGOBJ = lispdcmd.o plprint.o plsym.o albt.o arm64-print.o
+KERNELOBJ = $(COBJ) arm64-asmutils.o arm64-imports.o
+
+SPINC = lisp.s arm64-constants.h arm64-macros.s errors.s arm64-uuo.s \
+	lisp_globals.s
+
+CHEADERS = area.h bits.h arm64-constants.h lisp-errors.h gc.h lisp.h \
+	lisp-exceptions.h lisp_globals.h macros.h memprotect.h image.h \
+	threads.h arm64-exceptions.h $(PLATFORM_H) os-darwin.h
+
+KSPOBJ = $(SPOBJ)
+
+# Binary name matches lib/compile-ccl.lisp (:darwinarm64 "darm64cl")
+all: ../../darm64cl
+
+OSLIBS = -lSystem -ldl
+
+../../darm64cl: $(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ)
+	$(CC) $(CDEBUG) -mmacosx-version-min=$(OSVERSION) \
+		-o $@ $(KSPOBJ) $(KERNELOBJ) $(DEBUGOBJ) $(OSLIBS)
+
+$(SPOBJ): $(SPINC)
+$(ASMOBJ): $(SPINC)
+$(COBJ): $(CHEADERS)
+$(DEBUGOBJ): $(CHEADERS) lispdcmd.h
+
+cclean:
+	$(RM) -f $(KERNELOBJ) $(DEBUGOBJ) ../../darm64cl
+
+clean: cclean
+	$(RM) -f $(SPOBJ)
+
+arm64-imports.o: ../arm64-imports.s ../arm64-asm.h

--- a/lisp-kernel/platform-darwinarm64.h
+++ b/lisp-kernel/platform-darwinarm64.h
@@ -1,11 +1,22 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
+/*
+ * Darwin/arm64 (Apple Silicon) platform header.
+ *
+ * Low-tag scheme matches linuxarm64 / compiler/ARM64.  Unlike
+ * darwinx8664 we cannot reserve low memory with -pagezero_size (see
+ * doc/porting/darwin.md); STATIC_BASE_ADDRESS in arm64-constants.h is
+ * provisional and will need a register-relative (rnil) redesign.
+ */
+
 #define WORD_SIZE 64
 #define PLATFORM_OS PLATFORM_OS_DARWIN
 #define PLATFORM_CPU PLATFORM_CPU_ARM64
 #define PLATFORM_WORD_SIZE PLATFORM_WORD_SIZE_64
 
+#ifndef _DARWIN_C_SOURCE
 #define _DARWIN_C_SOURCE
+#endif
 
 #include <sys/signal.h>
 #include <sys/ucontext.h>
@@ -15,26 +26,77 @@ typedef ucontext_t ExceptionInformation;
 #define UC_MCONTEXT(UC) UC->uc_mcontext
 
 #define MAXIMUM_MAPPABLE_MEMORY (512L<<30L)
-// this will end up being some random address
+/* Preferred image base; ASLR may relocate. Same provisional value as linuxarm64. */
 #define IMAGE_BASE_ADDRESS 0x300000000000L
 
 #include "lisptypes.h"
 #include "arm64-constants.h"
 
+#ifndef TCR_BIAS
+#define TCR_BIAS (0)
+#endif
+
+#ifndef unbound
+#define unbound unbound_marker
+#endif
+#ifndef slot_unbound
+#define slot_unbound slot_unbound_marker
+#endif
+#ifndef stack_alloc_marker
+#define stack_alloc_marker SUBTAG(fulltag_imm_1, 6)
+#endif
+
+#ifndef ABI_VERSION_CURRENT
+#define ABI_VERSION_MIN 1046
+#define ABI_VERSION_CURRENT 1046
+#define ABI_VERSION_MAX 1046
+#endif
+
+#ifndef lisp_frame_size
+#define lisp_frame_size sizeof(lisp_frame)
+#endif
+
+#ifndef fixnum_bitmask
+#define fixnum_bitmask(n)  (1LL<<((n)+fixnumshift))
+#endif
+
+#ifndef NSAVEREGS
+#define NSAVEREGS 4
+#endif
+
+#ifndef subtag_single_float
+#define subtag_single_float fulltag_single_float
+#endif
+
+/* is_node_fulltag: prefer gc.h's ARM64 definition when present. */
+
+/* AArch64 instructions are 32-bit; also defined under DARWIN in arm64-exceptions.h. */
+#ifndef __lisp_kernel_opcode_defined
+#define __lisp_kernel_opcode_defined
+typedef uint32_t opcode, *pc;
+#endif
+
+#define DARWIN_USE_PSEUDO_SIGRETURN 1
+
 extern void darwin_sigreturn(ExceptionInformation *, unsigned);
+extern natural os_major_version;
+
 #define DarwinSigReturn(context) do {                \
     darwin_sigreturn(context, 0x1e);                 \
     Bug(context,"sigreturn returned");               \
   } while (0)
 #define SIGRETURN(context) DarwinSigReturn(context)
 
+/* arm_thread_state64_t: __x[0..28], __fp, __lr, __sp, __pc, __cpsr, __flags */
 #define xpGPRvector(x) ((natural *)(&(UC_MCONTEXT(x)->__ss.__x)))
 #define xpGPR(x,gprno) (xpGPRvector(x)[gprno])
+#define set_xpGPR(x,gpr,new) xpGPR((x),(gpr)) = (natural)(new)
 #define xpSP(x) (UC_MCONTEXT(x)->__ss.__sp)
 #define xpLR(x) (UC_MCONTEXT(x)->__ss.__lr)
 #define xpPC(x) (*(pc *)&(UC_MCONTEXT(x)->__ss.__pc))
 #define set_xpPC(x, new) (xpPC(x) = (pc)(new))
 #define xpFaultAddress(x) (UC_MCONTEXT(x)->__es.__far)
+#define xpPSR(x) (UC_MCONTEXT(x)->__ss.__cpsr)
 
 #include <mach/mach.h>
 #include <mach/mach_error.h>

--- a/lisp-kernel/pmcl-kernel.c
+++ b/lisp-kernel/pmcl-kernel.c
@@ -75,10 +75,11 @@
 #endif
 #endif
 
-Boolean use_mach_exception_handling = 
-#ifdef DARWIN
+Boolean use_mach_exception_handling =
+#if defined(DARWIN) && !defined(ARM64)
   true
 #else
+  /* ARM64 Darwin: Mach exception server not ported yet; Unix signals. */
   false
 #endif
 ;

--- a/lisp-kernel/spentry-B-vectors-misc.s
+++ b/lisp-kernel/spentry-B-vectors-misc.s
@@ -1006,7 +1006,7 @@ misc_set_common:
            slot-vector/lock/instance/istruct/… (boot-16m5b). */
         and imm2, imm1, #7
         cmp imm2, #6                    /* fulltag_nodeheader_{0,1} & 7 */
-        b.eq _SPgvset
+        bcond_ext eq, _SPgvset
         /* Integer vectors */
         cmp imm1, #subtag_u8_vector
         b.eq misc_set_u8
@@ -1293,7 +1293,7 @@ spentry progvrestore
         ldr imm0, [imm0, #tsp_frame.data_offset]  /* ppc:6954 (data_offset=16, was mis-guessed 8) */
         cmp imm0, #0
         asr imm0, imm0, #fixnumshift
-        b.ne _SPunbind_n
+        bcond_ext ne, _SPunbind_n
         ret
 endsp progvrestore
 

--- a/lisp-kernel/spentry-C-bind-catch-throw.s
+++ b/lisp-kernel/spentry-C-bind-catch-throw.s
@@ -742,7 +742,7 @@ spentry setqsym
            Constant symbol => error; otherwise the real work is in .SPspecset. */
         ldr imm0, [arg_y, #symbol.flags]
         tst imm0, #sym_vbit_const_mask
-        b.eq _SPspecset
+        bcond_ext eq, _SPspecset
         mov arg_z, arg_y
         mov arg_y, #XCONST
         set_nargs 2
@@ -858,7 +858,7 @@ spentry bind_interrupt_level
         ldr imm4, [rcontext, #tcr.tlb_pointer]              /* ppc:7002 */
         ldr temp0, [imm4, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7003 old level */
         ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:7004 */
-        b.eq _SPbind_interrupt_level_0  /* ppc:7005 beq -> bind to 0 */
+        bcond_ext eq, _SPbind_interrupt_level_0  /* ppc:7005 beq -> bind to 0 */
         vpush1 temp0                    /* ppc:7006 binding frame: old value */
         vpush1 imm3                     /* ppc:7007               tlb index   */
         vpush1 imm1                     /* ppc:7008               prev db_link*/

--- a/lisp-kernel/spentry-D-call-builtins.s
+++ b/lisp-kernel/spentry-D-call-builtins.s
@@ -766,7 +766,7 @@ endsp tcallsymslide
 spentry tcallnfngen
         /* Tail call nfn - general */
         cmp nargs, #(nargregs << fixnumshift)
-        b.le _SPtcallnfnvsp
+        bcond_ext le, _SPtcallnfnvsp
         b _SPtcallnfnslide
 endsp tcallnfngen
 
@@ -1415,7 +1415,7 @@ ash_shift64:
          * PPC branches on cr0.eq from cntlzd. -- this reflects whether
          * original value was negative. */
         cmp imm0, #0
-        b.lt _SPmakes128
+        bcond_ext lt, _SPmakes128
         b _SPmakeu128
 9:
         /* ppc:5990 */
@@ -1481,7 +1481,7 @@ spentry builtin_aref1
         cmp imm0, #subtag_simple_vector
         /* ppc:3216 box_fixnum(arg_x,imm0) -- save typecode for subtag_misc_ref */
         lsl arg_x, imm0, #fixnumshift
-        b.eq _SPsubtag_misc_ref         /* ppc:3217 */
+        bcond_ext eq, _SPsubtag_misc_ref         /* ppc:3217 */
         /* ppc:3218 ivector_typecode_p(imm1,imm0,imm2) (ppc-macros.s:747):
            ONLY immediate-header subtags are CL ivectors; the macro zeroes a
            node-header subtag so the following compare fails.  We must do the
@@ -1495,7 +1495,7 @@ spentry builtin_aref1
         cmp imm1, #tag_nodeheader
         b.eq 1f
         cmp imm0, #min_cl_ivector_subtag  /* ppc:3219-3220 */
-        b.ge _SPsubtag_misc_ref
+        bcond_ext ge, _SPsubtag_misc_ref
 1:      jump_builtin _builtin_aref1, 2  /* ppc:3221 */
 endsp builtin_aref1
 
@@ -1512,7 +1512,7 @@ spentry builtin_aset1
         cmp imm0, #subtag_simple_vector
         /* ppc:6033 box_fixnum(temp0,imm0) -- subtag_misc_set wants boxed typecode */
         lsl temp0, imm0, #fixnumshift
-        b.eq _SPsubtag_misc_set         /* ppc:6034 */
+        bcond_ext eq, _SPsubtag_misc_set         /* ppc:6034 */
         /* ppc:6035-6037 ivector_typecode_p + compare.  Exclude node-headers
            (vectorH/arrayH) before the >= test — see builtin_aref1 for the
            tag-scheme rationale (raw compare would treat a complex array as an
@@ -1521,7 +1521,7 @@ spentry builtin_aset1
         cmp imm1, #tag_nodeheader
         b.eq 1f
         cmp imm0, #min_cl_ivector_subtag
-        b.ge _SPsubtag_misc_set
+        bcond_ext ge, _SPsubtag_misc_set
 1:      jump_builtin _builtin_aset1, 3  /* ppc:6038 */
 endsp builtin_aset1
 

--- a/lisp-kernel/spentry-E-ffi.s
+++ b/lisp-kernel/spentry-E-ffi.s
@@ -458,7 +458,7 @@ spentry callback
         mov save1, arg_x
         /* Recover the thread context (ppc:5114-5124 get_tcr(1)). */
         mov x0, #1
-        bl get_tcr
+        bl C(get_tcr)
         mov rcontext, x0
         /* Stash the exact foreign sp for the return path. */
         mov imm0, sp
@@ -499,7 +499,7 @@ spentry callback
            must reload it.  Use the SAME idiom as start_lisp below: nil_value
            is patched into the C global lisp_nil at initial heap mapping (Matt
            2026-07-11), so it is NOT a compile-time immediate. */
-        ldr rnil, =lisp_nil
+        load_addr_of_lisp_nil rnil
         ldr rnil, [rnil]
         /* Cover the foreign region below the enclosing lisp boundary -- the C
            caller's frames plus every register block this spentry just pushed --
@@ -565,22 +565,16 @@ spentry callback
         ret
 endsp callback
 
-/* Do a LINUX system call (ppc:5402 poweropen_syscall; the Darwin
- * carry-flag/return-twice protocol is NOT ported).  Same c_frame contract
- * and lisp<->foreign transition as ffcall; the middle is the AArch64
- * Linux syscall sequence instead of a call:
- *   x8 = syscall number (unboxed from arg_z), x0-x5 = args, `svc #0'
- * (analog of x86-spentry64.s:4619 syscall; AArch64 Linux takes <=6
- * integer args).
- * ARM64-DEVIATION: Linux/AArch64 returns -errno directly in x0, so PPC's
- * error-path negation (ppc:5441-5454) has no analog - imm0 carries the
- * raw result.  No FP args => the FPCR dance is skipped (as on PPC, which
- * doesn't touch the FPSCR in syscall). */
-#ifdef DARWIN
-#error "Darwin syscall convention not ported (svc #0x80 + carry-flag error protocol)"
-#endif
+/* Do a system call (ppc:5402 poweropen_syscall).  Same c_frame contract
+ * and lisp<->foreign transition as ffcall; the middle is the platform
+ * AArch64 syscall sequence:
+ *   Linux:  x8 = number, x0-x5 = args, `svc #0'; result/-errno in x0
+ *   Darwin: x16 = number, x0-x5 = args, `svc #0x80`; C set on error with
+ *           errno in x0 — negate to match Linux-style -errno for Lisp.
+ * (analog of x86-spentry64.s:4619 syscall + SYSCALL_SETS_CARRY_ON_ERROR).
+ * No FP args => the FPCR dance is skipped. */
 /* Body = patch-0003 _SPffcall shape (same c_frame contract and
- * lisp<->foreign transition) with the AArch64 Linux syscall sequence
+ * lisp<->foreign transition) with the AArch64 syscall sequence
  * in the middle instead of a call. */
 spentry syscall
         str fn, [vsp, #-node_size]!             /* ppc:5404 vpush_saveregs   */
@@ -613,7 +607,11 @@ spentry syscall
                            exceptions; publish a clean slate (PPC zeroes
                            ffi_exception here, ppc:5415-5419) */
         /* Syscall number + up to 6 args (ppc:5424-5432 loads r3-r10 + r0). */
-        asr x8, arg_z, #fixnumshift             /* ppc:5432 unbox_fixnum     */
+#ifdef DARWIN
+        asr x16, arg_z, #fixnumshift            /* Darwin: number in x16 */
+#else
+        asr x8, arg_z, #fixnumshift             /* Linux: number in x8 */
+#endif
         ldp x0, x1, [sp, #c_frame.params]
         ldp x2, x3, [sp, #(c_frame.params + 2*node_size)]
         ldp x4, x5, [sp, #(c_frame.params + 4*node_size)]
@@ -632,7 +630,14 @@ spentry syscall
         str temp0, [rcontext, #tcr.last_lisp_frame]
         mov temp0, #TCR_STATE_FOREIGN
         str temp0, [rcontext, #tcr.valence]
-        svc #0                                  /* ppc:5433 sc               */
+#ifdef DARWIN
+        svc #0x80                               /* Darwin AArch64 syscall */
+        b.cc 1f                                 /* C clear => success */
+        neg x0, x0                              /* errno -> -errno */
+1:
+#else
+        svc #0                                  /* Linux AArch64 syscall */
+#endif
         /* ---- return path (x0 = raw result / -errno) (ppc:5455-5489) ---- */
         ldr allocptr,  [rcontext, #tcr.save_allocptr]   /* ppc:5470-5472     */
         ldr allocbase, [rcontext, #tcr.save_allocbase]
@@ -855,7 +860,7 @@ C(start_lisp):
         mov     save2, xzr
         mov     save3, xzr
         /* rnil: from the C global (image loader patches nil_value). */
-        ldr     rnil, =lisp_nil
+        load_addr_of_lisp_nil rnil
         ldr     rnil, [rnil]
         /* Lisp stack/alloc state from the TCR (ppc:162-165). */
         ldr     vsp, [rcontext, #tcr.save_vsp]

--- a/tools/xdarwinarm64.lisp
+++ b/tools/xdarwinarm64.lisp
@@ -1,0 +1,19 @@
+;;; Cross-compile setup for Darwin/arm64 (Apple Silicon).
+;;; Parallel to tools/xlinuxarm64.lisp; tools/xarm64.lisp is the older name.
+
+(in-package "CCL")
+
+(defpackage "ARM64-DARWIN" (:use))
+
+(defun load-darwinarm64-backend ()
+  (in-development-mode
+    (load "ccl:lib;systems.lisp")
+    (load "ccl:lib;compile-ccl"))
+  (update-modules '(arm64-arch arm64-asm arm64-lap arm64-backend
+                    arm64-vinsns arm642)
+                  t)
+  (setup-arm64-ftd *darwinarm64-backend*)
+  (update-modules '(arm64-lapmacros arm64-disassemble ffi-darwinarm64) t)
+  (update-modules *arm64-xload-modules* t))
+
+(load-darwinarm64-backend)


### PR DESCRIPTION
## Summary

Native Darwin/arm64 (Apple Silicon) port on top of the `arm64` branch: Mach exception server, MAP_JIT-based W^X, Apple AAPCS64 FFI, ObjC bridge, and the Cocoa IDE. The stock build path works like other platforms: `(rebuild-ccl :full t)` self-hosts, and `(require :cocoa-application)` builds Clozure CL64.app.

The branch is squashed into seven commits:

1. **native kernel** — Mach exception server (`arm64-darwin-mach.c`), MAP_JIT W^X policy (purify → `AREA_READONLY` RX, dynamic heap never executable), GC corrupt-header diagnostics, image/thread/syscall support, `lisp-kernel/darwinarm64/` build.
2. **runtime and AAPCS64 FFI** — atomic composite/HFA argument passing (AAPCS64 C.3/C.12), record returns (register and x8 indirect), Darwin variadic-on-stack, callback trampolines (index in x9 so the incoming x8 sret pointer survives), interpreted `%ff-call` parity, shared `lib/ffi-arm64.lisp`, and a fix for GC-invisible `.SPffcall` state (raw return PC parked on the vstack could alias an ivector header and hide older vstack slots from mark/forward; save0–save3 now spill around foreign calls).
3. **ObjC bridge and Cocoa IDE** — Apple tagged pointers, no `objc_msgSend*_stret` on arm64, `call-next-method` over ObjC methods, untitled Listener at launch, Trace/Source/Inspect selection fixes.
4. **interface database tooling** — scripts to regenerate darwin-arm64 `.cdb` databases from the current SDK with ffigen5 (databases themselves stay out of the tree).
5. **stock build path** — cross xload target, `rebuild-ccl` integration, dumplisp MAP_JIT handling.
6. **smoke tests and CI harness** — FFI/callback/Cocoa smokes, launch-layout regression reproducer, mini-app suite, `tools/run-darwin-arm64-ci.sh`.
7. **porting notes** — `doc/porting/darwin.md`, `doc/porting/progress.md`.

## Validation

- `(rebuild-ccl :full t)` twice (second rebuild self-hosted from the produced image)
- `ccl-tests` suite 244/244; ANSI+CCL `test-ccl-and-suites` 21920/21920
- Full smoke gate (`tools/run-darwin-arm64-ci.sh`): purify, cocoa, interp-ff-call, clean build, `(require :cocoa)`/Hemlock, mini-apps 01–17
- FFI/callback smokes: struct return, variadic, pack overflow, ffcall stack, callback sret/struct/HFA, NSRange, HFA args
- Stock-built IDE opens its untitled Listener, evaluates, and stays healthy with no init files present

## Relation to the current `arm64` branch

This branch is based on an earlier `arm64` state. Since then the branch gained the linuxarm64 AAPCS64 FFI rework (#572) and the consolidation of the split `spentry-[B-E]*.s` files into `arm64-spentry.s`, which overlap the FFI/spentry commits here (13 conflicting files). The two implementations agree on the ABI but differ in mechanism (ffcall/callback convention, file layout), so reconciling onto the current tip is a follow-up step — happy to coordinate on which convention should win before rebasing.

GitHub does not allow reopening this PR (the head branch was recreated after it was closed); superseded by #599, which is rebased onto the current `arm64` tip with the overlap reconciled.

