### PR TITLE
arm64: a derived code PC must not rest where the GC cannot relocate it

### DIFF
--- a/level-0/ARM64/arm64-clos.lisp
+++ b/level-0/ARM64/arm64-clos.lisp
@@ -242,11 +242,17 @@
      (arm64-lap-function
       gag
       ()
-      (mov temp4 lr)                        ; ppc:205 (mflr loc-pc) — LEXPR-RA
       (vpush-argregs)                       ; ppc:206
       (vpush nargs)                         ; ppc:207
       (add imm0 vsp nargs)                  ; ppc:208
       (add imm0 imm0 (:$ arm64::node-size)) ; ppc:209 caller's vsp
+      ;; W6/KI-026 co-design (was ppc:205 mflr loc-pc): the caller's
+      ;; return pc never rides in temp4 (node-scanned).  Build FRAME-A
+      ;; here, 0221 stp-pair shape; lr still holds the caller's pc and
+      ;; imm1 is call-subprim's scratch, free here.
+      (mov imm1 (:$ arm64::lisp-frame-marker))
+      (stp imm1 imm0 (:@! sp (:$ -32)))
+      (stp fn lr (:@ sp (:$ 16)))
       (call-subprim .SPlexpr-entry)         ; ppc:210 (bla) — DECIDE-10
       (mov lr temp4)                        ; ppc:211 (mtlr loc-pc) — lexpr cleanup continuation
       (mov arg_z vsp)                       ; ppc:212 lexpr
@@ -335,11 +341,15 @@
      (arm64-lap-function
       gag
       ()
-      (mov temp4 lr)                        ; ppc:317 (mflr loc-pc) — LEXPR-RA
       (vpush-argregs)                       ; ppc:318
       (vpush nargs)                         ; ppc:319
       (add imm0 vsp nargs)                  ; ppc:320
       (add imm0 imm0 (:$ arm64::node-size)) ; ppc:321 caller's vsp
+      ;; W6/KI-026 co-design (was ppc:317 mflr loc-pc): FRAME-A built
+      ;; here, 0221 stp-pair shape -- see *gf-proto* above.
+      (mov imm1 (:$ arm64::lisp-frame-marker))
+      (stp imm1 imm0 (:@! sp (:$ -32)))
+      (stp fn lr (:@ sp (:$ 16)))
       (call-subprim .SPlexpr-entry)         ; ppc:322 (bla) — DECIDE-10
       (mov lr temp4)                        ; ppc:323 (mtlr loc-pc) — lexpr cleanup continuation
       (mov arg_z vsp)                       ; ppc:324 lexpr

--- a/level-0/ARM64/arm64-misc.lisp
+++ b/level-0/ARM64/arm64-misc.lisp
@@ -189,11 +189,10 @@
   (unbox-fixnum imm1 disp)                          ; ppc:557
   (add imm0 node imm1)                             ; base = node+disp ([Xn]-only)
   @again
-  (ldxr arg_z (:@ imm0))                           ; ppc:559 lrarx
+  (ldaxr arg_z (:@ imm0))                           ; ppc:559 lrarx
   (add arg_z arg_z by)                             ; ppc:560
-  (stxr (:w temp4) arg_z (:@ imm0))                ; ppc:561 strcx.
+  (stlxr (:w temp4) arg_z (:@ imm0))                ; ppc:561 strcx.
   (cbnz (:w temp4) @again)                          ; ppc:562 (bne- @again)
-  (dmb (:$ 11))                                    ; ppc:563 isync
   (ret))                                           ; ppc:564
 
 ;;; =====================================================================
@@ -305,12 +304,11 @@
 (defarm64lapfunction %ptr-store-fixnum-conditional ((ptr arg_x) (expected-oldval arg_y) (newval arg_z))
   (macptr-ptr imm0 ptr)                            ; ppc:654 (base)
   @again
-  (ldxr imm1 (:@ imm0))                            ; ppc:656 lrarx actual-oldval
+  (ldaxr imm1 (:@ imm0))                            ; ppc:656 lrarx actual-oldval
   (cmp imm1 expected-oldval)                        ; ppc:657 cmpr
   (b.ne @done)                                     ; ppc:658 (bne-)
-  (stxr (:w temp4) newval (:@ imm0))               ; ppc:659 strcx.
+  (stlxr (:w temp4) newval (:@ imm0))               ; ppc:659 strcx.
   (cbnz (:w temp4) @again)                          ; ppc:660 (bne- @again)
-  (dmb (:$ 11))                                    ; ppc:661 isync
   (mov arg_z imm1)                                 ; ppc:662
   (ret)                                            ; ppc:663
   @done
@@ -335,8 +333,7 @@
 ;;; waiter path's avail increment before the release.
 (defarm64lapfunction %release-spin-lock ((p arg_z))
   (macptr-ptr imm0 p)
-  (dmb (:$ 11))                                    ; DMB ISH: release fence
-  (str xzr (:@ imm0))
+  (stlr xzr (:@ imm0))                             ; release store (0212)
   (mov arg_z rnil)
   (ret))
 

--- a/lisp-kernel/arm64-exceptions.c
+++ b/lisp-kernel/arm64-exceptions.c
@@ -2088,19 +2088,27 @@ extern opcode
 #define IS_STR_TO_SP(i) (((i) & 0xFFC003E0) == 0xF90003E0)
 #define STR_TO_SP_DISP(i) ((((i) >> 10) & 0xfff) << 3)
 
-/* The stp-pair marker-frame build (compiler save-lisp-context vinsns and
-   spentry build_catch_lisp_frame):
+/* The stp-pair marker-frame build (compiler save-lisp-context vinsns,
+   spentry build_catch_lisp_frame, mvpass, mvpasssym and lexpr_entry
+   FRAME-A/FRAME-B):
        mov Xm, #lisp_frame_marker
-       stp Xm, vsp, [sp, #-32]!     <- frame created; marker+savevsp stored
+       stp Xm, Xv,  [sp, #-32]!     <- frame created; marker+savevsp stored
        stp Xa, Xb,  [sp, #16]       <- savefn, savelr
    STP (64-bit, signed offset) Xa,Xb,[sp,#16]:
      0xA9000000 | (16>>3)<<15 | Rt2<<10 | 31<<5 | Rt; Rt/Rt2 masked out
      (fn/lr in most builds, xzr/temp4 in the lexpr prologue).
-   STP (64-bit, pre-index) Xm,vsp,[sp,#-32]!:
-     0xA9800000 | ((-32>>3)&0x7f)<<15 | 25<<10 | 31<<5 | Rt; Rt masked out
-     (the marker register is any :imm temp). */
+   STP (64-bit, pre-index) Xm,Xv,[sp,#-32]!:
+     0xA9800000 | ((-32>>3)&0x7f)<<15 | Rt2<<10 | 31<<5 | Rt; Rt/Rt2
+     masked out (the marker register is any :imm temp; Xv is vsp in the
+     vinsn and catch builds, a computed entry-vsp in imm0 at mvpass,
+     mvpasssym and lexpr_entry FRAME-A). */
 #define IS_STP_PAIR_TO_SP16(i) (((i) & 0xFFFF83E0) == 0xA90103E0)
-#define IS_STP_MARKER_VSP_PUSH(i) (((i) & 0xFFFFFFE0) == 0xA9BE67E0)
+/* stp Xt, Xt2, [sp, #-32]! -- the marker-frame push.  Rt2 is free:
+   the compiler vinsns and build_catch_lisp_frame push vsp, but
+   mvpass, mvpasssym and lexpr_entry FRAME-A push a computed
+   entry-vsp from imm0 (16m87 W5).  The stored marker word is
+   confirmed at run time instead (case (a2) below). */
+#define IS_STP_MARKER_PUSH(i) (((i) & 0xFFFF83E0) == 0xA9BE03E0)
 
 /*
  * Identify where we are in the consing sequence according to the
@@ -2323,14 +2331,19 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
          stp Xm, vsp, [sp, #-32]!    <- frame created + marker,savevsp stored
      --> stp fn, lr,  [sp, #16]      <- interrupted HERE
      (compiler save-lisp-context-no-stack-args / save-lisp-context-lexpr
-     (stp xzr,temp4) and spentry build_catch_lisp_frame).  The frame shows
+     (stp xzr,temp4), spentry build_catch_lisp_frame, and -- 16m87 W5 --
+     mvpass, mvpasssym and lexpr_entry FRAME-A/FRAME-B).  The frame shows
      a valid marker with GARBAGE savefn (node-scanned) and savelr
      (locative-scanned); zero both -- the interrupted stp re-executes on
      resume.  The save-lisp-context vinsn comment has claimed since its
      port that pc_luser_xp recognizes this build; case (a) above only ever
-     matched single-str builds, so until 16m86 nothing did. */
+     matched single-str builds, so until 16m86 nothing did.
+     The push recognizer no longer pins Rt2 to vsp, so the marker word
+     the completed push stored is checked instead: at this PC the push
+     HAS executed, so a real frame build always passes. */
   if (IS_STP_PAIR_TO_SP16(instr) &&
-      IS_STP_MARKER_VSP_PUSH(program_counter[-1])) {
+      IS_STP_MARKER_PUSH(program_counter[-1]) &&
+      (frame->marker == lisp_frame_marker)) {
     frame->savefn = 0;
     frame->savelr = 0;
     return;

--- a/lisp-kernel/arm64-exceptions.c
+++ b/lisp-kernel/arm64-exceptions.c
@@ -2057,6 +2057,22 @@ extern opcode
   egc_set_hash_key_conditional, egc_set_hash_key_conditional_test,
   egc_write_barrier_end;
 
+/* The two lr <-> lisp_frame.savelr swap windows in the nthrow spentries
+   (ARM32: swap_lr_lisp_frame_temp0 / _arg_z, arm-exceptions.c).  Window
+   body, 4 insns:
+       ldr temp4, [sp, #lisp_frame.savelr]
+       str lr,    [sp, #lisp_frame.savelr]
+       mov lr, temp4
+       mov temp4, #0
+   A movable interior code pc may rest ONLY in a pc-locative home (xpPC,
+   xpLR, or a walked savelr slot); these windows are the sole instants a
+   throw holds one in a scratch register, and pc_luser_xp rolls them
+   forward before any GC phase reads the context (16m86 pc-locative
+   class; comms/MT-CRASH-16m86.md C5/C6). */
+extern opcode
+  swap_lr_lisp_frame_0,                      /* nthrowvalues do_unwind    */
+  swap_lr_lisp_frame_1;                      /* nthrow1value do_unwind    */
+
 /* The tsp-frame "raw" mark: `str tsp, [tsp, #tsp_frame.type]' (type == 8;
    spentry-A tsp_frame equates / arm64-macros.s TSP frame discipline).
    STR (unsigned offset, 64-bit): 0xF9000000 | (8>>3)<<10 | tsp<<5 | tsp,
@@ -2071,6 +2087,20 @@ extern opcode
 #define CREATE_LISP_FRAME_INSTRUCTION 0xD10083FF
 #define IS_STR_TO_SP(i) (((i) & 0xFFC003E0) == 0xF90003E0)
 #define STR_TO_SP_DISP(i) ((((i) >> 10) & 0xfff) << 3)
+
+/* The stp-pair marker-frame build (compiler save-lisp-context vinsns and
+   spentry build_catch_lisp_frame):
+       mov Xm, #lisp_frame_marker
+       stp Xm, vsp, [sp, #-32]!     <- frame created; marker+savevsp stored
+       stp Xa, Xb,  [sp, #16]       <- savefn, savelr
+   STP (64-bit, signed offset) Xa,Xb,[sp,#16]:
+     0xA9000000 | (16>>3)<<15 | Rt2<<10 | 31<<5 | Rt; Rt/Rt2 masked out
+     (fn/lr in most builds, xzr/temp4 in the lexpr prologue).
+   STP (64-bit, pre-index) Xm,vsp,[sp,#-32]!:
+     0xA9800000 | ((-32>>3)&0x7f)<<15 | 25<<10 | 31<<5 | Rt; Rt masked out
+     (the marker register is any :imm temp). */
+#define IS_STP_PAIR_TO_SP16(i) (((i) & 0xFFFF83E0) == 0xA90103E0)
+#define IS_STP_MARKER_VSP_PUSH(i) (((i) & 0xFFFFFFE0) == 0xA9BE67E0)
 
 /*
  * Identify where we are in the consing sequence according to the
@@ -2288,6 +2318,24 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
     }
   }
 
+  /* (a2) the stp-pair marker-frame build:
+         mov Xm, #lisp_frame_marker
+         stp Xm, vsp, [sp, #-32]!    <- frame created + marker,savevsp stored
+     --> stp fn, lr,  [sp, #16]      <- interrupted HERE
+     (compiler save-lisp-context-no-stack-args / save-lisp-context-lexpr
+     (stp xzr,temp4) and spentry build_catch_lisp_frame).  The frame shows
+     a valid marker with GARBAGE savefn (node-scanned) and savelr
+     (locative-scanned); zero both -- the interrupted stp re-executes on
+     resume.  The save-lisp-context vinsn comment has claimed since its
+     port that pc_luser_xp recognizes this build; case (a) above only ever
+     matched single-str builds, so until 16m86 nothing did. */
+  if (IS_STP_PAIR_TO_SP16(instr) &&
+      IS_STP_MARKER_VSP_PUSH(program_counter[-1])) {
+    frame->savefn = 0;
+    frame->savelr = 0;
+    return;
+  }
+
   /* (c) consing / uvector allocation */
 
   /*
@@ -2374,6 +2422,41 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
           (LispObj)xpPC(xp));
     }
     return;
+  }
+
+  /* (f) the nthrow lr <-> savelr swap windows (ARM32 arm-exceptions.c,
+     swap_lr_lisp_frame_temp0/_arg_z; extern decls + window shape above).
+     Roll the swap FORWARD in the context: complete whichever of the
+     str/mov remain, so the cleanup pc and the caller's return pc both
+     rest in pc-locative homes (xpLR / the walked savelr slot) before
+     mark/forward/purify/impurify read the context.  temp4 is dead after
+     the window; zero it so a stale interior pc is never node-scanned. */
+  {
+    pc base = &swap_lr_lisp_frame_0;
+
+    if (!((program_counter > base) && (program_counter < (base + 4)))) {
+      base = &swap_lr_lisp_frame_1;
+      if (!((program_counter > base) && (program_counter < (base + 4)))) {
+        base = NULL;
+      }
+    }
+    if (base) {
+      lisp_frame *swap_frame = (lisp_frame *)ptr_from_lispobj(xpSP(xp));
+
+      if (program_counter == (base + 1)) {
+        /* ldr done, str pending: complete the str of our return pc. */
+        swap_frame->savelr = xpLR(xp);
+      }
+      /* Complete the `mov lr, temp4' -- idempotent when it already ran
+         (temp4 still holds the same pc at base+2 and base+3) -- and the
+         `mov temp4, #0'.  PC points at the NEXT insn to execute, so
+         every remaining step is completed here and none is redone in a
+         way that could differ. */
+      xpLR(xp) = xpGPR(xp, temp4);
+      xpGPR(xp, temp4) = 0;
+      xpPC(xp) = base + 4;
+      return;
+    }
   }
 
   /* PPC's INIT_CATCH_FRAME partial-init back-out (ppc:2096-2110) is NOT

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -2820,15 +2820,19 @@ endsp aset3
    unary-misc sub = error_propagate_suspend (10); reg field unused (x0). */
 
 /* control-stack lisp_frame build/discard (MARKER frame: \tmp carries the
-   marker constant, not a backlink).  savelr gets \clpc (catch cleanup
-   PC), savefn gets the volatile fn. */
-.macro build_catch_lisp_frame tmp, clpc
-        sub sp, sp, #lisp_frame.size
+   marker constant, not a backlink).  savelr gets LR ITSELF -- the address
+   of the compiler's forward `b <cleanup>` insn (ARM32 model, arm-macros.s
+   mkcatch): at throw time nthrow branches there and the b EXECUTES, so no
+   derived cleanup PC ever occupies a register the GC cannot see (16m86
+   pc-locative class, W1).  savefn gets the volatile fn.
+   Same stp shape as the compiler's save-lisp-context vinsns: the first stp
+   creates the frame and publishes marker+savevsp in one insn; a thread
+   suspended before the second stp shows garbage savefn/savelr, which
+   pc_luser_xp's stp-pair case zeroes (arm64-exceptions.c). */
+.macro build_catch_lisp_frame tmp
         mov \tmp, #lisp_frame_marker
-        str \tmp, [sp, #lisp_frame.marker]
-        str vsp, [sp, #lisp_frame.savevsp]
-        str fn, [sp, #lisp_frame.savefn]
-        str \clpc, [sp, #lisp_frame.savelr]
+        stp \tmp, vsp, [sp, #-lisp_frame.size]!
+        stp fn, lr, [sp, #lisp_frame.savefn]
 .endm
 
 /* tsp_alloc_fixed_unboxed / Set_TSP_Frame_Boxed / TSP_Unlink moved to the
@@ -2862,22 +2866,25 @@ endsp aset3
 
 /* mkcatch (ppc-macros.s:481-517).  Build a catch/unwind frame on the temp
    stack, with the caller's continuation saved in a control-stack lisp_frame.
-   In: arg_z = catch tag, imm2 = mvflag (0 or fixnum 1).  Clobbers imm0-5 and
+   In: arg_z = catch tag, imm2 = mvflag (0 or fixnum 1).  Clobbers imm0-4 and
    nargs ONLY; preserves save0..save3 (stored into the frame) and ALL temp
    regs -- PPC parity: ppc-macros.s mkcatch scratches imm0-4/loc_pc/nargs,
    and callers (toplevel_loop, compiled catch) keep the funcall target in
    temp0 across the _SPmkcatch* call (16j boot: temp0-as-scratch clobbered
    the toplevel function -> udf #49 in _SPfuncall).
-   PROPOSED: the cleanup-PC recovery assumes Matt's arm64 compiler emits a
-   forward `b <cleanup>` immediately after the `bl _SPmkcatch*`, exactly as the
-   PPC backend does. */
+   The compiler emits a forward `b <cleanup>` immediately after the
+   `bl _SPmkcatch*` (PPC protocol).  PPC decodes that insn HERE into loc_pc,
+   which its GC forwards as a pc-locative; arm64 has no loc_pc, and deriving
+   the target into imm5 left a ~7-insn window where a GC suspension
+   relocated the codevector but not the derived PC (16m86 corpse,
+   comms/MT-CRASH-16m86.md C5/C6, W1).  So store lr ITSELF as savelr (a
+   locative the frame walker updates) and let the b insn EXECUTE at throw
+   time -- the ARM32 model (arm-macros.s mkcatch), which needs no decode
+   and no derived PC at all. */
         .macro mkcatch
-        ldr w5, [lr]                   /* imm5: the forward branch insn       */
         ldr imm0, [rcontext, #tcr.catch_top]
-        sbfx imm5, imm5, #0, #26       /* B imm26, sign-extended              */
-        add imm5, lr, imm5, lsl #2     /* cleanup PC = lr + imm26*4           */
+        build_catch_lisp_frame imm4    /* csp frame: fn, lr(= the b insn), vsp */
         add lr, lr, #4                 /* normal return addr: skip the branch */
-        build_catch_lisp_frame imm4, imm5     /* csp frame: fn,cleanupPC,vsp  */
         ldr imm3, [rcontext, #tcr.xframe]
         ldr imm1, [rcontext, #tcr.db_link]
         TSP_Alloc_Fixed_Unboxed catch_frame.size, imm4
@@ -2989,9 +2996,11 @@ spentry throw
         ldr temp0, [imm3, #catch_frame.csp]
         mov sp, temp0
         ldr fn, [sp, #lisp_frame.savefn]
-        ldr temp4, [sp, #lisp_frame.savelr]  /* catch exit / cleanup PC        */
+        ldr lr, [sp, #lisp_frame.savelr]  /* catch exit pc STRAIGHT to lr: a
+                                             code pc parked in temp4 is a node
+                                             to the GC and goes stale across a
+                                             suspension (16m86 W2) */
         discard_lisp_frame
-        mov lr, temp4
         restore_catch_regs imm3
         ldr imm3, [imm3, #catch_frame.link]
         str imm3, [rcontext, #tcr.catch_top]
@@ -3009,6 +3018,30 @@ endsp throw
 /* tsp_alloc_var_boxed_nz moved to arm64-macros.s as TSP_Alloc_Var_Boxed
    (publish-last, 2-reg: size, scratch -- size is clobbered as the zeroing
    cursor, the live tsp is the loop's end sentinel). */
+
+/* Inline unbind-to-imm0 (ARM32 do_unbind_to model, arm-macros.s).
+   The nthrow spentries must NOT `bl _SPunbind_to': any bl clobbers lr, and
+   parking the caller's return pc in temp4 around the call hides a movable
+   interior code PC from the GC for the whole unbind (a node register skips
+   an untagged address -- the 16m86 pc-locative class, W2a).  PPC affords
+   the bl because it stashes into loc_pc, which ppc-gc.c forwards as a
+   pc-locative; arm64 has no loc_pc, so the loop is inlined (as on ARM32)
+   and lr is never disturbed.
+   Same body as `spentry unbind_to' (which now expands this macro).
+   In: imm0 = target db_link.  Clobbers imm1,imm2,arg_x,arg_y ONLY;
+   preserves nargs (.SPthrow relies on that). */
+        .macro unbind_to_imm0
+        ldr imm1, [rcontext, #tcr.db_link]
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+.Lu2i\@:
+        ldr arg_x, [imm1, #binding.sym]
+        ldr arg_y, [imm1, #binding.val]
+        ldr imm1, [imm1, #binding.link]
+        cmp imm0, imm1
+        str arg_y, [imm2, arg_x]
+        b.ne .Lu2i\@
+        str imm1, [rcontext, #tcr.db_link]
+        .endm
 
 spentry nthrowvalues
         /* ppc-spentry.s:166-284.  N values atop the vstack, nargs=count. */
@@ -3032,9 +3065,8 @@ spentry nthrowvalues
         mov sp, imm2                    /* sp = the frame's saved lisp_frame    */
         cmp imm0, imm1                  /* special bindings to undo?            */
         b.eq 2f
-        mov temp4, lr
-        bl _SPunbind_to                 /* imm0 = target db_link                */
-        mov lr, temp4
+        unbind_to_imm0                  /* imm0 = target db_link; inlined so
+                                           lr never leaves a pc-locative home */
 2:      /* _nthrowv_dont_unbind */
         cmp temp1, #unbound_marker      /* unwind-protect frame?                */
         b.eq 4f
@@ -3067,11 +3099,12 @@ spentry nthrowvalues
         restore_catch_regs temp0
         sub tsp, temp0, #(tsp_frame.fixed_overhead + fulltag_misc)
         TSP_Unlink
-        ldr temp4, [sp, #lisp_frame.savelr]   /* cleanup code address          */
         ldr nfn, [sp, #lisp_frame.savefn]     /* cleanup's own fn              */
         str fn, [sp, #lisp_frame.savefn]      /* stash caller fn in the frame  */
         mov fn, nfn
-        str lr, [sp, #lisp_frame.savelr]      /* stash our return in the frame */
+        /* The cleanup pc stays in the frame slot (locative-walked) until the
+           last moment; the lr<->savelr swap below is the only transit and
+           pc_luser_xp rolls it forward (16m86 W2b). */
         /* allocate a boxed tsp frame: overhead + nargs bytes + 2 nodes        */
         add imm0, nargs, #(tsp_frame.fixed_overhead + (2*node_size) + (dnode_size-1))
         and imm0, imm0, #~(dnode_size-1)
@@ -3089,15 +3122,28 @@ spentry nthrowvalues
         b.ne 41b
         str imm4, [imm0, #node_size]!   /* stash throw count after the values   */
         ldr vsp, [sp, #lisp_frame.savevsp]
+        /* lr <-> savelr swap: 3 insns, exported window; a thread suspended
+           inside it is rolled forward by pc_luser_xp (ARM32 model,
+           swap_lr_lisp_frame_temp0).  After the swap the cleanup pc rides in
+           lr, which every GC phase treats as a pc-locative. */
+        .globl C(swap_lr_lisp_frame_0)
+C(swap_lr_lisp_frame_0):
+        ldr temp4, [sp, #lisp_frame.savelr]   /* cleanup code address          */
+        str lr, [sp, #lisp_frame.savelr]      /* stash our return in the frame */
+        mov lr, temp4
+        mov temp4, #0                   /* dead, and an interior pc with low
+                                           nibble 0xc would be node-scanned
+                                           as a misc pointer at the next
+                                           suspension -- never leave one     */
         str xzr, [rcontext, #tcr.unwinding]
-        blr temp4                       /* call the cleanup form                */
+        blr lr                          /* call the cleanup form (blr reads Xn
+                                           before writing x30, C6.2.34)        */
         mov imm1, #1
         add imm0, tsp, #tsp_frame.data_offset
         str imm1, [rcontext, #tcr.unwinding]
         ldr fn, [sp, #lisp_frame.savefn]
-        ldr temp4, [sp, #lisp_frame.savelr]
+        ldr lr, [sp, #lisp_frame.savelr]    /* direct to lr: zero window     */
         discard_lisp_frame
-        mov lr, temp4
         ldr nargs, [imm0]               /* restore value count                  */
         mov imm2, nargs
         b 44f
@@ -3143,9 +3189,9 @@ spentry nthrow1value
         mov sp, imm2
         cmp imm0, imm1                  /* ppc:302 cr0, at its branch            */
         b.eq 2f                         /* ppc:311 beq cr0 -> dont_unbind        */
-        mov temp4, lr                   /* ppc:312 mflr                          */
-        bl _SPunbind_to                 /* ppc:313 (clobbers flags)              */
-        mov lr, temp4                   /* ppc:314 mtlr                          */
+        unbind_to_imm0                  /* ppc:312-314 mflr loc_pc/bl/mtlr --
+                                           inlined: temp4 is a NODE to the GC,
+                                           loc_pc was a pc-locative (16m86 W2a) */
 2:      /* ppc:315 _nthrow1v_dont_unbind */
         cmp temp1, #unbound_marker      /* ppc:307 cr7, recomputed post-unbind   */
         b.eq 4f                         /* ppc:316 beq cr7 -> do_unwind          */
@@ -3162,27 +3208,35 @@ spentry nthrow1value
         restore_catch_regs temp0        /* ppc:332 */
         sub tsp, temp0, #(tsp_frame.fixed_overhead + fulltag_misc)  /* ppc:333 */
         TSP_Unlink                      /* ppc:334 */
-        ldr temp4, [sp, #lisp_frame.savelr]  /* ppc:335,337 cleanup PC -> temp4  */
         ldr nfn, [sp, #lisp_frame.savefn]    /* ppc:336 cleanup's own fn         */
         str fn, [sp, #lisp_frame.savefn]     /* ppc:338 stash caller fn          */
         mov fn, nfn                     /* ppc:340 */
-        str lr, [sp, #lisp_frame.savelr]     /* ppc:339,341 stash our return     */
+        /* ppc:335/337/339/341 load loc_pc and stash lr here; on arm64 the
+           cleanup pc must not sit in temp4 across the tsp stores (16m86
+           W2b') -- it stays in the frame slot until the swap below. */
         /* fixed boxed tsp frame: value + throw count = 2 nodes (ppc:342)        */
         TSP_Alloc_Fixed_Unboxed 2*node_size, imm0
         Set_TSP_Frame_Boxed
         str arg_z, [tsp, #tsp_frame.data_offset]                /* ppc:343 */
         str imm4, [tsp, #(tsp_frame.data_offset + node_size)]   /* ppc:344 */
         ldr vsp, [sp, #lisp_frame.savevsp]   /* ppc:345 */
+        /* lr <-> savelr swap window; sibling of swap_lr_lisp_frame_0 above,
+           rolled forward by pc_luser_xp if a suspension lands inside. */
+        .globl C(swap_lr_lisp_frame_1)
+C(swap_lr_lisp_frame_1):
+        ldr temp4, [sp, #lisp_frame.savelr]  /* ppc:335,337 cleanup pc        */
+        str lr, [sp, #lisp_frame.savelr]     /* ppc:339,341 stash our return  */
+        mov lr, temp4
+        mov temp4, #0                   /* see swap_lr_lisp_frame_0          */
         str xzr, [rcontext, #tcr.unwinding]  /* ppc:346 */
-        blr temp4                       /* ppc:347 bctrl -> cleanup form         */
+        blr lr                          /* ppc:347 bctrl -> cleanup form         */
         mov imm1, #1                    /* ppc:348 */
         ldr arg_z, [tsp, #tsp_frame.data_offset]                /* ppc:349 */
         str imm1, [rcontext, #tcr.unwinding] /* ppc:350 */
         ldr imm4, [tsp, #(tsp_frame.data_offset + node_size)]   /* ppc:351 */
         ldr fn, [sp, #lisp_frame.savefn]     /* ppc:352 */
-        ldr temp4, [sp, #lisp_frame.savelr]  /* ppc:353 */
+        ldr lr, [sp, #lisp_frame.savelr]     /* ppc:353,355: direct to lr     */
         discard_lisp_frame              /* ppc:354 */
-        mov lr, temp4                   /* ppc:355 */
         TSP_Unlink                      /* ppc:356 */
         b 1b                            /* ppc:357 */
 8:      /* ppc:358 _nthrow1v_done.  nargs is dead here, so the poll may clobber it. */
@@ -3356,17 +3410,10 @@ endsp unbind_n
 spentry unbind_to
         /* Unbind until db_link == imm0.  Clobbers imm1,imm2,arg_x,arg_y.
            NOTE: unlike PPC (imm5 scratch), we must NOT touch imm5==nargs,
-           because .SPthrow relies on nargs surviving this call. */
-        ldr imm1, [rcontext, #tcr.db_link]
-        ldr imm2, [rcontext, #tcr.tlb_pointer]
-1:
-        ldr arg_x, [imm1, #binding.sym]
-        ldr arg_y, [imm1, #binding.val]
-        ldr imm1, [imm1, #binding.link]
-        cmp imm0, imm1
-        str arg_y, [imm2, arg_x]
-        b.ne 1b
-        str imm1, [rcontext, #tcr.db_link]
+           because .SPthrow relies on nargs surviving this call.
+           Body = unbind_to_imm0 (defined above spentry nthrowvalues), which
+           the nthrow spentries expand INLINE instead of bl'ing here. */
+        unbind_to_imm0
         ret
 endsp unbind_to
 

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -4672,13 +4672,15 @@ spentry mvpass
         sub imm0, imm0, #(nargregs<<fixnumshift) /* ppc:1158               */
         add imm0, imm0, nargs                   /* ppc:1159                */
 1:
-        /* ppc:1161 build_lisp_frame(fn,loc_pc,imm0) - MARKER frame */
-        sub sp, sp, #lisp_frame.size
+        /* ppc:1161 build_lisp_frame(fn,loc_pc,imm0) - MARKER frame.
+           stp form: the first stp creates the frame and publishes
+           marker+savevsp in one insn; a thread suspended before the
+           second stp shows garbage savefn/savelr, which pc_luser_xp's
+           stp-pair case zeroes (16m87 W5; same shape as
+           build_catch_lisp_frame and the save-lisp-context vinsns). */
         mov temp1, #lisp_frame_marker
-        str temp1, [sp, #lisp_frame.marker]
-        str imm0,  [sp, #lisp_frame.savevsp]
-        str fn,    [sp, #lisp_frame.savefn]
-        str lr,    [sp, #lisp_frame.savelr]
+        stp temp1, imm0, [sp, #-lisp_frame.size]!
+        stp fn, lr, [sp, #lisp_frame.savefn]
         /* ppc:1162 ref_global(loc_pc,ret1val_addr); ppc:1164 mtlr */
         ref_global lr, ret1val_addr             /* ppc:1162+1164           */
         mov fn, xzr                             /* ppc:1163 li fn,0        */
@@ -6003,13 +6005,12 @@ spentry mvpasssym
         add imm0, imm0, nargs          /* ppc:6892 */
 1:
         /* ppc:6894 build_lisp_frame(fn,loc_pc,imm0) -- MARKER frame
-         * (Matt's popj layout; no backlink word). */
-        sub sp, sp, #lisp_frame.size
+         * (Matt's popj layout; no backlink word).  stp form: no
+         * garbage-slot window; pc_luser_xp's stp-pair case covers a
+         * suspension between the two stps (16m87 W5). */
         mov temp0, #lisp_frame_marker
-        str temp0, [sp, #lisp_frame.marker]
-        str imm0, [sp, #lisp_frame.savevsp]
-        str fn, [sp, #lisp_frame.savefn]
-        str x30, [sp, #lisp_frame.savelr]
+        stp temp0, imm0, [sp, #-lisp_frame.size]!
+        stp fn, lr, [sp, #lisp_frame.savefn]
         /* ppc:6895 ref_global(loc_pc,ret1val_addr); ppc:6897 mtlr */
         ref_global lr, ret1val_addr     /* ppc:6895+6897 */
         mov fn, xzr                     /* ppc:6896 li fn,0 */
@@ -6870,25 +6871,27 @@ spentry lexpr_entry
         ref_global imm1, ret1val_addr           /* ppc:5363 (idiom: arm64-globals-proposed.s) */
         cmp imm1, temp4                         /* ppc:5364 cmpr w/ loc_pc   */
         /* FRAME-A (ppc:5365 build_lisp_frame(fn,loc_pc,imm0)): marker
-           frame; savevsp=entry-vsp, savelr=caller return pc. */
-        sub sp, sp, #lisp_frame.size
+           frame; savevsp=entry-vsp, savelr=caller return pc.  stp
+           form: no garbage-slot window (16m87 W5).  NB temp4 itself
+           is still not a pc-locative home across the prologue's bl
+           and this window -- that is W6, open, and needs a
+           compiler+spentry co-design.  The stps do not touch NZCV,
+           so the cmp above still governs the b.ne below. */
         mov imm2, #lisp_frame_marker
-        str imm2,  [sp, #lisp_frame.marker]
-        str imm0,  [sp, #lisp_frame.savevsp]
-        str fn,    [sp, #lisp_frame.savefn]
-        str temp4, [sp, #lisp_frame.savelr]
+        stp imm2, imm0, [sp, #-lisp_frame.size]!
+        stp fn, temp4, [sp, #lisp_frame.savefn]
         b.ne 1f                                 /* ppc:5366                  */
         /* Multiple-value case (caller's caller expects MVs).  FRAME-B
            (ppc:5367-5368 build_lisp_frame(rzero,lexpr_return,vsp)):
            savevsp=vsp (the count cell), savefn=0 (frame owns no fn),
            savelr=lexpr_return. */
         ref_global imm2, lexpr_return           /* ppc:5367 */
-        sub sp, sp, #lisp_frame.size
+        /* stp form: no garbage-slot window (16m87 W5).  savelr =
+           lexpr_return, a kernel static, so the value itself is
+           immovable. */
         mov imm3, #lisp_frame_marker
-        str imm3, [sp, #lisp_frame.marker]
-        str vsp,  [sp, #lisp_frame.savevsp]
-        str xzr,  [sp, #lisp_frame.savefn]
-        str imm2, [sp, #lisp_frame.savelr]
+        stp imm3, vsp, [sp, #-lisp_frame.size]!
+        stp xzr, imm2, [sp, #lisp_frame.savefn]
         mov temp4, imm1                         /* ppc:5369 loc_pc=ret1val   */
         /* Control-stack limit check (ppc:5370-5371 trllt(sp,cs_limit)). */
         ldr imm0, [rcontext, #tcr.cs_limit]

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -6859,27 +6859,29 @@ endsp syscall
  * caller, hiding the variable-length arglist; if the caller's caller
  * expects one value, take the simpler path.
  *
- * PROPOSED-CONVENTION LEXPR-RA (RATIFY): PPC compares/keeps the CALLER's
+ * LEXPR-RA (the W6/KI-026 co-design): PPC compares/keeps the CALLER's
  * return pc in loc_pc, while lr holds the return-to-prologue from the
- * `bla' - two live return addresses.  Matt's map has no loc_pc (x24=tsp),
- * so the lexpr function's prologue must pass the caller's return pc in
- * temp4=x16 before `bl _SPlexpr_entry`; lr = return-to-prologue.  On the
- * multiple-value path temp4 comes back = ret1val_addr for the prologue's
+ * `bla' - two live return addresses.  Matt's map has no loc_pc, and a
+ * node-scanned register (the old temp4 channel) is not a GC-safe home
+ * for a code pc, so the CALLER builds FRAME-A itself (marker frame:
+ * savevsp=entry-vsp, savefn=caller fn, savelr=caller return pc, stored
+ * from lr in the 0221 stp-pair shape BEFORE the call).  This subprim
+ * reads the caller's return pc from the walked savelr slot.  Builders:
+ * save-lexpr-argregs (arm64-vinsns.lisp) and the *gf-proto* /
+ * *cm-proto* LAP prototypes (arm64-clos.lisp).  On the multiple-value
+ * path temp4 goes back = ret1val_addr for the prologue's
  * save-lisp-context-lexpr to store; on the single-value path temp4 =
- * lexpr_return1v (both as on PPC, which returns them in loc_pc). */
+ * lexpr_return1v (both as on PPC, which returns them in loc_pc; both
+ * are kernel statics, so the RETURN leg is GC-safe in temp4). */
 spentry lexpr_entry
         ref_global imm1, ret1val_addr           /* ppc:5363 (idiom: arm64-globals-proposed.s) */
-        cmp imm1, temp4                         /* ppc:5364 cmpr w/ loc_pc   */
-        /* FRAME-A (ppc:5365 build_lisp_frame(fn,loc_pc,imm0)): marker
-           frame; savevsp=entry-vsp, savelr=caller return pc.  stp
-           form: no garbage-slot window (16m87 W5).  NB temp4 itself
-           is still not a pc-locative home across the prologue's bl
-           and this window -- that is W6, open, and needs a
-           compiler+spentry co-design.  The stps do not touch NZCV,
-           so the cmp above still governs the b.ne below. */
-        mov imm2, #lisp_frame_marker
-        stp imm2, imm0, [sp, #-lisp_frame.size]!
-        stp fn, temp4, [sp, #lisp_frame.savefn]
+        /* ARM64-DEVIATION: PPC builds FRAME-A here (ppc:5365) and
+           compares loc_pc (ppc:5364).  The caller already built
+           FRAME-A (see the header comment), so load the caller's
+           return pc from the walked slot and compare that.  Nothing
+           sits between the cmp and the b.ne. */
+        ldr imm2, [sp, #lisp_frame.savelr]
+        cmp imm1, imm2                          /* ppc:5364 cmpr w/ loc_pc   */
         b.ne 1f                                 /* ppc:5366                  */
         /* Multiple-value case (caller's caller expects MVs).  FRAME-B
            (ppc:5367-5368 build_lisp_frame(rzero,lexpr_return,vsp)):


### PR DESCRIPTION
Four commits on `d61da8d0`. Commits 1 to 3 are one defect class. Commit 4 is
unrelated. Each commit message carries its own detail.

Your `df738b0e` states the class better than my patch text did. *"Keeping a
pc-locative in the node register temp4 is not gc-safe."* These are the
remaining sites.

**The class.** `mark_xp`, `forward_xp`, `purify_xp` and `impurify_xp` treat
`xpPC` and `xpLR` as pc-locatives, and `x7`..`x23` as NODES. An untagged code
address in a node register therefore reads as a fixnum and stays unrelocated.
The GC never scans `x0`-`x6`. A thread crashed branching to an unwind-protect
cleanup at the PRE-GC address of a codevector a compacting GC had moved.

Every other port closes this deliberately. PPC keeps such PCs in `loc_pc`,
x86-64 tags them `tra`, and ARM32 keeps them in `lr` with one 3-instruction swap
window that `pc_luser_xp` rolls forward. arm64 took PPC's idiom onto
`temp4`/`x16` without its GC half.

**Commit 1 adopts the ARM32 model,** because neither `tra` nor a spare register
exists here. `mkcatch` stores `lr` itself as the catch frame's `savelr`, so the
walker relocates that slot. The 7-instruction derive window is gone. The
`nthrow` paths hold the cleanup PC in the frame slot until a 4-instruction
exported window moves it to `lr`, then call `blr lr`. That window also zeroes
`temp4`, so the GC never node-scans a dead interior PC.

Your `df738b0e` supersedes four of its hunks and I dropped them. Your `nvalret`
form is stronger than mine: fall-through, label deleted.

**Commit 2 fixes four frame builds `pc_luser_xp` cannot see.** Case (a)
recognizes a `str` to `sp` only when the frame-creating `sub` sits 1 to 3
instructions back. `mvpass`, `mvpasssym` and `lexpr_entry` use a `sub` and four
separate `str` instructions, which puts `savefn` and `savelr` 4 and 5
instructions out. A thread suspended there shows a valid marker, a garbage
`savefn` which the GC node-scans, and a garbage `savelr` which it
locative-scans.

All four now use the `stp` pair, and case (a2) zeroes both slots for a thread
caught between the two `stp`s. Case (a2) also had to widen: it pinned `Rt2` to
`vsp`, but three of the four push a computed entry-vsp from `imm0`. It now frees
`Rt2` and confirms the stored marker word instead. The push has already executed
at the recognized PC, so a real frame build always passes and a coincidental
`stp` pair cannot.

**Commit 3 is the entry-path sibling of your `df738b0e`.** Every lexpr and
`&rest` prologue ended `mov temp4, lr` and called `_SPlexpr_entry`, which stored
`temp4` to FRAME-A `savelr` eight instructions later. The `*gf-proto*` and
`*cm-proto*` LAP prototypes carried the same window. The fix moves FRAME-A into
the callers, which build it with commit 2's shape and store `LR` to `savelr`
before the call.

`pc_luser_xp` cannot close this window, by construction. It rolls forward the
partially built state it recognizes, and it normalizes the allocation
registers. It does not relocate a general register, and no case in it reads or
rewrites `temp4`.

Your shape does not transfer here, for one reason. `values` and `nvalret` hold
one live pc and call nothing, so it can stay in `lr`. The lexpr prologue holds
two live pcs across a call, and one `lr` cannot hold both, so the second home
must be the walked slot. This is your design under that constraint, not a second
design.

**Commit 4 is memory ordering, not GC.** The arm64 LAP atomics came from PPC64
instruction by instruction, and PPC has no acquire or release load or store.
Three sites therefore still pay a full `dmb` for ordering that ARMv8 already
provides. `%atomic-incf-node` and `%ptr-store-fixnum-conditional` become
`ldaxr`/`stlxr` with no fence, and `%release-spin-lock` becomes one `stlr`.
Every instruction is baseline ARMv8.0. ARMv7 has no `stlr`, so the ARM32 idiom
stays `dmb` plus `str` and this does not carry back.

Measured per operation on a 2-core arm64 Linux host: uncontended
`with-lock-grabbed` -18%, two threads on two locks -19%, `atomic-incf` -10%.

**Verified at `d61da8d0`.** The four commits chain-apply clean on a pristine
tree. Built and tested on linuxarm64 at that base: ANSI `:TOTAL 21679 :FAILED 0
:EXCLUDED NIL` and CCL `:TOTAL 243 :FAILED 0`.

**Scope.** Every file is arm64-scoped: `lisp-kernel/arm64-spentry.s`,
`lisp-kernel/arm64-exceptions.c`, `level-0/ARM64/arm64-clos.lisp` and
`level-0/ARM64/arm64-misc.lisp`. I have not built any other target.

**Two limits.** No red test forces a suspension inside these windows. Each is a
few instructions wide, and only another thread can suspend inside one. Both
suites are also single-thread, so they cannot certify a barrier-ordering change.

For commit 4 the ordering evidence is a litmus suite of 5 families and 12
variants. All 6 red controls fired. 155,435,310 synchronized iterations gave
zero anomalies, and every variant agrees with stock x86-64 CCL. That shows the
change is safe. It does not show it is necessary, because the `dmb` form is
strictly stronger and also passes.

`0215`, the `pc_luser_xp` EGC dispatch order, is deliberately not here. It is
already PR #611 and applies independently.
