### PR TITLE
kernel: three C fixes

### DIFF
--- a/lisp-kernel/albt.c
+++ b/lisp-kernel/albt.c
@@ -70,6 +70,31 @@ print_lisp_frame(lisp_frame *frame)
    Say whatever can be said about foreign frames and lisp frames.
 */
 
+/* A stack word that is fixnum-tagged, and the target of a stack-alloc
+   marker, are both followed as POINTERS to the next frame.  Zero satisfies
+   `(header & fixnummask) == 0', so a zero word -- which stacks are full of
+   -- produced next == NULL.  The loop then called lisp_frame_p(NULL), so
+   the backtrace printer died inside the very crash it was reporting.  Any
+   small fixnum faults the same way, and a candidate below `start' either
+   walks backwards or spins forever.
+
+   A candidate is therefore accepted only when it makes forward progress and
+   stays inside the region being walked.  Anything else ends the walk with a
+   diagnostic: a truncated backtrace is useful, and a SIGSEGV in the
+   debugger destroys the only evidence the crash produced.
+*/
+static lisp_frame *
+advance_or_stop(lisp_frame *start, lisp_frame *end, lisp_frame *candidate,
+                char *what)
+{
+  if ((candidate > start) && (candidate <= end)) {
+    return candidate;
+  }
+  fprintf(dbgout, "Bad %s at %p: %p is not a forward address below %p\n",
+          what, start, candidate, end);
+  return end;
+}
+
 void
 walk_stack_frames(lisp_frame *start, lisp_frame *end) 
 {
@@ -92,11 +117,13 @@ walk_stack_frames(lisp_frame *start, lisp_frame *end)
         elements = (header_element_count(header)+2)&~1;
         next = (lisp_frame *)(current+elements);
       } else if ((header & fixnummask) == 0) {
-        next = (lisp_frame *)header;
+        next = advance_or_stop(start, end, (lisp_frame *)header,
+                               "frame link");
       } else if (header == stack_alloc_marker) {
-        next = (lisp_frame *)(current[1]);
+        next = advance_or_stop(start, end, (lisp_frame *)(current[1]),
+                               "stack-alloc marker");
       } else {
-        fprintf(dbgout, "Bad frame! (0x%x)\n", start);
+        fprintf(dbgout, "Bad frame! (%p)\n", start);
         next = end;
       }
     }

--- a/lisp-kernel/lisp.h
+++ b/lisp-kernel/lisp.h
@@ -26,6 +26,29 @@
 #endif
 #endif
 
+/* SUPPORT_PRAGMA_UNUSED guards the `#pragma unused(...)' annotations in
+   {arm,arm64,ppc}-exceptions.c, which record that a parameter forced on a
+   function by a handler-dispatch signature is deliberately not used.  Nothing
+   in the tree has ever defined it, so those annotations have never reached a
+   compiler.
+
+   #pragma unused is a Metrowerks/MPW-lineage extension: clang implements it,
+   gcc does not.  Measured on the real do_hard_stack_overflow shape, with
+   -Wall -Wextra, gcc 11.5.0 and clang 15.0.7:
+
+     clang   both `unused parameter' warnings gone; no diagnostic at all;
+             -Werror still exits 0.
+     gcc     `ignoring #pragma unused [-Wunknown-pragmas]' AND both `unused
+             parameter' warnings still present -- one diagnostic added, none
+             removed; -Werror goes from 2 errors to 3.
+
+   Hence clang only.  Everywhere else this changes nothing and the annotations
+   stay dormant; suppressing the warnings there is a build flag's job
+   (-Wno-unused-parameter).  */
+#if defined(__clang__)
+#define SUPPORT_PRAGMA_UNUSED 1
+#endif
+
 #ifndef LOWMEM_BIAS
 #define LOWMEM_BIAS (0)
 #endif

--- a/lisp-kernel/thread_manager.c
+++ b/lisp-kernel/thread_manager.c
@@ -403,9 +403,9 @@ recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
     m->count++;
     if (was_free) {
       *was_free = 0;
-      RELEASE_SPINLOCK(m->spinlock);
-      return 0;
     }
+    RELEASE_SPINLOCK(m->spinlock);
+    return 0;
   }
   if (store_conditional((natural*)&(m->avail), 0, 1) == 0) {
     m->owner = tcr;
@@ -430,8 +430,8 @@ recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
     m->count++;
     if (was_free) {
       *was_free = 0;
-      return 0;
     }
+    return 0;
   }
   if (store_conditional((natural*)&(m->avail), 0, 1) == 0) {
     m->owner = tcr;


### PR DESCRIPTION
**1. The kernel backtrace follows a zero stack word to NULL.**
`walk_stack_frames` advances through the control stack by interpreting a
non-frame word, and two of its arms follow that word as a pointer:

```c
} else if ((header & fixnummask) == 0) {
  next = (lisp_frame *)header;
} else if (header == stack_alloc_marker) {
  next = (lisp_frame *)(current[1]);
```

Zero satisfies `(header & fixnummask) == 0`, and a control stack holds many
zero words. `next` becomes NULL, the loop tail does `start = next`, the
`while (start < end)` test passes, and `lisp_frame_p(NULL)` dereferences
address 0. The kernel backtrace therefore faults while it prints the backtrace
for another fault, and the report that would identify the original defect is
lost. Any small fixnum reaches the same end at a different address, and a
candidate below `start` walks backwards or spins forever. The test needed is
not "does this word carry a fixnum tag" but "is this a forward address inside the
region under walk".

**2. `recursive_lock_trylock` leaks a recursive count on EBUSY.**
In both arms, futex and non-futex, when the calling thread already owns the
lock and `was_free` is NULL, the owner branch increments `m->count` and falls
into the `store_conditional` on `m->avail`. That store fails, because the
caller already holds the lock. The function then returns EBUSY with the count
already raised, and the caller never releases a lock it believes it never got.

The early return was conditional on `was_free` being non-NULL, when only the
`*was_free` store needed that condition. No caller exists in the tree today,
and the kernel-import tables export the function. This is the fix for issue
#597.

**3. `SUPPORT_PRAGMA_UNUSED` is tested in ten places and defined in none.**
The patch defines it for clang only.

```
$ git grep -c SUPPORT_PRAGMA_UNUSED -- 'lisp-kernel/*.c'
lisp-kernel/arm-exceptions.c:3
lisp-kernel/arm64-exceptions.c:3
lisp-kernel/ppc-exceptions.c:4
$ git grep -n 'define[[:space:]]*SUPPORT_PRAGMA_UNUSED'
(nothing)
```

Most sites mark a parameter that a handler-dispatch signature forces on the
function and the body does not use. The intent is written down, and only the
channel to the compiler is dead.

Measured on the `do_hard_stack_overflow` shape, with a positive control that
compiles the same source without the pragma and emits `unused parameter` as
required. clang 15.0.7 accepts the pragma and those warnings go to 0. gcc 11.5.0
does not recognize it, so the warnings survive and `-Wunknown-pragmas` adds one
diagnostic of its own. That is why the define is clang-only: unconditional, it
would suppress nothing on gcc and add a warning per site.

Two boundaries on that. I compiled the arm64 shape, not all ten sites. And one
site is not an unused parameter at all: `handle_uuo` in `ppc-exceptions.c`
declares `#pragma unused(where)`, then passes `where` to `handle_error` twice.
That pragma looks simply wrong, and this patch does not change it -- it only
gives the guard a definition on the compiler that implements it.

---

**Verified at this base.** Built and run on linuxarm64 at `ec578745` with all
ten patches applied: ANSI 21679 tests, 0 failures. `tests/ccl.lsp` 243 tests, 0
failures. Image `281a49e5`, kernel `67bb66b4`.
