### PR TITLE
arm64: build the lexpr frame before the fixed-arg copies so backtrace can decode lexpr locals

### DIFF
--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1161,9 +1161,23 @@
 (defun arm642-lexpr-entry (seg num-fixed)
   (with-arm64-local-vinsn-macros (seg)
     (! save-lexpr-argregs num-fixed)
+    ;; ARM64-DEVIATION: build the frame BEFORE the fixed-arg copies --
+    ;; x86-64's order (x862-lexpr-entry), not PPC64's.
+    ;; save-lisp-context-lexpr stores the CURRENT vsp as the frame's
+    ;; savevsp, and the backtrace decoder (map-entry-value ->
+    ;; %raw-frame-ref) uses that savevsp as the symbol map's vloc-0
+    ;; origin.  The origin is the lexpr count cell; each
+    ;; copy-lexpr-argument push moves vsp one word below it, so the
+    ;; copies-then-frame order records a savevsp 8*num-fixed bytes low
+    ;; and every symbol-map entry of a lexpr function reads one slot
+    ;; below its variable (Clozure/ccl#600: MORE decodes to the fixnum
+    ;; count, and %lexpr-count then reads machine address 8).  The
+    ;; savevsp slot is dead on the return path -- popj / nvalret
+    ;; restore vsp from the frames .SPlexpr-entry built -- so only the
+    ;; decoder sees the difference.
+    (! save-lisp-context-lexpr)
     (dotimes (i num-fixed)
-      (! copy-lexpr-argument))
-    (! save-lisp-context-lexpr)))
+      (! copy-lexpr-argument))))
 
 (defun arm642-load-lexpr-address (seg dest)
   (with-arm64-local-vinsn-macros (seg)


### PR DESCRIPTION
Gary Palter reported this as #600. `(/ 0 0)` signals DIVISION-BY-ZERO. Printing the backtrace then faults with "Fault during read of memory address #x8" inside `CCL::SUPPLIED-ARGUMENT-LIST`.

## The decoder contract

The backtrace reads a stack-resident variable of function F at

```
savevsp(prologue frame of F) - 8 - 8*slot
```

`map-entry-value` and `%raw-frame-ref` do this. The slot comes from the symbol map of F. Its entries encode `(vloc << 6) | #o77`.

On every normal entry path, `save-lisp-context-offset` stores `vsp + nbytes-vpushed`. The recorded savevsp is therefore the vloc-0 origin, and the arithmetic is exact.

## The lexpr path broke that invariant

`arm642-lexpr-entry` emitted three steps in the order PPC64 uses:

```
save-lexpr-argregs        ; blob: args + count cell, vsp = &count
copy-lexpr-argument (xN)  ; copy num-fixed args below, vsp -= 8*N
save-lisp-context-lexpr   ; savevsp := CURRENT vsp (count cell - 8*N)
```

The compiler then defines vloc 0 at the count cell. So the recorded savevsp sat `8*num-fixed` bytes below the vloc-0 origin. Every symbol-map entry of a lexpr function with num-fixed of 1 or more then read one slot below its variable.

Observed on a live frame for `/` at pc 220. Addresses descend:

```
#xFFFFA95DBA48  8               count cell (boxed 1)   <- vloc origin
#xFFFFA95DBA40  0               NUM copy               vloc 0
#xFFFFA95DBA38  #xFFFFA95DBA48  lexpr local MORE       vloc 8
#xFFFFA95DBA30  8               local COUNT (fixnum 1) vloc 16
#xFFFFA95DBA28  0               local I (fixnum 0)     vloc 24
```

The recorded savevsp was `#xFFFFA95DBA40`, one word low. NUM read the MORE slot. MORE read COUNT, the fixnum 1. COUNT read I, which holds 0. I fell off the `vsp-limits` bounds check.

`supplied-argument-list` then took the fixnum 1 from MORE, machine value 8, for a lexpr pointer. `%lexpr-count` dereferenced address 8. That is the fault in the issue.

`+` and `*` have num-fixed 0, so the defect misses them. `/` and `-` have num-fixed 1, so they shift by one word.

## The fix

Emit `save-lisp-context-lexpr` before the `copy-lexpr-argument` loop. At that point vsp is the count cell. The recorded savevsp is then the vloc-0 origin, and the normal-entry invariant holds again. `x862-lexpr-entry` already uses this order.

The savevsp slot is dead on the return path. popj and nvalret restore vsp from the `.SPlexpr-entry` frames. Only the decoder sees the change.

## The x86-64 oracle agrees

Stock x86-64 builds the identical symbol map for `/`. The raw addresses match: 63, 575, 1087 and 1599. It decodes all four entries correctly. Its raw-size is 4 where arm64 gave 3.

So the map was correct on both targets. Only the arm64 frame was wrong.

## Verification boundary

I built and measured this on linuxarm64. The post-fix probe shows savevsp equal to the count cell, raw-size 3 to 4, and all four entries of `/` decoding.

A new 5-case test failed 5 of 5 on the pre-fix image, with the #x8 fault verbatim. It passes 5 of 5 after the fix. It also passes 5 of 5 on stock x86-64.

Full suites on the patched image: ANSI `:EXCLUDED NIL :TOTAL 21679 :FAILED 0`, and ccl.lsp `:TOTAL 243 :FAILED 0`. The patch touches `compiler/ARM64/arm642.lisp` only.

## PPC64 may share this defect, and I cannot test it

`ppc2.lisp` has the same emission order. `ppc64-vinsns.lisp:3502` also stores the raw vsp. Both feed the same decoder in `lib/backtrace.lisp`.

I read that from source and did not run it, because I have no POWER hardware. ARM32 has the same emission order, but I did not analyze its decoder. You know the PPC frame layout far better than I do, so please judge whether the ordering really matches.

Fixes #600.
