### PR TITLE
arm64: pc_luser_xp's EGC dispatch must use ARM64's label order, not PPC's

### DIFF
--- a/lisp-kernel/arm64-exceptions.c
+++ b/lisp-kernel/arm64-exceptions.c
@@ -2168,7 +2168,10 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
      Conditional-store "did it store?" test: PPC reads CR0.EQ
      (xpCCR & 0x20000000); the drafts' ll/sc loops leave the stxr status
      in w17 (= temp5 after the 01d73c3 renumber; the uniform status register):
-     status != 0 means not-stored/will-retry. */
+     status != 0 means not-stored/will-retry.
+     ⛔ DISPATCH ORDER IS THIS FILE'S ADDRESS ORDER, NOT PPC's: rplaca/
+     rplacd sit ABOVE the whole spentry-B half here, so they must be
+     tested FIRST or they fall into the conditional leg (lost stores). */
   if (((program_counter >= &egc_rplaca) &&
        (program_counter < &egc_rplacd_end)) ||
       ((program_counter >= &egc_gvset) &&
@@ -2177,7 +2180,19 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
     bitvector refbits = (bitvector)(lisp_global(REFBITS));
     Boolean need_check_memo = true, need_memoize_root = false;
 
-    if (program_counter >= &egc_set_hash_key_conditional) {
+    if (program_counter >= &egc_rplacd) {
+      if (program_counter < &egc_rplacd_did_store) {
+        return;
+      }
+      ea = (LispObj *)untag(xpGPR(xp, arg_y));       /* cdr @ untag+0 */
+      val = xpGPR(xp, arg_z);
+    } else if (program_counter >= &egc_rplaca) {
+      if (program_counter < &egc_rplaca_did_store) {
+        return;
+      }
+      ea = ((LispObj *)untag(xpGPR(xp, arg_y))) + 1; /* car @ untag+8 */
+      val = xpGPR(xp, arg_z);
+    } else if (program_counter >= &egc_set_hash_key_conditional) {
       if ((program_counter < &egc_set_hash_key_conditional_test) ||
           ((program_counter == &egc_set_hash_key_conditional_test) &&
            ((xpGPR(xp, temp5) & 0xffffffff) != 0))) {
@@ -2204,23 +2219,12 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
       val = xpGPR(xp, arg_z);
       ea = (LispObj *)(root + xpGPR(xp, arg_y) + misc_data_offset);
       need_memoize_root = true;
-    } else if (program_counter >= &egc_gvset) {
+    } else {                      /* egc_gvset (lowest label; the outer
+                                     window test guarantees membership) */
       if (program_counter < &egc_gvset_did_store) {
         return;
       }
       ea = (LispObj *)(xpGPR(xp, arg_x) + xpGPR(xp, arg_y) + misc_data_offset);
-      val = xpGPR(xp, arg_z);
-    } else if (program_counter >= &egc_rplacd) {
-      if (program_counter < &egc_rplacd_did_store) {
-        return;
-      }
-      ea = (LispObj *)untag(xpGPR(xp, arg_y));       /* cdr @ untag+0 */
-      val = xpGPR(xp, arg_z);
-    } else {                      /* egc_rplaca */
-      if (program_counter < &egc_rplaca_did_store) {
-        return;
-      }
-      ea = ((LispObj *)untag(xpGPR(xp, arg_y))) + 1; /* car @ untag+8 */
       val = xpGPR(xp, arg_z);
     }
     if (need_check_memo) {        /* ppc:1964-1976 verbatim */


### PR DESCRIPTION
Sorry about this one — it is ours, and it has been in the tree since we
clustered the spentry files. We only found it while doing multithread testing.

`pc_luser_xp`'s write-barrier dispatch is a descending `>=` chain over the egc
labels, so it depends on their address order. On PPC and ARM32 rplaca and
rplacd are the lowest labels and the chain is right. On arm64 they are the
highest — `arm64-spentry.s` has them at 4802 and 4849, above
`egc_write_barrier_end` at 1571. `nm -n` on a built kernel confirms it rather
than trusting file order: `0x413880` and `0x413928` against `0x411908`.

So every PC inside `.SPrplaca` or `.SPrplacd` matches
`pc >= &egc_set_hash_key_conditional` first. It is past that leg's `_test`
guard so it does not return, `val` is never assigned so the memoize guard
`((LispObj)ea < val)` is false, and `set_xpPC(xp, xpLR(xp))` returns past the
rest of the spentry. Both legs are unreachable.

That means a thread suspended at or before the `str` loses the store outright.
We hit it as a circular thread-startup binding list: `initial-bindings` conses
a fresh list, so a dropped `rplacd` terminator leaves the last cons pointing
back into it. The worse case is a suspension *after* the `str`, which loses the
memoization instead and leaves a missed old-to-young refbit. We have reasoned
that one, not seen it.

The fix moves the two tests to the top of the chain. Leg bodies are unchanged
and `gvset` becomes the `else`, which the outer window guard makes exact. I
checked the routing for all five families rather than assuming it: every
conditional-family PC is below `egc_rplaca`, so both new tests are false for
them, and the outer guard excludes the gap between the two ranges so there is
no third state.

Evidence against `4c88f6ab`:

- A forced-GC probe loses a store within 26 to 37 full collections, on a
  shipped kernel and on one built from the current series. The signature is
  `LOST-STORE i=9569 cdr-read=9568` — the cdr exactly one iteration behind,
  which is a skipped store and not a bad pointer.
- With the patch as the only change: 500 forced collections clean, 33,271 more
  under the same allocation shape clean, the configuration that first crashed
  now runs to completion over about 19,600 thread creations, and ANSI
  `21679/0` and the CCL tests `243/0` stay green. Kernel md5 moves, image
  byte-identical.
- A separate memory-ordering probe's unsynchronized control still fires at the
  same rate with the patch applied, so the barrier is not quietly weakened.

One negative worth stating: an interrupt-driven variant of the probe stayed
green on both kernels. Interrupt bursts arrive at negative interrupt level and
take the defer branch, which never calls `pc_luser_xp`, so I read that as
underpowered rather than as evidence of safety.

Where the evidence comes from, since the two are not the same configuration:
the red-then-green above was measured on our patch series with our other
kernel changes applied, not on a pristine tree. Against pristine `4c88f6ab`
with only this patch applied, `arm64-exceptions.c` **adds no diagnostics**: 46
warnings at `-Wall -Wextra -Wno-unused-parameter`, identical to the unpatched
file, with an empty set difference between them. Under your Makefile's own
flags it is silent, but that is a weak statement since those flags carry no
`-Wall`, so the comparison above is the one worth quoting. The compile check
was watched failing on two deliberately broken inputs, one of them a brace
removed from the code this patch adds. I have not linked a full pristine kernel
or re-run the probes in that configuration.
