### PR TITLE
def-foreign-type of a named transparent union fails an ecase

### DIFF
--- a/lib/foreign-types.lisp
+++ b/lib/foreign-types.lisp
@@ -576,7 +576,13 @@ Which one name refers to depends on foreign-type-spec in the obvious manner."
 		      (setf (,accessor name) defn))))
 	(ecase kind
 	  (:struct (frob info-foreign-type-struct))
-	  (:union (frob info-foreign-type-union))
+	  ;; A transparent union lives in the union namespace, exactly
+	  ;; where PARSE-FOREIGN-RECORD-TYPE looks it up and where the
+	  ;; interface-database reader files it (db-io.lisp); the record
+	  ;; type's KIND slot keeps the distinction.  Without this arm,
+	  ;; DEF-FOREIGN-TYPE of any named transparent union fails the
+	  ;; ECASE, on every platform.
+	  ((:union :transparent-union) (frob info-foreign-type-union))
 	  (:enum (frob info-foreign-type-enum)))))))
 
 (defun %def-foreign-type (name new &optional (ftd *target-ftd*))


### PR DESCRIPTION
Portable bug, found while porting the x86-64 transparent-union
argument handling to arm64, and watched on stock x86-64 CCL 1.12.2:

```
? (def-foreign-type nil (:transparent-union :tu (:p (:* :char))))
> Error: The value :TRANSPARENT-UNION is not of the expected type
>        (MEMBER :STRUCT :UNION :ENUM).
> While executing: CCL::%DEF-AUXILIARY-FOREIGN-TYPES
```

`parse-foreign-record-type` registers a named record as an auxiliary
type under its KIND, and `def-foreign-type`'s expansion replays those
through `%def-auxiliary-foreign-types`, whose ecase knows `:struct`,
`:union` and `:enum` only.  A transparent union belongs to the union
namespace: `parse-foreign-record-type` looks it up with
`info-foreign-type-union`, and the interface-database reader in
db-io.lisp files it there too; the record type's KIND slot keeps the
distinction.

Anonymous transparent unions never hit this (the auxiliary
registration is guarded by the name), which is why databases built by
the old gcc ffigen worked: the reader path does not go through
`def-foreign-type`.

Related: the arm64 argument-passing arm for transparent unions is on
the arm64-ffi-hfa-records branch (#572), and #587 tracks the
over-aligned-composite modeling gap found in the same audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
