### PR TITLE
ffi: an array-typed function parameter must decay to a pointer

### DIFF
--- a/lib/db-io.lisp
+++ b/lib/db-io.lisp
@@ -1442,8 +1442,12 @@ satisfy the optional predicate PREDICATE."
      `(#\t ,@(encode-name (ffi-typedef-name (cadr spec)))))
     (:pointer
       `(#\a))
+    ;; C adjusts a parameter of array type to a pointer to the element
+    ;; type (C11 6.7.6.3p7); clang-era ffigen emits the array type
+    ;; verbatim, so perform the adjustment here.  Arrays do not decay
+    ;; in ENCODE-FFI-TYPE (typedefs, record fields), and must not.
     (:array
-      `(#\?))))
+      `(#\a))))
 
 (defun encode-ffi-arg-list (args)
   (if args

--- a/lib/foreign-types.lisp
+++ b/lib/foreign-types.lisp
@@ -1567,7 +1567,9 @@ result-type-specifer is :VOID or NIL"
 (defun translate-foreign-arg-type (foreign-type-spec)
   (let* ((foreign-type (parse-foreign-type foreign-type-spec)))
     (etypecase foreign-type
-      (foreign-pointer-type :address)
+      ;; An array-typed parameter decays to a pointer (C11 6.7.6.3p7),
+      ;; mirroring FOREIGN-TYPE-TO-REPRESENTATION-TYPE.
+      ((or foreign-pointer-type foreign-array-type) :address)
       (foreign-integer-type
        (let* ((bits (foreign-integer-type-bits foreign-type))
               (signed (foreign-integer-type-signed foreign-type)))


### PR DESCRIPTION
An array-typed function parameter reaches the interface database as `#\?`, the "unknown" marker. Nothing decodes that marker. The argument spec becomes NIL, and a caller then fails at macroexpansion with `Unknown foreign type: NIL`. The error names neither the function nor the array.

This is not arm64. I measured it on stock 1.12.2, LinuxX8664:

```
(encode-ffi-arg-type '(:array 20 (:primitive (:unsigned 8))))  =>  (#\?)
compiling a call through such a definition  =>  Error: Unknown foreign type: NIL
```

Older ffigen decayed arrays before it wrote the database, so no committed .ffi file holds an array parameter. I scanned our 82 and found none. clang 19.1.7 emits them verbatim. This may bear on #13.

The fix encodes an array parameter as a pointer, which C requires (C11 6.7.6.3p7). The rest of the chain agrees already. `foreign-type-to-representation-type` maps `foreign-array-type` to `:address`. The ppc64 and arm64 callback generators read such an argument with `%get-ptr`. The second hunk gives `translate-foreign-arg-type` the same arm.

`encode-ffi-type` keeps full array types for typedefs and record fields, and I left it alone. An array must not decay there.

I watched the test fail, then pass, on one variable. It ends in a live `tmpnam(3)` call that fills a 20-byte buffer.

`lib/db-io.lisp` matches byte for byte on master, so master carries the same defect. I based this on arm64 because `lib/foreign-types.lisp` differs and the second hunk needs the arm64 text.

I have no PowerPC machine. I did not run this on ppc64.
