### PR TITLE
arm64: four-targeted-reg-forms evaluates its operands in the wrong order

### DIFF
--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -3589,75 +3589,36 @@
                       (or (arm64-side-effect-free-form-p cform)
                           (let ((cvar (arm642-lexical-reference-p cform)))
                             (and cvar
-                                 (nx2-var-not-set-by-form-p cvar dform)))))))
-    (cond (atriv
-           (arm642-one-targeted-reg-form seg bform breg)
-           (arm642-one-targeted-reg-form seg cform creg)
-           (arm642-one-targeted-reg-form seg dform dreg)
-           (arm642-one-targeted-reg-form seg aform areg))
-          (aconst
-           (cond (btriv
-                  (arm642-one-targeted-reg-form seg cform creg)
-                  (arm642-one-targeted-reg-form seg dform dreg)
-                  (arm642-one-targeted-reg-form seg bform breg))
-                 (bconst
-                  (cond (ctriv
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (cconst
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (t
-                         (arm642-push-register seg (arm642-one-untargeted-reg-form seg cform creg))
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-pop-register seg creg)))
-                  (arm642-one-targeted-reg-form seg bform breg))
-                 (t
-                  (arm642-push-register seg (arm642-one-untargeted-reg-form seg bform breg))
-                  (cond (ctriv
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (cconst
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (t
-                         (arm642-push-register seg (arm642-one-untargeted-reg-form seg cform creg))
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-pop-register seg creg)))
-                  (arm642-pop-register seg breg)))
-           (arm642-one-targeted-reg-form seg aform areg))
-          (t
-           (arm642-push-register seg (arm642-one-untargeted-reg-form seg aform areg))
-           (cond (btriv
-                  (arm642-one-targeted-reg-form seg cform creg)
-                  (arm642-one-targeted-reg-form seg dform dreg)
-                  (arm642-one-targeted-reg-form seg bform breg))
-                 (bconst
-                  (cond (ctriv
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (cconst
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (t
-                         (arm642-push-register seg (arm642-one-untargeted-reg-form seg cform creg))
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-pop-register seg creg)))
-                  (arm642-one-targeted-reg-form seg bform breg))
-                 (t
-                  (arm642-push-register seg (arm642-one-untargeted-reg-form seg bform breg))
-                  (cond (ctriv
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (cconst
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-one-targeted-reg-form seg cform creg))
-                        (t
-                         (arm642-push-register seg (arm642-one-untargeted-reg-form seg cform creg))
-                         (arm642-one-targeted-reg-form seg dform dreg)
-                         (arm642-pop-register seg creg)))
-                  (arm642-pop-register seg breg)))
-           (arm642-pop-register seg areg)))))
+                                 (nx2-var-not-set-by-form-p cvar dform))))))
+         (apushed nil)
+         (bpushed nil)
+         (cpushed nil))
+    (if (and aform (not aconst))
+      (if atriv
+        (arm642-one-targeted-reg-form seg aform areg)
+        (setq apushed (arm642-push-reg-for-form seg aform areg t))))
+    (if (and bform (not bconst))
+      (if btriv
+        (arm642-one-targeted-reg-form seg bform breg)
+        (setq bpushed (arm642-push-reg-for-form seg bform breg t))))
+    (if (and cform (not cconst))
+      (if ctriv
+        (arm642-one-targeted-reg-form seg cform creg)
+        (setq cpushed (arm642-push-reg-for-form seg cform creg t))))
+    (arm642-one-targeted-reg-form seg dform dreg)
+    (unless ctriv
+      (if cconst
+        (arm642-one-targeted-reg-form seg cform creg)
+        (arm642-elide-pushes seg cpushed (arm642-pop-register seg creg))))
+    (unless btriv
+      (if bconst
+        (arm642-one-targeted-reg-form seg bform breg)
+        (arm642-elide-pushes seg bpushed (arm642-pop-register seg breg))))
+    (unless atriv
+      (if aconst
+        (arm642-one-targeted-reg-form seg aform areg)
+        (arm642-elide-pushes seg apushed (arm642-pop-register seg areg))))
+    (values areg breg creg dreg)))
 
 (defun arm642-three-targeted-reg-forms (seg aform areg bform breg cform creg)
   (let* ((*arm642-nfp-depth* *arm642-nfp-depth*)


### PR DESCRIPTION
# arm64: four-targeted-reg-forms evaluates its operands in the wrong order

`arm642-four-targeted-reg-forms` stores the wrong value into a
two-dimensional array element.

Reported and reduced by @tincircus, who supplied two probes that differ by one
token, plus a third form that works. He had already ruled out `&key` arguments,
multiple-place `setf`, the instance variable alone, and stale artifacts. That
last point set the direction: re-evaluating the `defmethod` at run time still
reproduces the fault, so the resident compiler emits it too.

## The defect

Here `s` is a structure, `i` a lexical, `*col*` a special and `new` a
parameter:

```lisp
(setf (aref (ib-arr s) i *col*) new)
```

This stores the second subscript into the element. `.SPaset2` starts with
`arg_z` still holding the specref result.

Two more shapes fail. A literal new value reaches `arg_z`, and the next
instruction overwrites it. With all four operands trivial, the structure loads
into `arg_y` after the second subscript was targeted there, so `.SPaset2` reads
the structure as a subscript.

Stock x86-64 CCL passes all six shapes. The arm64 image failed four of them.

## The cause

Three backends share one linear structure: `x862.lisp:4306`, `ppc2.lisp:2866`
and `arm2.lisp:3516`. The arm64 version rewrote it as a nested `cond`, and
three arms transposed the order.

| arm | fault |
|---|---|
| `ctriv` | Evaluates `dform` before `cform`. `cform` can be arbitrary code, so it must run first. A specref returns in `arg_z` and clobbers `dform`. |
| `atriv` | Evaluates `aform` last. `atriv` constrains `bform`, `cform` and `dform`, not `aform`. The scratch registers then overwrite the targeted `b`, `c` and `d`. |
| `btriv` | Evaluates `bform` after `cform` and `dform`. Same fault. |

The two-operand, three-operand and untargeted variants are correct. Only this
function needs the change.

## The fix

Restore the linear structure. The transcription follows
`arm2-four-targeted-reg-forms` but uses this file's own idioms, as
`arm642-three-targeted-reg-forms` already does.

## Verification

The post-fix disassembly holds the instruction that was absent. After the
specref call it emits `mov arg_y,arg_z`, then `ldr arg_z,[vsp,8]`, then
`ldr arg_x,[vsp,16]`.

| check | result |
|---|---|
| reduced test, stock x86-64 CCL | 6 of 6 pass |
| reduced test, arm64 before | 4 of 6 fail |
| reduced test, arm64 after | 6 of 6 pass |
| ANSI | 21679 tests, 0 failed |
| `ccl.lsp` | 243 tests, 0 failed |

The arm64 runs used a stdin REPL, so the resident compiler compiled the test.
That matches the reported case.

**Boundary.** We watched the test fail before the fix and pass after it, and
the image md5 moved between the two runs. We did not run a build with only this
patch withheld. The emitted code is the direct evidence.

The ANSI suite ran 21679 tests with 0 failures over this defect.
