### PR TITLE
fix: `#.` (read-eval) reader-macro crash when eval `#.(values ...)`

### DIFF
--- a/level-1/l1-reader.lisp
+++ b/level-1/l1-reader.lisp
@@ -2792,7 +2792,7 @@ initially NIL.")
   (if *read-eval*
     (let* ((exp (%read-list-expression stream nil)))
       (unless *read-suppress*
-        (eval exp)))
+        (values (eval exp))))
     (signal-reader-error stream "#. reader macro invoked when ~S is false ."
                          '*read-eval*)))
 


### PR DESCRIPTION
- Fixed the code because it simply used `eval` and did not anticipate the use of `values`, which returns multiple values.
- Ref: https://github.com/Clozure/ccl/issues/530