### PR TITLE
image: the section count from the file header is unchecked

### DIFF
--- a/lisp-kernel/image.c
+++ b/lisp-kernel/image.c
@@ -348,14 +348,19 @@ load_openmcl_image(int fd, openmcl_image_file_header *h)
   LispObj image_nil = 0;
   area *a;
   if (find_openmcl_image_file_header(fd, h)) {
-    int i, nsections = h->nsections;
-    openmcl_image_section_header sections[nsections], *sect=sections;
+    unsigned i, nsections = h->nsections;
+    openmcl_image_section_header sections[NUM_IMAGE_SECTIONS], *sect=sections;
     LispObj bias = image_base - ACTUAL_IMAGE_BASE(h);
 #if (WORD_SIZE== 64)
     signed_natural section_data_delta = 
       ((signed_natural)(h->section_data_offset_high) << 32L) | h->section_data_offset_low;
 #endif
 
+    if (nsections > NUM_IMAGE_SECTIONS) {
+      fprintf(dbgout, "Heap image has %u sections; this kernel supports "
+              "at most %d.\n", nsections, NUM_IMAGE_SECTIONS);
+      return 0;
+    }
     if (read (fd, sections, nsections*sizeof(openmcl_image_section_header)) !=
 	nsections * sizeof(openmcl_image_section_header)) {
       return 0;


### PR DESCRIPTION
# image: the section count from the file header is unchecked

DRAFT -- NOT SENT. Awaiting Mauro's approval.

`load_openmcl_image` reads the section count out of the image file header, puts
it in an `int`, and uses it as the size of a variable-length array on the stack.
Nothing checks the value first.

```
lisp-kernel/image.c:351    int i, nsections = h->nsections;
lisp-kernel/image.c:352    openmcl_image_section_header sections[nsections], *sect=sections;
```

`h->nsections` is `unsigned` (`image.h:56`). Line 351 narrows it to `int`, so a
header that holds a count above `INT_MAX` gives a negative VLA size, and line
352 declares the array with it. This is undefined behaviour, and it happens
before the first read of the section data, so the read-error return at `:359`
cannot catch it.

The narrowing is only the sharper half. A count of 2^28 stays positive and asks
the stack for 8 GB.

## The fix

The reader is the only side of this file that trusts the number. The writer
uses a fixed array and always writes the same count:

```
lisp-kernel/image.c:590    openmcl_image_section_header sections[NUM_IMAGE_SECTIONS];
lisp-kernel/image.c:592    area *areas[NUM_IMAGE_SECTIONS], *a;
lisp-kernel/image.c:621    for (i = 0; i < NUM_IMAGE_SECTIONS; i++) {
lisp-kernel/image.c:639    fh.nsections = NUM_IMAGE_SECTIONS;
lisp-kernel/image.c:653    write_file_and_section_headers(fd, &fh, sections, NUM_IMAGE_SECTIONS, &header_pos);
lisp-kernel/image.c:688    write_file_and_section_headers(fd, &fh, sections, NUM_IMAGE_SECTIONS, &header_pos);
```

So the patch makes the reader match the writer: a fixed array of
`NUM_IMAGE_SECTIONS`, an unsigned count, and a bound check before the read.

All three parts are necessary.

- `unsigned` alone leaves the 8 GB stack request.
- The fixed array alone is worse than the original, because the `read()` at
  `:359` would then read `nsections * sizeof(...)` bytes into a 5-element array.
- `unsigned i` follows from `unsigned nsections`. `i` is only a loop counter
  compared against `nsections`, so an `int i` adds a signed/unsigned comparison.

The `read()` comparison keeps its behaviour: it already compared `ssize_t`
against `size_t`, and `-1` still converts to `SIZE_MAX` and still fails.

## Why the check is an upper bound and not an equality

`NUM_IMAGE_SECTIONS` is 5, and `image.h:103` records that it was 3 before:

```
lisp-kernel/image.h:103    #define NUM_IMAGE_SECTIONS 5    /* used to be 3 */
```

An image written when it was 3 carries `nsections == 3`. Whether such an image
can still reach this line is a question about the accepted ABI range, and that
range is not the same on every port:

```
arm64-constants.h:635-637    ABI_VERSION_MIN 1      MAX 1046
arm-constants.h:350-352      ABI_VERSION_MIN 1045   MAX 1045
x86-constants64.h:355-357    ABI_VERSION_MIN 1042   MAX 1042
ppc-constants64.h:308-310    ABI_VERSION_MIN 1040   MAX 1040
```

arm64 is the one port whose MIN is not its MAX, so it is the one port that
accepts image vintages other than its own.
`find_openmcl_image_file_header` range-checks the version that way at
`image.c:187` and `:193`. An equality check on the section count would refuse an
image that those two lines had just accepted. So the check is "greater than",
and 3 and 5 both pass.

A count above `NUM_IMAGE_SECTIONS` can only come from a kernel newer than this
one, and `image.c:193` already refuses that image on its `abi_version`. The
bound therefore rejects nothing this kernel must load. It only stops the stack
allocation from being sized by an unvalidated field.

The message follows the two version messages above it, which report the same
class of problem: this image is not one that this kernel can load.

## What I built, and what I only read

No image the tree produces can reach the defect, because
`save_application_internal` always writes `fh.nsections = NUM_IMAGE_SECTIONS`.
So I built a header that carries a bad count, and watched the two kernels
against it. The tool copies a real image, finds the header the way
`find_openmcl_image_file_header` does (trailer at EOF-16,
`header_pos = filesize + trailer.delta`), asserts the signature is there, and
changes one field.

```
CRAFT:   header_pos=3872 abi_version=1046
CRAFT:   nsections 5 -> 4294967295  (as int: -1)

before the patch, crafted image     KILLED BY SIGNAL 7   (SIGBUS)
after  the patch, crafted image     exit 255
                                    Heap image has 4294967295 sections;
                                    this kernel supports at most 5.
                                    Couldn't load lisp heap image from ...
before / after, UNTOUCHED image     identical on both kernels
```

The SIGBUS is the negative VLA. Every other check ahead of it still passed, so
the crafted image reached line 351.

**linuxarm64** -- built and tested.

```
kernel md5 before   befaa9d216675b34a885f40ff27fccb5
kernel md5 after    04e942621c8534f21b47f625c837887a
ANSI                21679 tests, 0 failed
ccl.lsp             243 tests, 0 failed
```

**x86-64 (linuxx8664)** -- built, and it loads an image through this code.
Rebuilding our host x86-64 CCL compiles the same `image.c`; the kernel md5 moved
from `992082642705008cd4e588c578a58c2c` to `23a61040ece81dd1a04e29376589c6ea`,
the rebuilt kernel loaded its own heap image, and it then ran two full
`rebuild-ccl` generations. I have not run the ANSI suite on x86-64 with it.

**ppc32, ppc64 and ARM32** -- not built by me. I have no machine for any of
them. The change is portable C, and `NUM_IMAGE_SECTIONS`, `dbgout` and the
`return 0` failure path are all already used in this file, but I have not
compiled those kernels.

I report this as an unvalidated field used as an allocation size. It is not a
fault that anyone has hit in normal use.
