### PR TITLE
arm64: define DISASSEMBLE-LINES, which the Inspector requires

### DIFF
--- a/compiler/ARM64/arm64-disassemble.lisp
+++ b/compiler/ARM64/arm64-disassemble.lisp
@@ -573,3 +573,70 @@
 (defun ccl::arm64-xdisassemble (function)
   (ccl::arm64-disassemble-xfunction (ccl::function-to-function-vector function)
                                     *standard-output*))
+
+;;; The Inspector's disassembly pane (lib/describe.lisp) asks for a VECTOR of
+;;; lines rather than printed output.  Each line is (OBJECT LABEL INSTRUCTION):
+;;; OBJECT is a constant the instruction refers to, so the pane can inspect it;
+;;; LABEL is the pc, or (:label pc) when a label is defined there; INSTRUCTION
+;;; is the printed form.  x86-64 is the model -- lib/describe.lisp already
+;;; dispatches its prin1-value method on #+(or x86-target arm64-target) and so
+;;; expects exactly that shape from us.  Without this, the pane signals
+;;; "undefined function CCL::DISASSEMBLE-LINES" (Clozure/ccl#601).
+;;;
+;;; #+arm64-target because a cross-compiling host loads this backend: an
+;;; unguarded definition of CCL::DISASSEMBLE-LINES would clobber the host's own.
+;;; ARM32 guards its stub the same way (compiler/ARM/arm-disassemble.lisp).
+
+(defun constant-referenced-by (di function-vector)
+  ;; The constant an instruction loads out of the function vector, or NIL.
+  ;; The ref-constant vinsn emits `ldur dest,(:@ fn (:$ function.constants+8i))',
+  ;; so a non-indexed memory operand based on FN names constant i.  FN is an
+  ;; index into *REGISTERS* and GPR-REF interns out of that same vector, so EQ
+  ;; is exact here and discriminates x7 from w7 without comparing numbers.
+  ;; ref-indexed-constant computes its offset in a register and is not
+  ;; statically resolvable; those lines get NIL, as they should.
+  (dolist (op (di-operands di))
+    (when (memory-operand-p op)
+      (let ((base (memory-operand-base op))
+            (offset (memory-operand-offset op)))
+        (when (and (register-operand-p base)
+                   (eq (register-operand-register base) (svref *registers* fn))
+                   (immediate-operand-p offset)
+                   (not (memory-operand-pre-indexed op))
+                   (not (memory-operand-post-indexed op)))
+          (let ((byte-offset (immediate-operand-value offset)))
+            (when (and (>= byte-offset arm64::function.constants)
+                       (zerop (logand (- byte-offset arm64::function.constants) 7)))
+              ;; Slot 0 of the function vector is the code vector, so constant i
+              ;; lives at slot i+1.
+              (let ((slot (1+ (ash (- byte-offset arm64::function.constants) -3))))
+                (when (< slot (uvsize function-vector))
+                  (return (uvref function-vector slot)))))))))))
+
+(defun di-instruction-string (di)
+  ;; Reuse PRINT-DI so the pane and the disassembler listing can never drift.
+  ;; The instruction word is suppressed: the pane shows the pc in its own
+  ;; column and the raw word would only be noise there.  PRINT-DI opens with
+  ;; ~& , which emits nothing at column 0 of a fresh string stream, and indents
+  ;; by two -- trimmed here because the pane does its own layout.
+  (let ((*disassemble-print-instruction-word* nil))
+    (string-left-trim " " (with-output-to-string (s) (print-di di s)))))
+
+#+arm64-target
+(defun ccl::disassemble-lines (function)
+  (let* ((function (ccl::require-type function 'function))
+         (function-vector (ccl::function-to-function-vector function))
+         (di-vector (make-di-vector (uvref function-vector 0)))
+         (lines (make-array (length di-vector) :fill-pointer 0)))
+    (let ((source-note (ccl::function-source-note function)))
+      (when source-note
+        (ccl::ensure-source-note-text source-note)))
+    (resolve-labels di-vector)
+    (dotimes (i (length di-vector))
+      (let ((di (svref di-vector i))
+            (pc (* 4 i)))
+        (vector-push (list (constant-referenced-by di function-vector)
+                           (if (di-label di) (list :label pc) pc)
+                           (di-instruction-string di))
+                     lines)))
+    (coerce lines 'simple-vector)))


### PR DESCRIPTION
Gary Palter reported this as #601.

`ccl::disassemble-lines` is not defined in the arm64 port, and the Inspector disassembly pane calls it. At `lib/describe.lisp:1332` on branch arm64 at `84021fff`, `compute-disassembly-lines` evaluates `(ccl::disassemble-lines function)`. It reads the result as a vector of `(OBJECT LABEL INSTRUCTION)` lines.

Every other backend supplies the function: PPC at `compiler/PPC/ppc-disassemble.lisp:437`, x86 at `compiler/X86/x86-disassemble.lisp:3155`, and ARM32 as a stub that signals at `compiler/ARM/arm-disassemble.lisp:573`. ARM64 supplies nothing, so the pane signals an undefined-function error.

This patch follows x86 and not PPC, because the consumer already expects the x86 shape. At `lib/describe.lisp:1391` the function-inspector `prin1-value` method dispatches on `#+(or x86-target arm64-target)` and reads each line as `(cdr data)`. The PPC label form differs.

The OBJECT column resolves constants statically from the `ref-constant` vinsn. `ref-indexed-constant` computes its offset in a register, so those lines get NIL. That is correct.

Verification boundary. I built this patch and ran it on a live linuxarm64 image. The call returns a 16-element simple-vector, recovers `HELLO-CONSTANT` in the object column, and emits the labels `0`, `4`, `8` and `(:LABEL 12)`. I did not build any other target. The patch touches `compiler/ARM64/arm64-disassemble.lisp` and nothing else.

Fixes #601.
