### PR TITLE
library/elf.lisp: arm64 support, and a ppc compile fix

### DIFF
--- a/library/elf.lisp
+++ b/library/elf.lisp
@@ -265,7 +265,7 @@
                   #+64-bit-target :<E>lf64_<S>ym.st_value
                   #+32-bit-target :<E>lf32_<S>ym.st_value)
             #+x86-target (%address-of f)
-            #+ppc-target (- (%address-of (uvref f 0)) (- ppc::fulltag-misc ppc::node-size))
+            #+ppc-target (- (%address-of (uvref f 0)) (- target::fulltag-misc target::node-size))
             #+arm-target (- (%address-of (uvref f 1)) (- arm::fulltag-misc arm::node-size))
             ;; arm64: element 0 is the code-vector (arm64-arch.lisp:673); this
             ;; is its DATA start, i.e. tagged address + misc-data-offset (-4).
@@ -276,8 +276,22 @@
                   #+64-bit-target :<E>lf64_<S>ym.st_size
                   #+32-bit-target :<E>lf32_<S>ym.st_size)
             #+x86-target (1+ (ash (1- (%function-code-words f)) target::word-shift))
-            #+ppc-target (ash (uvsize (uvref f 0)) ppc::word-shift)
-            #+arm-target (ash (uvsize (uvref f 1)) arm::word-shift)
+            ;; uvsize counts ELEMENTS, and a code-vector's elements are 32
+            ;; bits wide (ppc64-arch.lisp declares code-vector
+            ;; ivector-class-32-bit, and says so in the comment above it),
+            ;; while word-shift is the NODE shift: 3 on ppc64, 2 on ppc32.
+            ;; (ash n word-shift) was therefore 8n bytes for a 4n-byte
+            ;; code-vector on ppc64, and right on ppc32 only by coincidence.
+            ;; ppc64-misc-byte-count in ppc64-arch.lisp gives the intended
+            ;; answer for this ivector class: (ash element-count 2).
+            #+ppc-target (subtag-bytes target::subtag-code-vector
+                                       (uvsize (uvref f 0)))
+            ;; 4n either way on arm32 (word-shift is 2 there), but written the
+            ;; same way so that it states the element width rather than
+            ;; depending on a coincidence -- the same coincidence that stopped
+            ;; holding for #+ppc-target when ppc64 joined ppc32 under it.
+            #+arm-target (subtag-bytes target::subtag-code-vector
+                                       (uvsize (uvref f 1)))
             ;; NOT (ash (uvsize cv) word-shift): an arm64 code-vector is an
             ;; ivector-class-32-bit (arm64-arch.lisp:153) but word-shift is 3
             ;; (:31), so that spelling doubles the size.  subtag-bytes knows

--- a/library/elf.lisp
+++ b/library/elf.lisp
@@ -189,7 +189,12 @@
                   ))
     (functions)))
 
-#+(or arm-target ppc-target)
+;; arm64 uses this definition and not the #+x86-target one above.  PURIFY
+;; moves a function's CODE VECTOR to the readonly area on arm64 and leaves
+;; the function object itself in dynamic space, so a scan of :readonly for
+;; objects of type FUNCTION finds none.  This arm walks %map-lfuns instead
+;; and keeps the lfuns whose code vector landed in the readonly range.
+#+(or arm-target ppc-target arm64-target)
 (defun collect-elf-static-functions ()
   (ccl::purify)
   (multiple-value-bind (pure-low pure-high)
@@ -200,7 +205,7 @@
             (values (ash (ccl::%fixnum-ref a target::area.low) target::fixnumshift)
                     (ash (ccl::%fixnum-ref a target::area.active) target::fixnumshift)))))
     (let* ((hash (make-hash-table :test #'eq))
-           (code-vector-index #+ppc-target 0 #+arm-target 1))
+           (code-vector-index #+ppc-target 0 #+arm-target 1 #+arm64-target 0))
       (ccl::%map-lfuns #'(lambda (f)
                            (let* ((code-vector  (ccl:uvref f code-vector-index))
                                   (startaddr (+ (ccl::%address-of code-vector)

--- a/library/elf.lisp
+++ b/library/elf.lisp
@@ -267,12 +267,23 @@
             #+x86-target (%address-of f)
             #+ppc-target (- (%address-of (uvref f 0)) (- ppc::fulltag-misc ppc::node-size))
             #+arm-target (- (%address-of (uvref f 1)) (- arm::fulltag-misc arm::node-size))
+            ;; arm64: element 0 is the code-vector (arm64-arch.lisp:673); this
+            ;; is its DATA start, i.e. tagged address + misc-data-offset (-4).
+            ;; The first executable instruction is 4 bytes later: data word 0
+            ;; is the `udf #0' sentinel (arm64-arch.lisp:73-76).
+            #+arm64-target (+ (%address-of (uvref f 0)) target::misc-data-offset)
             (pref p
                   #+64-bit-target :<E>lf64_<S>ym.st_size
                   #+32-bit-target :<E>lf32_<S>ym.st_size)
             #+x86-target (1+ (ash (1- (%function-code-words f)) target::word-shift))
             #+ppc-target (ash (uvsize (uvref f 0)) ppc::word-shift)
             #+arm-target (ash (uvsize (uvref f 1)) arm::word-shift)
+            ;; NOT (ash (uvsize cv) word-shift): an arm64 code-vector is an
+            ;; ivector-class-32-bit (arm64-arch.lisp:153) but word-shift is 3
+            ;; (:31), so that spelling doubles the size.  subtag-bytes knows
+            ;; the element width (level-0/l0-array.lisp:922-951).
+            #+arm64-target (subtag-bytes target::subtag-code-vector
+                                         (uvsize (uvref f 0)))
             ))))
 
 (defun elf-section-index (section)
@@ -379,6 +390,7 @@
                                            #+ppc32-target #$EM_PPC
                                            #+ppc64-target #$EM_PPC64
                                            #+arm-target #$EM_ARM
+                                           #+arm64-target #$EM_AARCH64
                                            ))
          (program-header (new-elf-program-header object))
          (lisp-section (new-elf-section object))


### PR DESCRIPTION
You asked for `elf.lisp` on its own when it was more or less ready. Here it is: three commits, one file.

This replaces the three commits you declined from #573, but it is not the same history. `6f5b50fa` was inert on arm64 — you said so yourself — and `a8de1dc8` corrected it. I folded those two into one commit so that you review the code as it should be, not the route I took to it. The net effect on the `#+x86-target` arm is nothing: `6f5b50fa` widened it, `a8de1dc8` put it back.

## The three defects

**1. `collect-elf-static-functions` was undefined on arm64.** Neither of the two definitions applied to arm64, so `(require "ELF")` could not write symbols at all.

arm64 needs the `%map-lfuns` arm and not the `:readonly` scan. PURIFY moves a function code vector to the readonly area and leaves the function object itself in dynamic space, so `%map-areas` over `:readonly` finds no objects of type `FUNCTION`. Measured on the image: the readonly area holds 12764 code vectors and zero functions. Element 0 of an arm64 function is its code vector, as it is on ppc.

**2. `register-elf-functions` and `new-elf-object` had no arm64 arms.** `st_value`, `st_size` and `e_machine` were all missing, so the symbols came out with value 0 and size 0 in a file that named the wrong machine.

`st_size` uses `subtag-bytes` and not `(ash (uvsize cv) word-shift)`. An arm64 code vector is `ivector-class-32-bit` while `word-shift` is 3, so the shift spelling reports twice the size.

**3. The `#+ppc-target` arms name a package that does not exist.** `ppc::fulltag-misc`, `ppc::node-size` and `ppc::word-shift` are unbound, because the ppc packages are `PPC32` and `PPC64`. The file therefore does not compile on ppc. `st_size` was also 8n bytes for a 4n-byte code vector on ppc64, and correct on ppc32 only by coincidence.

This is `elf.lisp`, so it belongs in this PR. But it is a ppc defect, and **I have no ppc hardware. I have not compiled or run this arm.**

You can settle commit 3 without running anything. Unbound package symbols fail at COMPILE time, so compiling `library/elf.lisp` on a ppc machine either works or it does not. That is the whole check, and it is the one I cannot do myself.

## What was measured, on arm64 hardware

The oracle is `readelf` (GNU binutils 2.41) reading the written object file. It is an external tool, not the collector counting itself.

Red first, on the same image and the same kernel:

| | before commit 1 | after |
|---|---|---|
| `.symtab` entries | **1** (the mandatory index-0 NULL) | **12720** |
| file size | 584 bytes | 903640 bytes |

Each of the 12719 real symbols, 12719 of 12719 on every invariant:

- nonzero `st_value` and nonzero `st_size`
- type `FUNC`, bind `GLOBAL`, `Ndx` = the `.lisp` section
- `st_value` ≡ 8 (mod 16) — the code vector data start, from the object layout
- `st_size` ≡ 0 (mod 4) — the `subtag-bytes` arithmetic of commit 2
- inside `.lisp [0x300000000000, +0xb82570)`

**0 overlapping `[st_value, st_value+st_size)` ranges** across 12718 adjacent pairs. That is the failure mode commit 3 removes, measured on arm64, where the same arithmetic runs.

Names: 6989 Lisp symbol names and 5730 printed forms, all 12719 distinct, none empty, and no `duplicate:` report from `elf-register-string`. `Machine: AArch64`.

Sample rows: `CCL::%INIT-MISC` at `0x300000000f68` size 760, and `CCL::%EXTEND-VECTOR` at `0x3000000012d8` size 436.

## What is not covered, plainly

No automated suite EXECUTES `library/elf.lisp`. Not ANSI, not `ccl.lsp`. It runs only under `(require "ELF")`. That is exactly how the inert version shipped green: it compiled clean and returned an empty set, and no compiler catches an empty set.

Compiling the file is a real test, and it does happen in my build. But compiling is not the test that catches either arm64 defect here. It is the test that catches defect 3, at compile time, on a ppc machine.

I measured everything above by hand on a Graviton box for that reason. I did not exercise gdb or perf actually consuming these symbols against a live image. The evidence is `readelf` plus the object layout arithmetic of the image itself.
