### PR TITLE
arm64: four codegen fixes

### DIFF
--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -1726,9 +1726,15 @@
 ;;; s61-truncation class).  Lane order low-then-high; the first emitted
 ;;; insn reads src, any second insn reads dest -- dest=src safe.
 ;;; const=0 degenerates to (add dest src #0) -- a copy, correct.
+;;; The class is :s24const because AArch64 ADD (immediate) holds imm12 with an
+;;; optional LSL #12, so the two lanes below reach 24 bits of magnitude and no
+;;; more.  A :s32const declaration admits a constant the body then drops: at
+;;; 2^24 both ldb fields are 0 and the vinsn emits `add dest,src,#0,lsl #12',
+;;; which adds ZERO with no diagnostic.  (signed-byte 24) is the conservative
+;;; fit, and every emit site already gates at (signed-byte 24) or tighter.
 (define-arm64-vinsn add-immediate (((dest :imm))
                                    ((src :imm)
-                                    (const :s32const)))
+                                    (const :s24const)))
   ((:pred >= const 0)
    ((:not (:pred = 0 (:apply ldb (byte 12 0) const)))
     (add dest src (:$ (:apply ldb (byte 12 0) const)))

--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -2189,25 +2189,19 @@
 ;;; ============ misc-ref-c-complex-double-float ============
 ;;; PPC64 ppc64-vinsns.lisp:271: two lfd loads (realpart @
 ;;; complex-double-float.realpart + 16k, imagpart +8) into an FPR pair.
-;;; Matt: ONE 128-bit vector register, D lanes 0/1 -- but his template
-;;; table has NO Q-form load/store, so the transfer is composed exactly
-;;; like his %make-complex-double-float: load lane 0 via the D view
-;;; (zeroing the upper lane -- hence low lane FIRST), load the imag word
-;;; into a D temp, INS it into lane 1.  (:d dest) is load-bearing: the
-;;; :complex-double-float class is (:fpr 128) and matches no load
-;;; template bare.  Data start .realpart = +4 = misc-complex-dfloat-
-;;; offset (pad word => absolute 16-alignment, arch @199-202, U6a);
-;;; disps 16k+4 / 16k+12, k <= 11 handler-gated (conservative) => both in simm9.
+;;; A complex-double-float lives in ONE 128-bit vector register here, so this
+;;; is a single Q-form LDUR.  A bare :complex-double-float operand resolves to
+;;; the Q view through vinsn-gpr-class->family+width.
+;;; Data start .realpart = +4 from the fulltag-misc pointer = base+16, and base
+;;; is dnode-aligned, so the 128-bit access is naturally aligned.  That is what
+;;; the arch pad cell is for.  disp 16k+4, k <= 11 handler-gated
+;;; (conservative) => in simm9.
 (define-arm64-vinsn misc-ref-c-complex-double-float
     (((dest :complex-double-float))
      ((v :lisp)
-      (idx :u32const))
-     ((dtemp :double-float)))
-  (ldur (:d dest) (:@ v (:$ (:apply + arm64::complex-double-float.realpart
-                                    (:apply ash idx 4)))))
-  (ldur dtemp (:@ v (:$ (:apply + (+ arm64::complex-double-float.realpart 8)
-                                (:apply ash idx 4)))))
-  (ins (:d dest 1) (:d dtemp 0)))
+      (idx :u32const)))
+  (ldur dest (:@ v (:$ (:apply + arm64::complex-double-float.realpart
+                               (:apply ash idx 4))))))
 
 ;;; ============================================================
 ;;; Variable-index misc-ref (12) -- scaled-idx = byte offset INCLUDING
@@ -2319,20 +2313,22 @@
 
 ;;; ============ misc-ref-complex-double-float ============
 ;;; PPC64 ppc64-vinsns.lisp:262: (addi idx2 scaled-idx 8) then two lfdx
-;;; into an FPR pair.  Composed 128-bit load (U6a): PPC's idx2-temp
-;;; structure carried for the second lane's address; low lane loaded
-;;; FIRST via the D view (zeroing lane 1), then ins.  scaled-idx
-;;; already includes misc-complex-dfloat-offset (scale-128bit contract).
+;;; into an FPR pair.  One 128-bit load here, as in the constant-index
+;;; sibling.  There is no Q-form REG-OFFSET template -- arm64-asm.lisp
+;;; defines :q loads/stores only for :mem-scaled/:uoff4 and
+;;; :mem-unscaled/:simm9 -- so fold the index into the address
+;;; with the plain add + [reg,#0] shape this file already uses for
+;;; mem-ref-double-float.  idx2 is imm-class (x0-x5), which the GC does
+;;; not scan as a node, and no allocation point separates the add from
+;;; the load.  scaled-idx already includes misc-complex-dfloat-offset
+;;; (scale-128bit contract).
 (define-arm64-vinsn misc-ref-complex-double-float
     (((dest :complex-double-float))
      ((v :lisp)
       (scaled-idx :u64))
-     ((idx2 :u64)
-      (dtemp :double-float)))
-  (add idx2 scaled-idx (:$ 8))
-  (ldr (:d dest) (:@ v scaled-idx))
-  (ldr dtemp (:@ v idx2))
-  (ins (:d dest 1) (:d dtemp 0)))
+     ((idx2 :u64)))
+  (add idx2 v scaled-idx)
+  (ldur dest (:@ idx2 (:$ 0))))
 
 ;;; ============================================================
 ;;; Constant-index misc-set (12).  Same displacement arithmetic as the
@@ -2480,21 +2476,15 @@
 
 ;;; ============ misc-set-c-complex-double-float ============
 ;;; PPC64 ppc64-vinsns.lisp:279: two stfd (realpart @ .realpart + 16k,
-;;; imagpart +8) from an FPR pair.  Composed 128-bit store (U6a): STUR
-;;; the D view (lane 0), DUP lane 1 into a D temp (his
-;;; %complex-double-float-imagpart idiom), STUR the temp.  (:d val)
-;;; load-bearing ((:fpr 128) matches no store template bare).
-;;; disps 16k+4 / 16k+12, k <= 11 handler-gated (conservative).
+;;; imagpart +8) from an FPR pair.  One 128-bit store here: a Q-form STUR.  A
+;;; bare :complex-double-float operand is the Q view.
+;;; disp 16k+4, k <= 11 handler-gated (conservative).
 (define-arm64-vinsn misc-set-c-complex-double-float
     (((val :complex-double-float))
      ((v :lisp)
-      (idx :u32const))
-     ((dtemp :double-float)))
-  (stur (:d val) (:@ v (:$ (:apply + arm64::complex-double-float.realpart
-                                   (:apply ash idx 4)))))
-  (dup dtemp (:d val 1))
-  (stur dtemp (:@ v (:$ (:apply + (+ arm64::complex-double-float.realpart 8)
-                                (:apply ash idx 4))))))
+      (idx :u32const)))
+  (stur val (:@ v (:$ (:apply + arm64::complex-double-float.realpart
+                              (:apply ash idx 4))))))
 
 ;;; ============================================================
 ;;; Variable-index misc-set (12) -- scaled-idx contract as misc-ref-*.
@@ -2601,19 +2591,16 @@
 
 ;;; ============ misc-set-complex-double-float ============
 ;;; PPC64 ppc64-vinsns.lisp:287: (addi idx2 scaled-idx 8), two stfdx.
-;;; Composed store (U6a): str (:d val) lane 0 at scaled-idx, dup lane 1
-;;; into dtemp, str dtemp at idx2.
+;;; One 128-bit store; no Q-form reg-offset template exists, so plain add
+;;; into the GPR temp then [reg,#0] -- the mem-set-double-float shape.
 (define-arm64-vinsn misc-set-complex-double-float
     (()
      ((val :complex-double-float)
       (v :lisp)
       (scaled-idx :u64))
-     ((idx2 :u64)
-      (dtemp :double-float)))
-  (add idx2 scaled-idx (:$ 8))
-  (str (:d val) (:@ v scaled-idx))
-  (dup dtemp (:d val 1))
-  (str dtemp (:@ v idx2)))
+     ((idx2 :u64)))
+  (add idx2 v scaled-idx)
+  (stur val (:@ idx2 (:$ 0))))
 
 ;;; ============ misc-ref-c-bit-fixnum ============
 ;;; The one member of the MISC-REF family this file deferred (see the header:
@@ -3379,21 +3366,19 @@
   (ldur (:d target) (:@ source (:$ arm64::complex-single-float.realpart))))
 
 ;;; ============ get-complex-double ============
-;;; Emit site: w3 complex-double aset leg (arm642-additions-w3.lisp:422).
 ;;; PPC64 ppc64-vinsns.lisp:2651 (lfd realpart / lfd imagpart into a
-;;; pair); Matt: ONE 128-bit vector register, lanes 0/1 of the D view
-;;; (his %make-complex-double-float).  His assembler has NO Q-form
-;;; load/store template (verified @115b7aa), so the load is two D-form
-;;; LDURs + INS -- exactly his %make-complex-double-float lane idiom.
-;;; Offsets symbolic: complex-double-float has a PAD slot (his arch
-;;; @449-452: pad @+4, realpart @+12, imagpart @+20; both simm9,
-;;; unaligned => LDUR).
+;;; pair).  A complex-double-float is ONE 128-bit vector register here,
+;;; so this is one Q-form LDUR.  Offsets are symbolic: complex-double-float
+;;; carries a pad cell so that .realpart (+4 from the fulltag-misc pointer) is
+;;; 16-aligned in absolute terms.  The earlier two-D-LDUR-plus-INS form here
+;;; recorded that no Q template existed; "Support :q sized loads and stores"
+;;; added them.
+;;; No emit site refers to this vinsn today; get-complex-double-float below is
+;;; what arm642.lisp uses.  Converted rather than deleted so the family stays
+;;; uniform.
 (define-arm64-vinsn get-complex-double (((target :complex-double-float))
-                                        ((source :lisp))
-                                        ((temp :double-float)))
-  (ldur (:d target) (:@ source (:$ arm64::complex-double-float.realpart)))
-  (ldur temp (:@ source (:$ arm64::complex-double-float.imagpart)))
-  (ins (:d target 1) (:d temp 0)))
+                                        ((source :lisp)))
+  (ldur target (:@ source (:$ arm64::complex-double-float.realpart))))
 
 ;;; ============================================================
 ;;; (f) singletons
@@ -3928,14 +3913,21 @@
 
 ;;; complex-double-float->heap -- box a cdf (both double lanes live in
 ;;; one 128-bit Q reg, :fpr 128 per arm64-asm.lisp:2934) into a fresh
-;;; 32-byte miscobj.  The pad word 16-aligns realpart.  The payload
-;;; store is composed as two D STURs + DUP (the misc-set-c-complex-
-;;; double-float idiom): the template table has no Q-form stur, and a
-;;; bare 128-bit val matches nothing.
+;;; 32-byte miscobj.  The pad word 16-aligns realpart.  The payload is
+;;; ONE Q-form STUR.  The comment that used to stand here said the template
+;;; table has no Q-form stur and that a bare 128-bit val matches nothing.
+;;; That was true when it was written and is now stale: "Support :q sized
+;;; loads and stores" added the :q templates, and a bare
+;;; :complex-double-float operand resolves to the Q view through
+;;; vinsn-gpr-class->family+width.
+;;;
+;;; The composed form also declared an FPR scratch, which this vinsn
+;;; family must not do -- see the note on get-complex-double-float
+;;; below for why a vinsn-local FPR temp lands on the caller's other
+;;; live operand.
 (define-arm64-vinsn complex-double-float->heap (((dest :lisp))
                                                 ((val :complex-double-float))
-                                                ((header :u64)
-                                                 (dtemp :double-float)))
+                                                ((header :u64)))
   (mov header (:$ arm64::complex-double-float-header))
   (sub allocptr allocptr (:$ (- arm64::complex-double-float.size
                                 arm64::fulltag-misc)))
@@ -3946,9 +3938,7 @@
   (stur header (:@ allocptr (:$ arm64::misc-header-offset)))
   (mov dest allocptr)
   (bic allocptr allocptr (:$ arm64::fulltagmask))
-  (stur (:d val) (:@ dest (:$ arm64::complex-double-float.realpart)))
-  (dup dtemp (:d val 1))
-  (stur dtemp (:@ dest (:$ (+ arm64::complex-double-float.realpart 8)))))
+  (stur val (:@ dest (:$ arm64::complex-double-float.realpart))))
 
 ;;; ============ demand-scan CUT-8: the last vinsn ============
 ;;; trap-unless-single-float -- singles are IMMEDIATES in his scheme
@@ -4002,16 +3992,25 @@
   (uuo-error-cstack-overflow)
   :ok)
 
-;;; get-complex-double-float -- x8664's 128-bit load; his template
-;;; table has no Q-form load, so composed exactly like w3a's
-;;; misc-ref-c-complex-double-float: D-lane 0 (zeroing upper), imag
-;;; word into a D temp, INS to lane 1.  realpart = +4 (see w3a KEY).
+;;; get-complex-double-float -- a single 128-bit Q-form LDUR.  A bare
+;;; :complex-double-float operand is the Q view.  realpart = +4 from the
+;;; fulltag-misc pointer = base+16, naturally aligned.
+;;;
+;;; This vinsn MUST NOT declare an FPR temp.  with-fp-target and
+;;; available-fp-temp CHOOSE an FPR without reserving it, as the comment
+;;; above with-imm-target in compiler/backend.lisp says in as many words,
+;;; while a vinsn temp is allocated by select-fp-temp from
+;;; *available-backend-fp-temps* minus only that vinsn's own result and
+;;; args, in match-template-vregs.  So a scratch FPR here lands on the
+;;; caller's OTHER live complex-double-float operand: in
+;;; arm642-%complex-double-float+-2 the operands are r1 = target = v0 and
+;;; r2 = v1, the argument forms are unboxed b-first, and the second
+;;; unbox gets scratch = v1 -- whose D-form load also zeroes the upper
+;;; lane, so y became #C(<a.imagpart> 0d0) and
+;;; (+ #C(1d0 2d0) #C(3d0 4d0)) returned #C(3d0 2d0).
 (define-arm64-vinsn get-complex-double-float (((result :complex-double-float))
-                                              ((source :lisp))
-                                              ((dtemp :double-float)))
-  (ldur (:d result) (:@ source (:$ arm64::complex-double-float.realpart)))
-  (ldur dtemp (:@ source (:$ (+ arm64::complex-double-float.realpart 8))))
-  (ins (:d result 1) (:d dtemp 0)))
+                                              ((source :lisp)))
+  (ldur result (:@ source (:$ arm64::complex-double-float.realpart))))
 
 ;;; ============ demand-scan CUT-5 wave: 3 vinsns ============
 

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1888,6 +1888,9 @@
     (let* ((index-known-fixnum (acode-fixnum-form-p index))
            (unscaled-idx nil)
            (src nil))
+      (when index-known-fixnum
+        (unless (>= index-known-fixnum 0)
+          (setq index-known-fixnum nil)))
       (if (or safe (not index-known-fixnum))
         (multiple-value-setq (src unscaled-idx)
           (arm642-two-untargeted-reg-forms seg vector
@@ -2656,6 +2659,9 @@
            (constval (arm642-constant-value-ok-for-type-keyword type-keyword value))
            (needs-memoization (and is-node (arm642-acode-needs-memoization value)))
            (index-known-fixnum (acode-fixnum-form-p index)))
+      (when index-known-fixnum
+        (unless (>= index-known-fixnum 0)
+          (setq index-known-fixnum nil)))
       (let* ((src ($ arm64::arg_x))
              (unscaled-idx ($ arm64::arg_y))
              (result-reg ($ arm64::arg_z)))
@@ -2698,6 +2704,9 @@
            (constval (arm642-constant-value-ok-for-type-keyword type-keyword value))
            (needs-memoization (and is-node (arm642-acode-needs-memoization value)))
            (index-known-fixnum (acode-fixnum-form-p index)))
+      (when index-known-fixnum
+        (unless (>= index-known-fixnum 0)
+          (setq index-known-fixnum nil)))
       (let* ((src ($ arm64::arg_x))
              (unscaled-idx ($ arm64::arg_y))
              (result-reg ($ arm64::arg_z)))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -6712,23 +6712,61 @@
       (! test-fixnums crf x y)
       (! cbranch-false label crf arm64::cond-eq))))
 
+;;; The BOXED value of FORM when FORM is a fixnum literal that cmp or cmn can
+;;; take as an immediate, else NIL.
+;;;
+;;; Deliberately NOT arm642-constant-for-compare-p.  That
+;;; one also admits %unbound-marker and %slot-unbound-marker, which are not
+;;; numbers and must never reach a numeric comparison or its out-of-line
+;;; subprim call.
+;;;
+;;; The 4096 gate is the one arm642-constant-for-compare-p uses, and it is on
+;;; the BOXED value, so the window is |c| < 512 at fixnumshift 3.
+;;; compare-signed-s16const accepts the whole s16
+;;; range -- it has an :lsl 12 leg and movz/movn legs -- but those legs have
+;;; never run: that vinsn is emitted at exactly one site today, with the
+;;; constant 0.  Widening the gate is a separate change with its own control.
+(defun arm642-fixnum-constant-for-compare-p (form)
+  (let* ((val (acode-fixnum-form-p form)))
+    (when val
+      (let* ((boxed (ash val arm64::fixnumshift)))
+        (when (< (abs boxed) 4096)
+          boxed)))))
+
 (defun arm642-inline-numcmp (seg vreg xfer cc name form1 form2)
   (with-arm64-local-vinsn-macros (seg vreg xfer)
     (multiple-value-bind (cr-bit true-p) (acode-condition-to-arm64-cond-bit cc)
-      (let* ((otherform (and (eql cr-bit arm64::cond-eq)
-                             (if (eql (acode-fixnum-form-p form2) 0)
-                               form1
-                               (if (eql (acode-fixnum-form-p form1) 0)
-                                 form2)))))
+      ;; A fixnum literal on EITHER side becomes a cmp/cmn immediate, for every
+      ;; predicate.  Before this, the constant path took only (= x 0):
+      ;; cr-bit had to be cond-eq and the literal had to be exactly 0, so
+      ;; (< i 10) computed 10 into a register and tag-checked both operands.
+      (let* ((const2 (arm642-fixnum-constant-for-compare-p form2))
+             (const1 (unless const2 (arm642-fixnum-constant-for-compare-p form1)))
+             (constval (or const2 const1))
+             (otherform (if const2 form1 (if const1 form2)))
+             ;; Keep the non-constant operand in the register its ORIGINAL
+             ;; position implies.  Then the out-of-line subprim call gets its
+             ;; two arguments in the right order, with no register exchange in
+             ;; either direction.
+             (otherreg (if const2 arm64::arg_y arm64::arg_z))
+             (constreg (if const2 arm64::arg_z arm64::arg_y)))
+        ;; A constant on the LEFT means the compare emits (form2 <op> form1),
+        ;; which is CC with its operands reversed.  cr-bit here is only ever
+        ;; cond-eq, cond-gt or cond-lt, from condition-to-arm64-cond-bit, and
+        ;; true-p carries the negation -- which is exactly the encoding
+        ;; arm642-swap-compare-cond-bit was written for.  It had no caller
+        ;; until now.
+        (when const1
+          (setq cr-bit (arm642-swap-compare-cond-bit cr-bit)))
         (if otherform
-          (arm642-one-targeted-reg-form seg otherform ($ arm64::arg_z))
+          (arm642-one-targeted-reg-form seg otherform ($ otherreg))
           (arm642-two-targeted-reg-forms seg form1 ($ arm64::arg_y) form2 ($ arm64::arg_z)))
         (let* ((out-of-line (backend-get-next-label))
                (done (backend-get-next-label))
                (continue (backend-get-next-label)))
           (if otherform
             (unless (acode-fixnum-form-p otherform)
-              (arm642-branch-unless-arg-fixnum seg ($ arm64::arg_z) (aref *backend-labels* out-of-line)))
+              (arm642-branch-unless-arg-fixnum seg ($ otherreg) (aref *backend-labels* out-of-line)))
             (if (acode-fixnum-form-p form1)
               (arm642-branch-unless-arg-fixnum seg ($ arm64::arg_z) (aref *backend-labels* out-of-line))
               (if (acode-fixnum-form-p form2)
@@ -6736,7 +6774,7 @@
                 (arm642-branch-unless-both-args-fixnums seg ($ arm64::arg_y) ($ arm64::arg_z) (aref *backend-labels* out-of-line)))))
           (with-crf-target () crf
             (if otherform
-              (! compare-signed-s16const crf ($ arm64::arg_z) 0)
+              (! compare-signed-s16const crf ($ otherreg) constval)
               (! compare crf ($ arm64::arg_y) ($ arm64::arg_z)))
             (if (and vreg (eql (hard-regspec-class vreg) hard-reg-class-crf))
               (arm642-branch seg (arm642-cd-merge xfer continue) crf cr-bit true-p)
@@ -6744,8 +6782,12 @@
                 (! cond->boolean ($ arm64::arg_z) (if true-p cr-bit (logxor cr-bit 1)))
                 (-> done))))
           (@ out-of-line)
+          ;; The old code always wrote the constant to arg_y, which put the
+          ;; subprim's arguments in the WRONG ORDER whenever the 0 was form2.
+          ;; That was invisible because = is symmetric, and it is the reason
+          ;; the path could not be extended to < or >.
           (if otherform
-            (arm642-lri seg ($ arm64::arg_y) 0))
+            (arm642-lri seg ($ constreg) constval))
           (let* ((index (arch::builtin-function-name-offset name))
                  (idx-subprim (arm642-builtin-index-subprim index)))
             (! call-subprim-2 ($ arm64::arg_z) idx-subprim ($ arm64::arg_y) ($ arm64::arg_z)))

--- a/compiler/vreg.lisp
+++ b/compiler/vreg.lisp
@@ -151,6 +151,7 @@
     (:u64const . ,(specifier-type '(unsigned-byte 64)))
     (:s8const . ,(specifier-type '(signed-byte 8)))
     (:s16const . ,(specifier-type '(signed-byte 16)))
+    (:s24const . ,(specifier-type '(signed-byte 24)))
     (:s32const . ,(specifier-type '(signed-byte 32)))
     (:s64const . ,(specifier-type '(signed-byte 64)))
     (:stack-offset . ,(specifier-type '(signed-byte 32)))))


### PR DESCRIPTION
Four independent fixes in the arm64 backend, one file family, each separately
revertible. Split them if you prefer to review them apart.

**1. No FPR scratch in the complex-double-float 128-bit accessors.**
`(+ #C(1d0 2d0) #C(3d0 4d0))` returns `#C(3d0 2d0)`. The rule is
`result.realpart = a.realpart OP a.imagpart` and
`result.imagpart = a.imagpart`. The compiler never reads `b`. Subtraction has
the same shape. `*` is correct.

No other backend declares an FPR temp for this. x86-64 and x86-32 move the
whole 128 bits with one `movdqu`. ARM32 needs a scratch but takes a GPR, `lr`,
which it declares through `:sets-lr`. arm64 composes it from
two D-form `LDUR`s plus an `INS` through a `(dtemp :double-float)`, and that
scratch is not safe. `with-fp-target` and `available-fp-temp` only choose a
register. `compiler/backend.lisp:492`, above `with-imm-target`, which
`with-fp-target` copies: *"Choose an immediate register (for targeting), but
don't 'reserve' it."* Neither macro assigns `*available-backend-fp-temps*`, and
no FPR-targeting path in `arm642.lisp` calls `use-fp-reg`. So the scratch
avoids that vinsn's own operands and nothing else, in particular not the
caller's other live operand.

**2. A fixnum literal in a numeric comparison becomes a cmp-immediate.**
`arm642-inline-numcmp` takes its constant path only for `(= x 0)`. So
`(< i 10)` computes 10 into a register, tag-checks both operands, then does a
register-register compare. `x862-inline-numcmp` admits any constant that fits
its immediate, for every predicate, and reverses the condition when the
constant sits on the left.

This does the same, and both pieces already exist.
`compare-signed-s16const` encodes the whole signed range but has one caller
passing it 0. `arm642-swap-compare-cond-bit` sits at `arm642.lisp:9787` with no
caller anywhere in the tree, and it is the operand-order reversal this needs.
The patch gates the constant to `|boxed| < 4096`, so `|c| < 512` at fixnumshift
3, which covers a literal loop bound. A wider gate is a separate change.

**3. A negative constant array index must not stay `index-known-fixnum`.**
`acode-fixnum-form-p` returns the VALUE, so a negative literal makes the flag
non-nil and the compiler treats the index as a trusted displacement. At
`safety 0` both arms then go wrong at once. `unscaled-idx` stays `NIL`,
`check-misc-bound` never runs, and `vref1` gets the negative constant as its
displacement. The access lands at a fixed offset BEFORE the vector data. At
index -1 that is the uvector header.

With the guard deleted in a live image, read back through the resident
disassembler: the specialized element types raise a template constraint error,
and `(svref v -1)` silently emits `(ldur arg_z (:@ arg_z (:$ -12)))` and
returns the header as an object.

**4. `add-immediate` must declare the range its body can encode.**
It declares its constant operand `:s32const`, and `compiler/vreg.lisp` maps
that to `(signed-byte 32)`. The body reads two 12-bit fields, so it reaches 24
bits of magnitude and no more. At `2^24` both fields are zero and the body
emits `add dest,src,#0,lsl #12`, which adds ZERO. The class check is the only
instrument in that path, and the declaration tells it to stay silent.

The defect is LATENT, not live: all three emit sites gate the constant first,
at 12, 24 and 24 bits. The patch also touches one line of `compiler/vreg.lisp`,
the portable half of the same declaration.

---

**Verified at this base.** Built and run on linuxarm64 at `ec578745` with all
ten patches applied: ANSI 21679 tests, 0 failures. `tests/ccl.lsp` 243 tests, 0
failures. Image `281a49e5`, kernel `67bb66b4`.
