### PR TITLE
arm64: populate the NVR register pool, and the four changes it requires

### DIFF
--- a/compiler/ARM64/arm64-lap.lisp
+++ b/compiler/ARM64/arm64-lap.lisp
@@ -84,7 +84,13 @@
       (arm64-lap-generate-code current section-size *arm64-lap-lfun-bits*)
       )))
 
-(defun arm64-lap-generate-code (seg code-vector-size &optional (lfbits 0))
+;;; TRAILER-WORD, when non-nil, is appended as one extra data word at
+;;; the very end of the code vector (the register-save trailer --
+;;; format and rationale at arm642.lisp arm642-encode-regsave-trailer).
+;;; Hand-written lap functions never pass it: they manage save0-3
+;;; explicitly and record nothing.
+(defun arm64-lap-generate-code (seg code-vector-size &optional (lfbits 0)
+                                    trailer-word)
   (declare (fixnum code-vector-size))
   (let* ((target-backend *target-backend*)
          (cross-compiling (target-arch-case
@@ -101,7 +107,8 @@
          (i prefix-size))
     (declare (fixnum i constants-size))
     (let* ((code-vector (%alloc-misc
-                         (+ code-vector-size prefix-size)
+                         (+ code-vector-size prefix-size
+                            (if trailer-word 1 0))
                          (if cross-compiling
                            target::subtag-xcode-vector
                            arm64::subtag-code-vector))))
@@ -111,6 +118,9 @@
         (unless (eql (arm64::instruction-element-size insn) 0)
           (setf (uvref code-vector i) (arm64::instruction-word insn))
           (incf i)))
+      (when trailer-word
+        (setf (uvref code-vector i) trailer-word)
+        (incf i))
       (dolist (pair arm64::*constants*)
         (let ((imm (car pair))
               (k (cdr pair)))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -633,7 +633,10 @@
                            (arm642-xmake-function
                             code
                             *backend-immediates*
-                            bits))
+                            bits
+                            *arm642-compiler-register-save-note*
+                            *arm642-register-restore-ea*
+                            *arm642-register-restore-count*))
                      (when (getf debug-info 'pc-source-map)
                        (setf (getf debug-info 'pc-source-map)
                              (arm642-generate-pc-source-map debug-info)))
@@ -642,12 +645,64 @@
                              (arm642-digest-symbols)))))))))
     afunc))
 
-(defun arm642-xmake-function (code imms bits)
+(defun arm642-xmake-function (code imms bits &optional regsave-note
+                                   restore-ea nregs)
   (collect ((lap-imms))
     (dotimes (i (length imms))
       (lap-imms (cons (aref imms i) i)))
-    (let* ((arm64::*constants* (lap-imms)))
-      (arm64-lap-generate-code code (arm64::finalize code) bits))))
+    (let* ((arm64::*constants* (lap-imms))
+           ;; FINALIZE assigns every lap label's address; the regsave
+           ;; note's label is only readable after it runs.
+           (code-vector-size (arm64::finalize code))
+           (trailer (arm642-encode-regsave-trailer regsave-note
+                                                   restore-ea nregs)))
+      (arm64-lap-generate-code code code-vector-size bits trailer))))
+
+;;; Register-save trailer: one DATA word appended as the last word of
+;;; the code vector, never executed, recording where the function
+;;; saved save0..save(nregs-1).  This is PPC's scheme (the LWZ trailer:
+;;; emitted at ppc-lap.lisp:68 ppc-lap-encode-regsave-info, decoded at
+;;; lib/ppc-backtrace.lisp:101-134); lib/arm64-backtrace.lisp's
+;;; REGISTERS-USED-BY decodes ours via %CODE-VECTOR-LAST-INSTRUCTION,
+;;; which arm64 already carries (level-0/ARM64/arm64-misc.lisp:1249).
+;;; ARM64-DEVIATION (format only): PPC hides its trailer in a load
+;;; opcode that cannot end a PPC function.  Ours lives in the RESERVED
+;;; encoding space: bits[31:25]=0 with bits[24:22]/=0 is permanently
+;;; unallocated -- it is NOT UDF (imm16 form, bits[31:16]=0), which
+;;; matters because UUOs are UDF-space words (arm64-asm.lisp:453-494)
+;;; and a function can END with a uuo-error-*, so the marker must be
+;;; disjoint from that space as well as from every allocated
+;;; instruction and from the zero words the last-instruction scan
+;;; terminates on.
+;;;   bits[31:25] = 0      marker (reserved space)
+;;;   bits[24:22] = nregs  1..4; nonzero by construction
+;;;   bits[21:14] = pc     save-COMPLETION pc in words, %cfp-lfun
+;;;                        origin (label bytes/4 + 1 prefix word
+;;;                        + nregs instructions)
+;;;   bits[13:0]  = ea     *arm642-register-restore-ea* in 8-byte cells
+;;; No trailer is emitted when nothing was saved, when the save-nvrs
+;;; vinsn was optimized away (its note then never got a label), or
+;;; when a field overflows (pc >= #x100 words -- PPC gives up at #x80
+;;; -- or ea >= #x4000 cells).  REGISTERS-USED-BY then answers (nil
+;;; nil) as it did when the pool was empty, and the register walk
+;;; degrades to the xp/catch-frame fallback instead of decoding
+;;; garbage.
+(defun arm642-encode-regsave-trailer (note restore-ea nregs)
+  (when (and (typep note 'vinsn-note)
+             nregs
+             (> nregs 0)
+             restore-ea)
+    (let* ((lap-label (vinsn-note-address note))
+           (addr (and lap-label (arm64::label-address lap-label))))
+      (when addr
+        (let* ((pc-words (+ (ash addr -2) 1 nregs))
+               (ea-cells (ash restore-ea (- arm64::word-shift))))
+          (declare (fixnum pc-words ea-cells))
+          (when (and (< pc-words #x100)
+                     (< ea-cells #x4000))
+            (logior (ash nregs 22)
+                    (ash pc-words 14)
+                    ea-cells)))))))
 
 (defun arm642-make-stack (size &optional (subtype target::subtag-s16-vector))
   (make-uarray-1 subtype size t 0 nil nil nil nil t nil))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -2866,7 +2866,21 @@
           (if (eq spread-p 0)
             (! spread-lexpr)
             (! spread-list))
-          (arm642-restore-nvrs seg nil)
+          ;; ARM64-DEVIATION: guarded with tail-p, following PPC64
+          ;; (ppc2.lisp:2383-2391, `(when (and tail-p
+          ;; *ppc2-register-restore-count*) ...)') and x86-64
+          ;; (x862.lisp:3512).  ARM32 (arm2.lisp:2832) leaves it
+          ;; unguarded and ARM64 inherited that form.  Unguarded, every
+          ;; NON-tail (apply f list) reloads the caller's saved NVRs over
+          ;; this frame's live NVR-homed lexicals just before the call.
+          ;; The restore lives in this branch because the tail-p block
+          ;; above defers to it ((unless spread-p ...)) -- but that branch
+          ;; runs for non-tail calls too.  Invisible while *arm642-nvrs*
+          ;; is nil.  STILL WRONG for a tail spread of >4 args: PPC64
+          ;; restores relative to a PRE-spread vsp snapshot in temp1,
+          ;; because pushed spread args move vsp below the save area.
+          (when tail-p
+            (arm642-restore-nvrs seg nil))
           (arm642-restore-non-volatile-fprs seg)
           (! restore-nfp))
         (if nargs

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -5924,6 +5924,22 @@
       (with-arm64-p2-declarations p2decls
         (setq *arm642-inhibit-register-allocation*
               (setq no-regs (%ilogbitp $fbitnoregs fbits)))
+        ;; ARM64-DEVIATION: x86-64's guard (x862.lisp:7297-7305), ported
+        ;; verbatim.  A float-typed lexical must never win a GPR NVR:
+        ;; homing one there boxes the value on every setq, which turns an
+        ;; unboxed accumulator loop into an allocation loop (measured
+        ;; Measured under the pool: float-sum-unboxed 2.4 -> 4.3 ns/it,
+        ;; aref-df-declared 9955 -> 11830).  PPC64 has no such guard;
+        ;; the donor here is the port that added one.
+        (unless no-regs
+          (dolist (v (afunc-all-vars afunc))
+            (let* ((type (acode-var-type v *arm642-trust-declarations*)))
+              (when (or (subtypep type 'single-float)
+                        (subtypep type 'double-float)
+                        (subtypep type '(complex single-float))
+                        (subtypep type '(complex double-float)))
+                (nx-set-var-bits v (logior (ash 1 $vbitnoreg)
+                                           (nx-var-bits v)))))))
         (multiple-value-setq (pregs reglocatives)
 
           (nx2-afunc-allocate-global-registers afunc (unless no-regs *arm642-nvrs*)))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -203,7 +203,8 @@
 (defvar *arm642-emitted-source-notes* nil)
 
 (defvar *arm642-result-reg* arm64::arg_z)
-(defparameter *arm642-nvrs* nil)
+(defparameter *arm642-nvrs* (list arm64::save0 arm64::save1
+                                  arm64::save2 arm64::save3))
 (defparameter *arm642-first-nvr* -1)
 
 (defvar *arm642-gpr-locations* nil)

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -896,7 +896,11 @@
     (setq *arm642-register-restore-ea* *arm642-vstack*
           *arm642-register-restore-count* n)))
 
-(defun arm642-restore-nvrs (seg multiple-values-on-stack)
+;;; ARM64-DEVIATION: base-reg follows PPC64's ppc2-restore-nvrs base
+;;; parameter (default vsp).  A tail spread call passes a PRE-spread
+;;; vsp snapshot, because the spread subprim moves vsp at run time.
+(defun arm642-restore-nvrs (seg multiple-values-on-stack
+                            &optional (base-reg arm64::vsp))
   (let* ((ea *arm642-register-restore-ea*)
          (n *arm642-register-restore-count*))
     (when (and ea n)
@@ -904,7 +908,7 @@
         (let* ((diff (- *arm642-vstack* ea)))
           (if (and (eql 0 diff)
                    (not multiple-values-on-stack))
-            (! restore-nvrs n arm64::vsp)
+            (! restore-nvrs n base-reg)
             ;; ARM64-DEVIATION: rebind the temp-register masks around the
             ;; scratch selection.  The ARM32 original (arm2.lisp, same
             ;; function) calls SELECT-IMM-TEMP/SELECT-NODE-TEMP here with the
@@ -930,13 +934,13 @@
                          :class hard-reg-class-gpr
                          :mode hard-reg-class-gpr-mode-node)))
               (if (eql 0 diff)
-                (! fixnum-add reg arm64::vsp arm64::nargs)
+                (! fixnum-add reg base-reg arm64::nargs)
                 (progn
                   (if (< diff 4096)
-                    (! add-immediate reg arm64::vsp diff)
+                    (! add-immediate reg base-reg diff)
                     (progn
                       (arm642-lri seg reg diff)
-                      (! fixnum-add reg arm64::vsp reg)))
+                      (! fixnum-add reg base-reg reg)))
                   (when multiple-values-on-stack
                     (! fixnum-add reg reg arm64::nargs))))
               (! restore-nvrs n reg))))))))
@@ -2864,6 +2868,14 @@
       (if spread-p
         (progn
           (arm642-set-nargs seg (%i- nargs 1))
+          ;; ARM64-DEVIATION: snapshot the pre-spread vsp, following
+          ;; PPC64 (ppc2.lisp:2385-2386).  spreadargz/spread_lexprz
+          ;; preserve temp1 (x13): arm64-spentry.s shows both touch
+          ;; only imm0/imm1/arg_x/arg_y/arg_z/nargs/vsp.  The spread
+          ;; vinsns' own scratch is imm1, so temp1 survives into the
+          ;; restore below.
+          (when (and tail-p *arm642-register-restore-count*)
+            (! copy-gpr ($ arm64::temp1) ($ arm64::vsp)))
           (if (eq spread-p 0)
             (! spread-lexpr)
             (! spread-list))
@@ -2877,11 +2889,12 @@
           ;; The restore lives in this branch because the tail-p block
           ;; above defers to it ((unless spread-p ...)) -- but that branch
           ;; runs for non-tail calls too.  Invisible while *arm642-nvrs*
-          ;; is nil.  STILL WRONG for a tail spread of >4 args: PPC64
-          ;; restores relative to a PRE-spread vsp snapshot in temp1,
-          ;; because pushed spread args move vsp below the save area.
+          ;; is nil.  A tail spread of more than $numarm64argregs
+          ;; arguments pushes value-stack words and moves vsp below
+          ;; the save area, so the restore reads relative to the
+          ;; PRE-spread snapshot in temp1, as PPC64 does.
           (when tail-p
-            (arm642-restore-nvrs seg nil))
+            (arm642-restore-nvrs seg nil arm64::temp1))
           (arm642-restore-non-volatile-fprs seg)
           (! restore-nfp))
         (if nargs

--- a/compiler/PPC/ppc2.lisp
+++ b/compiler/PPC/ppc2.lisp
@@ -5267,6 +5267,18 @@
       (with-ppc-p2-declarations p2decls
         (setq *ppc2-inhibit-register-allocation*
               (setq no-regs (%ilogbitp $fbitnoregs fbits)))
+        ;; A float-typed lexical must never win one of *ppc2-nvrs*: those
+        ;; are general purpose registers, so the value would be boxed on
+        ;; every setq.  Donor: x862.lisp:7297-7305.
+        (unless no-regs
+          (dolist (v (afunc-all-vars afunc))
+            (let* ((type (acode-var-type v *ppc2-trust-declarations*)))
+              (when (or (subtypep type 'single-float)
+                        (subtypep type 'double-float)
+                        (subtypep type '(complex single-float))
+                        (subtypep type '(complex double-float)))
+                (nx-set-var-bits v (logior (ash 1 $vbitnoreg)
+                                           (nx-var-bits v)))))))
         (multiple-value-setq (pregs reglocatives) 
           (nx2-afunc-allocate-global-registers afunc (unless no-regs *ppc2-nvrs*)))
         (@ (backend-get-next-label)) ; generic self-reference label, should be label #1

--- a/lib/arm64-backtrace.lisp
+++ b/lib/arm64-backtrace.lisp
@@ -13,15 +13,18 @@
 ;;; lisp-frame-marker, NOT chained through a stored backlink as on
 ;;; PPC).
 ;;;
-;;; Scope follows the shipped ARM32 port (lib/arm-backtrace.lisp): the
-;;; saved-register machinery (registers-used-by encodings, srv vectors,
-;;; frame-restartable-p, %apply-in-frame and its PPC-instruction
-;;; branch-tree parser, ppc:379-736) has no analog because this design
-;;; keeps NO non-volatile lisp registers (lib/arm64env.lisp R1:
-;;; empty save pool) — the compiler can never record a saved-register
-;;; variable location.  APPLY-IN-FRAME is therefore unimplemented, as
-;;; on ARM32.  LATENT: revisit if save0-3 ever enter the register
-;;; pool.
+;;; Scope: save0..save3 are IN the register pool (*arm642-nvrs*,
+;;; arm642.lisp), so the saved-register recovery set is real here:
+;;; the compiler homes variables in save0-3, records those locations
+;;; in the symbol map (arm642-digest-symbols), and appends a
+;;; register-save trailer word to the code vector
+;;; (arm642-encode-regsave-trailer, format documented there) that
+;;; REGISTERS-USED-BY below decodes via %code-vector-last-instruction
+;;; -- PPC's LWZ-trailer scheme (ppc:101-134) carried into ARM64's
+;;; reserved encoding space.  Still absent, as on ARM32
+;;; (lib/arm-backtrace.lisp): the srv vectors, frame-restartable-p and
+;;; %apply-in-frame's PPC-instruction branch-tree parser (ppc:379-736).
+;;; APPLY-IN-FRAME therefore remains unimplemented.
 ;;;
 ;;; %frame-backlink and lisp-frame-p live HERE, not in
 ;;; arm64-threads-utils.lisp as on PPC: they need the
@@ -102,13 +105,41 @@
                   (%ptr-in-area-p index2 cs-area)
                   (< (the fixnum index1) (the fixnum index2)))))))
 
-;;; No non-volatile lisp registers in this design (header note), so no
-;;; register-save encoding exists to decode — the ARM32 answer
-;;; (arm-backtrace.lisp:49-51), not PPC's LWZ-trailer scheme
-;;; (ppc:101-134).
+;;; ppc:101-134 (the ppc64 arm, trailer-decoding form).  The trailer
+;;; is the last nonzero word of the code vector; the emitter and the
+;;; full format/reserved-space rationale live at
+;;; arm642-encode-regsave-trailer (arm642.lisp):
+;;;   bits[31:25]=0 (marker)  bits[24:22]=nregs (1..4)
+;;;   bits[21:14]=save-completion pc (words, %cfp-lfun origin)
+;;;   bits[13:0] =restore-ea (8-byte cells)
+;;; Returns (mask where) once AT-PC has passed the save sequence,
+;;; (mask nil) with no AT-PC ("saved somewhere, can't locate" -- the
+;;; walkers then answer their BAD value), (nil nil) otherwise.
+;;; Index space, shared by the mask, *saved-register-names* and the
+;;; catch-frame fallback: save0=3 .. save3=0.  The save-nvrs vinsn
+;;; (arm64-vinsns.lisp:7741) pushes save0 FIRST, so save0 sits at the
+;;; HIGHEST address = raw-frame index WHERE+0 = the highest mask bit,
+;;; PPC's exact geometry (stmw leaves save0=r31 highest, index 7).
+;;; ARM64-DEVIATION: the recorded pc is the save COMPLETION point, so
+;;; the AT-PC comparison is exact even for an exception pc inside the
+;;; save sequence; PPC (>= the sequence START) and x86-64 (<= rpc) are
+;;; both off by up to the sequence length there.
 (defun registers-used-by (lfun &optional at-pc)
-  (declare (ignore lfun at-pc))
-  (values nil nil))
+  (let* ((instr (%code-vector-last-instruction (uvref lfun 0))))
+    (if (and instr
+             (eql 0 (ldb (byte 7 25) instr))
+             (not (eql 0 (ldb (byte 3 22) instr))))
+      (let* ((nregs (ldb (byte 3 22) instr))
+             (pc (ldb (byte 8 14) instr))
+             (ea-cells (ldb (byte 14 0) instr))
+             (mask (ash (1- (ash 1 nregs)) (- 4 nregs))))
+        (declare (fixnum nregs pc ea-cells mask))
+        (if at-pc
+          (if (>= (ash at-pc -2) pc)
+            (values mask (- ea-cells nregs))
+            (values nil nil))
+          (values mask nil)))
+      (values nil nil))))
 
 (defun %frame-savefn (p)        ; ppc:153-156
   (if (fake-stack-frame-p p)
@@ -181,16 +212,95 @@
         (setq last-catch catch
               catch (next-catch catch))))))
 
-;;; With no saved registers (see registers-used-by) the compiler never
-;;; records a saved-register variable location, so these are
-;;; unreachable — the ARM32 answer (arm-backtrace.lisp:131-139).
-(defun %find-register-argument-value (context cfp regval bad)
-  (declare (ignore context cfp regval))
-  bad)
+;;; ppc:224-225.  ARM64-DEVIATION: this pool ASCENDS from save0=x19
+;;; where PPC's DESCENDS to save0=r31, and save0 must get the highest
+;;; index (see registers-used-by), so the sense flips: save3 - regno.
+(defun register-number->saved-register-index (regno)
+  (- arm64::save3 regno))
 
+;;; ppc:340-351.  ARM64-DEVIATION: our catch frame stores save0 FIRST,
+;;; ascending (arm64-arch.lisp catch-frame: "regs[] holds save0..save3
+;;; in ascending order"); PPC stores save7 first.  With index save0=3,
+;;; the cell is save-save0-cell + (3 - index).
+(defun get-register-value (address last-catch index)
+  (if address
+    (%fixnum-ref address)
+    (uvref last-catch (+ (- 3 index) target::catch-frame.save-save0-cell))))
+
+;;; Inverse of get-register-value
+(defun set-register-value (value address last-catch index)
+  (if address
+    (%fixnum-set address value)
+    (setf (uvref last-catch (+ (- 3 index) target::catch-frame.save-save0-cell))
+          value)))
+
+;;; ppc:227-249, with x86-backtrace.lisp:176-181's nil-WHERE guard (a
+;;; younger frame that saved the register at an unknown location must
+;;; answer BAD, not keep walking: an older copy or the catch snapshot
+;;; would be a stale value presented as current).  Walk correctness:
+;;; going from CFP toward YOUNGER frames, the FIRST frame whose mask
+;;; claims the register stored the value it saw at ITS entry, and no
+;;; live frame between CFP and it touched the register (one that had
+;;; would have saved it and been found first), so that stored value is
+;;; CFP's function's value.  A fake frame carries the register live in
+;;; its exception context.  If nothing saved it, the innermost catch
+;;; frame's snapshot is the donor-sanctioned fallback.
+(defun %find-register-argument-value (context cfp regval bad)
+  (let* ((last-catch (last-catch-since cfp context))
+         (index (register-number->saved-register-index regval)))
+    (do* ((frame cfp (child-frame frame context))
+          (first t))
+         ((null frame))
+      (if (fake-stack-frame-p frame)
+        (return-from %find-register-argument-value
+          (xp-gpr-lisp (%fake-stack-frame.xp frame) regval))
+        (if first
+          (setq first nil)
+          (multiple-value-bind (lfun pc)
+              (cfp-lfun frame)
+            (when lfun
+              (multiple-value-bind (mask where)
+                  (registers-used-by lfun pc)
+                (when (if mask (logbitp index mask))
+                  (return-from %find-register-argument-value
+                    (if where
+                      (raw-frame-ref frame context
+                                     (+ where
+                                        (logcount
+                                         (logandc2 mask
+                                                   (1- (ash 1 (1+ index))))))
+                                     bad)
+                      bad)))))))))
+    (get-register-value nil last-catch index)))
+
+;;; ppc:251-275, same shape and the same nil-WHERE guard (return NIL:
+;;; the caller set-map-entry-value treats non-nil as success).
 (defun %set-register-argument-value (context cfp regval new)
-  (declare (ignore context cfp regval))
-  new)
+  (let* ((last-catch (last-catch-since cfp context))
+         (index (register-number->saved-register-index regval)))
+    (do* ((frame cfp (child-frame frame context))
+          (first t))
+         ((null frame))
+      (if (fake-stack-frame-p frame)
+        (return-from %set-register-argument-value
+          (setf (xp-gpr-lisp (%fake-stack-frame.xp frame) regval) new))
+        (if first
+          (setq first nil)
+          (multiple-value-bind (lfun pc)
+              (cfp-lfun frame)
+            (when lfun
+              (multiple-value-bind (mask where)
+                  (registers-used-by lfun pc)
+                (when (if mask (logbitp index mask))
+                  (return-from %set-register-argument-value
+                    (when where
+                      (raw-frame-set frame context
+                                     (+ where
+                                        (logcount
+                                         (logandc2 mask
+                                                   (1- (ash 1 (1+ index))))))
+                                     new))))))))))
+    (set-register-value new nil last-catch index)))
 
 (defun %raw-frame-ref (cfp context idx bad) ; ppc:276-297
   (declare (fixnum idx))

--- a/lib/backtrace-lds.lisp
+++ b/lib/backtrace-lds.lisp
@@ -21,13 +21,13 @@
 
 
 (defparameter *saved-register-count*
-  #+(or x8632-target arm-target arm64-target) 0
-  #+x8664-target 4
+  #+(or x8632-target arm-target) 0
+  #+(or x8664-target arm64-target) 4
   #+ppc-target 8)
 
 (defparameter *saved-register-names*
-  #+(or x8632-target arm-target arm64-target) nil
-  #+x8664-target #(save3 save2 save1 save0)
+  #+(or x8632-target arm-target) nil
+  #+(or x8664-target arm64-target) #(save3 save2 save1 save0)
   #+ppc-target #(save7 save6 save5 save4 save3 save2 save1 save0))
 
 (defun frame-function (frame context)


### PR DESCRIPTION
This branch is the arm64 NVR register pool: seven commits, one subject.
Everything unrelated has been removed, as agreed in the comments.

`*arm642-nvrs*` is nil (arm642.lisp:206), so every lexical is homed on the
value stack. Patch 1 populates it with save0..save3. Details per patch are in
the commit messages.

**Aggregate: 10.5% less DO-TESTS CPU time** — 49.86 s against 55.72 s median,
6 interleaved pairs on one Graviton5, pool-on wins all 6, ranges do not
overlap. Hardware cycles agree at 10.2% fewer. The pool executes 3.9% MORE
instructions and still wins, IPC 3.041 to 3.520, so an instruction-count
argument predicts the wrong sign. ANSI 21679/0 and ccl.lsp 243/0 on all 12
runs.

The declared-array inner loop goes from 6.98 to 2.98 cycles per element.
Costs: deep recursion 1.16x slower, small allocation 1.11x to 1.13x, both from
save and restore on every call. The aggregate is the net.

1. Populate the pool.
2. Restore NVRs from a pre-spread vsp snapshot. **A correctness fix you can
   take alone.** A tail spread moves vsp below the save area, so the restore
   reads pushed arguments into save0-3 and they ride the return chain into
   every caller. Latent while the pool is empty. PPC64 donor,
   ppc2.lisp:2385-2391.
3. Float-typed lexicals never win a GPR NVR. Ports x862.lisp:7297-7305.
4. and 5. **Do not take patch 1 without these.** With the pool live a
   pool-homed local reads :UNAVAILABLE in the debugger. Patch 4 encodes the
   unused `:regsave` note into a code-vector trailer and carries a test we
   watched fail first; patch 5 supplies the portable count and names.

Not tested: Apple hardware, rebuild-ccl.

