### PR TITLE
arm64: two bound checks translate a PPC64 *logical* comparison as a signed branch

### DIFF
--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -877,7 +877,7 @@ spentry stack_misc_alloc
         dnode_align imm1, imm1, (tsp_frame.fixed_overhead + node_size)
         mov     imm3, #tstack_alloc_limit
         cmp     imm1, imm3
-        b.ge    9f
+        b.hs    9f                    /* cmplri (ppc:1093) is UNSIGNED; b.ge accepted a bit-63 size */
         /* Push a boxed frame of imm1 bytes (built below the live tsp and
          * published atomically).  "_nz": imm1 always includes the frame
          * overhead + object header, so the data area is never empty. */
@@ -913,7 +913,7 @@ spentry makestackblock
         dnode_align imm0, imm0, (tsp_frame.fixed_overhead + macptr.size)
         mov     imm1, #tstack_alloc_limit
         cmp     imm0, imm1
-        b.ge    1f
+        b.hs    1f                    /* cmplri (ppc:3300) is UNSIGNED; b.ge accepted a bit-63 size */
         /* Push a raw/unboxed frame of imm0 bytes (built below the live tsp
          * and published atomically -- see arm64-macros.s). */
         TSP_Alloc_Var_Unboxed imm0, temp4
@@ -946,7 +946,7 @@ spentry makestacklist
         mov     imm3, #((tstack_alloc_limit + 1) - cons.size)
         cmp     imm0, imm3
         add     imm0, imm0, #tsp_frame.fixed_overhead
-        b.ge    3f
+        b.hs    3f                    /* cmplri (ppc:3353) is UNSIGNED; b.ge accepted a bit-63 size */
         /* Push a boxed frame of imm0 bytes (built below the live tsp and
          * published atomically).  imm0 == fixed_overhead when arg_y=0, so the
          * data area may be empty -- the leading-test TSP_Alloc_Var_Boxed (not
@@ -1072,7 +1072,7 @@ spentry makestackblock0
         dnode_align imm0, imm0, (tsp_frame.fixed_overhead + macptr.size)
         mov     imm1, #tstack_alloc_limit
         cmp     imm0, imm1
-        b.ge    makestackblock0_too_big
+        b.hs    makestackblock0_too_big  /* cmplri (ppc:3327) is UNSIGNED; b.ge accepted a bit-63 size */
         /* Push a raw/unboxed frame of imm0 bytes (built below the live tsp
          * and published atomically).  The frame stays raw, so the GC skips
          * it -- the data-zeroing below is for the block's contents (clear-p),

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -1715,7 +1715,7 @@ spentry misc_ref
         lsr imm1, imm0, #num_subtag_bits
         lsl imm1, imm1, #fixnumshift
         cmp arg_z, imm1
-        b.ge misc_ref_invalid
+        b.hs misc_ref_invalid           /* trlge (ppc:2409) is UNSIGNED; b.ge accepted a negative index */
         /* Extract subtag */
         and imm1, imm0, #subtagmask
 misc_ref_common:
@@ -1973,7 +1973,7 @@ spentry subtag_misc_ref
         lsr imm1, imm0, #num_subtag_bits
         lsl imm1, imm1, #fixnumshift
         cmp arg_z, imm1
-        b.ge 1f
+        b.hs 1f                         /* trlge (ppc:3209) is UNSIGNED; b.ge accepted a negative index */
         asr imm1, arg_x, #fixnumshift         /* unbox_fixnum(imm1,arg_x) = subtag override */
         b misc_ref_common
 1:      mov arg_x, #XBADVEC             /* errors.s:177 deferr           */
@@ -2044,7 +2044,7 @@ spentry subtag_misc_set
         lsr imm1, imm0, #num_subtag_bits
         lsl imm1, imm1, #fixnumshift
         cmp arg_y, imm1
-        b.ge 1f
+        b.hs 1f                         /* trlge (ppc:3911) is UNSIGNED; b.ge accepted a negative index */
         asr imm1, temp0, #fixnumshift         /* unbox subtag override from temp0 */
         b misc_set_common
 1:      mov arg_w, #XBADVEC             /* errors.s:177 deferr           */
@@ -2064,7 +2064,7 @@ spentry misc_set
         lsr imm1, imm0, #num_subtag_bits
         lsl imm1, imm1, #fixnumshift
         cmp arg_y, imm1
-        b.ge misc_set_invalid
+        b.hs misc_set_invalid           /* trlge (ppc:4877) is UNSIGNED; b.ge accepted a negative index */
         and imm1, imm0, #subtagmask
 misc_set_common:
         /* Node vectors -> delegate to gvset for write barrier.  Class


### PR DESCRIPTION
PPC64 checks both of these bounds with a LOGICAL, that is unsigned, comparison.
The arm64 translation keeps the values and branches with `b.ge`, which is signed.
The dropped word is "logical". The same file already spells the correct form 23
times as `b.hs`.

**1. `misc_ref` and `misc_set`: a negative index passes.** `arm64-spentry.s` at
`d61da8d0`, lines 1827, 2085, 2168 and 2188, against PPC64 `trlge` at
`ppc-spentry.s`:2409, :3209, :3911 and :4877. A negative boxed index is
signed-less-than every count, so the access ran at a negative offset from the
vector data. Measured at `safety 1`, one source tree: LinuxX8664 signals on 9 of 9
cases, LinuxARM6464 on the two upper-bound cases only. `(svref v -1)` returned
`#<BOGUS object @ #x4BE>`, which is `(4 << 8) | subtag-simple-vector` — the test
vector's own header word, handed to Lisp as an object. A store at -1 rewrote a
header and the GC died later on a corrupt uvector.

**2. `tstack_alloc_limit`: a bit-63 size passes.** Found by sweeping for the same
signature. PPC64 uses `cmplri` at four call sites: `ppc-spentry.s`:1059 in the
PPC64 arm of `stack_misc_alloc`, then :3300, :3327 and :3353. Note that
`ppc-spentry.s`:1093 is the 32-bit arm of that same entry, not a fifth site. The
four arm64 translations all use `b.ge`, at `arm64-spentry.s`:924, :974, :1013 and
:1152. A size with bit 63 set is signed-negative, so it passes and reaches
`sub tsp, tsp, size`, which moves `tsp` the wrong way. Four sites on each side, so
this completes the class.

**Verified.** Red-then-green on one image with the kernel relinked at each step:
without patch 1 the new test fails 8 of 12, with it 12 of 12, and every step moved
the artifact md5. Full suite after both, on linuxarm64 at `d61da8d0`: ANSI
`:TOTAL 21679 :FAILED 0 :EXCLUDED NIL`, CCL `:TOTAL 243 :FAILED 0`. The new test
also passes on a stock x86-64 CCL.

**Not verified.** The four `tstack_alloc_limit` sites were never observed firing —
found by signature, confirmed against the PPC64 source, an assembled kernel and an
unchanged suite. Neither the store side nor a bit-63 size has a red test, because
both corrupt memory by construction. The remaining signed `b.ge` in the file were
each read against their PPC64 source: sign tests, fixnum compares, subtag
byte-range checks, or deliberate parity with a PPC64 `cmpri`.

Those 21679 ANSI tests pass with defect 1 present. Measured across the suite's 851
files: only `elt.lsp` names a negative index, and only through `ELT`. No test
passes one to `AREF`, `SVREF`, `ROW-MAJOR-AREF` or `UVREF`.
