### PR TITLE
arm64: the #-futex spin-lock release needs RELEASE ordering

### DIFF
--- a/level-0/ARM64/arm64-misc.lisp
+++ b/level-0/ARM64/arm64-misc.lisp
@@ -319,6 +319,28 @@
   (ret))                                           ; ppc:668
 
 ;;; =====================================================================
+;;; %release-spin-lock
+;;; =====================================================================
+;;; Free a spinlock word with RELEASE ordering.  The #-futex lock
+;;; protocols (l0-misc.lisp) publish their critical-section stores by
+;;; freeing the lockptr spinlock; on ARMv8 that hand-off requires a
+;;; release barrier on the freeing store.  With a plain str the next
+;;; spinlock owner can observe pre-critical-section values of
+;;; avail/owner/count -- measured on Graviton4 as a boot deadlock
+;;; (both threads in wait_on_semaphore on the lock's semaphore, frozen
+;;; state avail=nwaiters+1 owner=0 count=0) and as spurious
+;;; not-lock-owner errors.  dmb ish + str is the shape that was
+;;; A/B-confirmed against the reproducer (red 4/4 without, green 10/10
+;;; with, 900k contended ops per run); it also orders the failed-acquire
+;;; waiter path's avail increment before the release.
+(defarm64lapfunction %release-spin-lock ((p arg_z))
+  (macptr-ptr imm0 p)
+  (dmb (:$ 11))                                    ; DMB ISH: release fence
+  (str xzr (:@ imm0))
+  (mov arg_z rnil)
+  (ret))
+
+;;; =====================================================================
 ;;; %fixnum-truncate — ppc-numbers.lisp:251 (#+ppc64-target arm; placed
 ;;; here like called-for-mv-p below, pending the numbers-file story vs
 ;;; Matt's own arm64-numbers.lisp).  Promoted 16m14 from the wave-2

--- a/level-0/l0-misc.lisp
+++ b/level-0/l0-misc.lisp
@@ -565,6 +565,19 @@
       (%atomic-incf-node 1 '*spin-lock-timeouts* target::symbol.vcell)
       (yield))))
 
+;;; Freeing a spinlock publishes every store made while it was held, so
+;;; it needs RELEASE ordering on weakly-ordered targets.  ARM64 defines
+;;; this as a lap function (dmb ish + str, level-0/ARM64/arm64-misc.lisp);
+;;; a plain store is correct on TSO targets.  The declaim stays inside
+;;; eval-when (this file's idiom) so no load-time proclaim call reaches
+;;; the boot image, where proclaim (level-1) is not yet defined.
+#-arm64-target
+(progn
+  (eval-when (:compile-toplevel :execute)
+    (declaim (inline %release-spin-lock)))
+  (defun %release-spin-lock (p)
+    (setf (%get-natural p 0) 0)))
+
 (eval-when (:compile-toplevel :execute)
   (declaim (inline note-lock-wait note-lock-held note-lock-released)))
 
@@ -595,11 +608,11 @@
        (when (eql 1 (incf (%get-natural ptr target::lockptr.avail)))
          (setf (%get-ptr ptr target::lockptr.owner) p
                (%get-natural ptr target::lockptr.count) 1)
-         (setf (%get-natural spin 0) 0)
+         (%release-spin-lock spin)
          (if flag
            (setf (lock-acquisition.status flag) t))
          (return t))
-       (setf (%get-natural spin 0) 0))
+       (%release-spin-lock spin))
       (%process-wait-on-semaphore-ptr signal 1 0 (recursive-lock-whostate lock)))))
 
 #+futex
@@ -710,7 +723,7 @@
                   (setf (%get-ptr ptr target::lockptr.owner) p
                         (%get-natural ptr target::lockptr.count) 1)
                   (if flag (setf (lock-acquisition.status flag) t)))
-                (setf (%get-ptr spin) (%null-ptr))
+                (%release-spin-lock spin)
                 win)))))))
 
 
@@ -757,7 +770,7 @@
          (declare (fixnum pending))
          (setf (%get-natural ptr target::lockptr.avail) 0
                (%get-natural ptr target::lockptr.waiting) 0)
-         (setf (%get-ptr spin) (%null-ptr))
+         (%release-spin-lock spin)
          (dotimes (i pending)
            (%signal-semaphore-ptr signal)))))
     nil))
@@ -869,21 +882,21 @@
        (if (eq (%get-object ptr target::rwlock.writer) tcr)
          (progn
            (incf (%get-signed-natural ptr target::rwlock.state))
-           (setf (%get-natural ptr target::rwlock.spin) 0)
+           (%release-spin-lock ptr)
            (if flag
              (setf (lock-acquisition.status flag) t))
            t)
          (do* ()
               ((eql 0 (%get-signed-natural ptr target::rwlock.state))
                ;; That wasn't so bad, was it ?  We have the spinlock now.
-               (setf (%get-signed-natural ptr target::rwlock.state) 1
-                     (%get-natural ptr target::rwlock.spin) 0)
+               (setf (%get-signed-natural ptr target::rwlock.state) 1)
+               (%release-spin-lock ptr)
                (%set-object ptr target::rwlock.writer tcr)
                (if flag
                  (setf (lock-acquisition.status flag) t))
                t)
            (incf (%get-natural ptr target::rwlock.blocked-writers))
-           (setf (%get-natural ptr target::rwlock.spin) 0)
+           (%release-spin-lock ptr)
            (let* ((*interrupt-level* level))
                   (%process-wait-on-semaphore-ptr write-signal 1 0 (rwlock-write-whostate lock)))
            (%get-spin-lock ptr)))))))
@@ -942,7 +955,7 @@
        (%get-spin-lock ptr)             ;(%get-spin-lock (%inc-ptr ptr target::rwlock.spin))
        (if (eq (%get-object ptr target::rwlock.writer) tcr)
          (progn
-           (setf (%get-natural ptr target::rwlock.spin) 0)
+           (%release-spin-lock ptr)
            (error 'deadlock :lock lock))
          (do* ((state
                 (%get-signed-natural ptr target::rwlock.state)
@@ -950,14 +963,14 @@
               ((<= state 0)
                ;; That wasn't so bad, was it ?  We have the spinlock now.
                (setf (%get-signed-natural ptr target::rwlock.state)
-                     (the fixnum (1- state))
-                     (%get-natural ptr target::rwlock.spin) 0)
+                     (the fixnum (1- state)))
+               (%release-spin-lock ptr)
                (if flag
                  (setf (lock-acquisition.status flag) t))
                t)
            (declare (fixnum state))
            (incf (%get-natural ptr target::rwlock.blocked-readers))
-           (setf (%get-natural ptr target::rwlock.spin) 0)
+           (%release-spin-lock ptr)
            (let* ((*interrupt-level* level))
              (%process-wait-on-semaphore-ptr read-signal 1 0 (rwlock-read-whostate lock)))
            (%get-spin-lock ptr)))))))
@@ -1016,11 +1029,11 @@
        (declare (fixnum state tcr))
        (cond ((> state 0)
               (unless (eql tcr (%get-object ptr target::rwlock.writer))
-                (setf (%get-natural ptr target::rwlock.spin) 0)
+                (%release-spin-lock ptr)
                 (error 'not-lock-owner :lock lock))
               (decf state))
              ((< state 0) (incf state))
-             (t (setf (%get-natural ptr target::rwlock.spin) 0)
+             (t (%release-spin-lock ptr)
                 (error 'not-locked :lock lock)))
        (setf (%get-signed-natural ptr target::rwlock.state) state)
        (when (zerop state)
@@ -1056,7 +1069,7 @@
              (setf (%get-natural ptr target::rwlock.blocked-readers) 0)
              (dotimes (i nreaders)
                (%signal-semaphore-ptr reader-signal)))))
-       (setf (%get-natural ptr target::rwlock.spin) 0)
+       (%release-spin-lock ptr)
        t))))
 
 #+futex
@@ -1126,11 +1139,11 @@
                   #+futex
                   (%unlock-futex ptr)
                   #-futex
-                  (setf (%get-natural ptr target::rwlock.spin) 0)
+                  (%release-spin-lock ptr)
                   (error :not-lock-owner :lock lock)))
                ((= state 0)
                 #+futex (%unlock-futex ptr)
-                #-futex (setf (%get-natural ptr target::rwlock.spin) 0)
+                #-futex (%release-spin-lock ptr)
                 (error :not-locked :lock lock))
                (t
                 (if (= state -1)
@@ -1140,7 +1153,7 @@
                     #+futex
                     (%unlock-futex ptr)
                     #-futex
-                    (setf (%get-natural ptr target::rwlock.spin) 0)
+                    (%release-spin-lock ptr)
                     (if flag
                       (setf (lock-acquisition.status flag) t))
                     t)
@@ -1148,7 +1161,7 @@
                     #+futex
                     (%unlock-futex ptr)
                     #-futex
-                    (setf (%get-natural ptr target::rwlock.spin) 0)
+                    (%release-spin-lock ptr)
                     (%unlock-rwlock-ptr ptr lock)
                     (let* ((*interrupt-level* level))
                       (%write-lock-rwlock-ptr ptr lock flag)))))))))))

--- a/lisp-kernel/threads.h
+++ b/lisp-kernel/threads.h
@@ -106,7 +106,18 @@ Boolean extern threads_initialized;
 Boolean extern log_tcr_info;
 
 #define LOCK_SPINLOCK(x,tcr) get_spin_lock(&(x),tcr)
+#ifdef ARM64
+/* Freeing a spinlock publishes every store made while it was held, so it
+   needs RELEASE ordering on a weakly-ordered target; a plain store lets
+   the next owner read pre-critical-section values (and lets the compiler
+   sink protected stores past the release -- gcc was observed sinking
+   m->waiting past it in unlock_recursive_lock).  release_spin_lock
+   (arm64-asmutils.s, stlr) has been present but unused. */
+extern void release_spin_lock(signed_natural *);
+#define RELEASE_SPINLOCK(x) release_spin_lock((signed_natural *)&(x))
+#else
 #define RELEASE_SPINLOCK(x) (x)=0
+#endif
 
 #ifdef WIN_32
 #define TCR_TO_TSD(tcr) ((void *)((natural)(tcr)))


### PR DESCRIPTION
On linuxarm64 about 1 boot in 40 hangs. The initial thread and the listener both park in `wait_on_semaphore` on the semaphore of the `binding-index-lock` recursive lock (`level-0/l0-symbol.lisp`). Both reach it at boot through `ensure-binding-index`. The wedged lock reads `avail=nwaiters+1, owner=0, count=0, waiting=0`, with every waiter parked and no signaler. That state is unreachable under sequentially consistent execution. The same mechanism also produced occasional "not-lock-owner" errors.

**Cause.** The `#-futex` lock protocols free the lockptr spinlock with a plain store. That store hands off the spinlock, so it must publish every store made while the lock was held. On a weakly-ordered target it needs RELEASE ordering. Without it the next owner reads pre-critical-section values of `avail`, `owner` and `count`. Waiter increments are lost, and an unlock computes `pending=0` while waiters sit on the semaphore. The acquire side is already correct: the Lisp CAS and the C `atomic_swap` both end in `dmb ish`.

This protocol is live on Linux because the feature gate in `level-0/l0-misc.lisp:21` reads `#+(and linux-target no (or x86-target arm-target))`. The `no` comes from `b502cf10` ("work-in-progress") and disables `:futex` for every Linux target on this branch. Stock Linux CCL never runs this code. Darwin always does.

**Evidence, all on one binary** (probe kernel plus runtime redefinition, no image rebuild):

- A contended `ensure-binding-index` hammer reproduces the boot wedge within about 2000 lock cycles.
- Probe kernels logged every exception, suspension and interrupt across a wedge. The fatal window contains no GC, no suspension, no `pc_luser_xp` and no asynchronous signal. The loss is pure concurrent execution.
- The protocol recompiled verbatim hangs 4 of 4 runs. The identical code with a `dmb ish` before each spin-release store runs 10 of 10 clean at 900,000 contended operations per run.

**The fix, in three parts.**

1. `level-0/ARM64/arm64-misc.lisp`: new lap function `%release-spin-lock` (`dmb ish`, then `str xzr`).
2. `level-0/l0-misc.lisp`: all 17 `#-futex` spin-release stores use it. Other targets get an inline plain-store definition, so TSO targets compile as before.
3. `lisp-kernel/threads.h`: `RELEASE_SPINLOCK` on ARM64 calls `release_spin_lock` (`stlr`), which has existed in `arm64-asmutils.s` since the asmutils port but was never wired. The C side shares the lockptr words with Lisp. gcc was also seen sinking `m->waiting = pending` past the plain store, so this stops a compiler reorder as well.

**Verification** of the built image and kernel, Graviton4, quiet box:

- Boot loop: 250 boots, 0 hangs. The unfixed pair measures 1 hang in 220 boots on the same harness.
- Hammer: 10 of 10 runs clean at 900,000 contended operations each. The unfixed pair hangs 4 of 4 on the same harness, run again the same day as a positive control.
- Regression: ANSI 21679 tests, 0 failures. ccl.lsp 243 tests, 0 failures.

Verification boundary: measured on linuxarm64 only. We did not build or test Darwin or ARM32.

**Two observations, reported and not measured.** ARM32 has the same shape: `release_spin_lock` and `atomic_swap_acquire` exist in its asmutils, the C macros do not use them, and its Lisp spin-release stores are plain. Darwin PPC `#-futex` has the same theoretical gap.

**One residual, recorded honestly.** The reproducer wedges only when the `with-lock-grabbed` body executes from the purified readonly section. Byte-identical dynamic-heap copies never trip it, at more than 12M operations, while 12 of 12 readonly runs wedge. Anonymous remap and RWX experiments refuted backing and permission as the variable. We record the placement as an unexplained probability modulator of the race window. The fix removes the wedge in both placements.
