### PR TITLE
portable: two fixes

### DIFF
--- a/lib/pathnames.lisp
+++ b/lib/pathnames.lisp
@@ -51,7 +51,7 @@
   (let ((newpath (back-translate-pathname-1 path hosts)))
     (cond ((equalp path newpath)
 	   ;; (fcomp-standard-source path)
-	   (namestring (pathname path)))
+	   (pathname path))
           (t newpath))))
 
 

--- a/library/core-files.lisp
+++ b/library/core-files.lisp
@@ -520,15 +520,19 @@
          (high4 (ash typecode (- target::ntagbits))))
     (declare (type (unsigned-byte 8) typecode)
              (type (unsigned-byte 4) low4 high4))
-    (cond ((eql low4 x8664::fulltag-immheader-0)
+    ;; The header-class fulltags differ per target (x8664 has
+    ;; fulltag-nodeheader-1 = 6, arm64 has fulltag-nodeheader-0 = 6), so
+    ;; these must be TARGET constants or every header class is filed in
+    ;; the wrong table on any non-x8664 target.
+    (cond ((eql low4 target::fulltag-immheader-0)
            (%svref *immheader-0-types* high4))
-          ((eql low4 x8664::fulltag-immheader-1)
+          ((eql low4 target::fulltag-immheader-1)
            (%svref *immheader-1-types* high4))
-          ((eql low4 x8664::fulltag-immheader-2)
+          ((eql low4 target::fulltag-immheader-2)
            (%svref *immheader-2-types* high4))
-          ((eql low4 x8664::fulltag-nodeheader-0)
+          ((eql low4 target::fulltag-nodeheader-0)
            (%svref *nodeheader-0-types* high4))
-          ((eql low4 x8664::fulltag-nodeheader-1)
+          ((eql low4 target::fulltag-nodeheader-1)
            (%svref *nodeheader-1-types* high4))
           (t 'bogus))))
 
@@ -705,12 +709,19 @@
                 (fixnump obj))
            ;; Assumes we're running on same architecture as core file.
            (type-of (%%raw-obj obj)))
+          ;; TAG-TRA exists only in the x8664 tag model; other targets keep
+          ;; return addresses untagged and have no clause here.
+          #+x8664-target
           ((eq (logand fulltag target::tagmask) target::tag-tra) 'tagged-return-address)
           ((eq fulltag target::fulltag-misc)
            ;; (core-uvtype obj)
            (handler-case (core-uvtype obj) (invalid-core-address () 'unmapped)))
           ((eq fulltag target::fulltag-symbol) 'symbol)
           ;; TODO: Could get hairier based on lfun-bits, but usually don't care.
+          ;; FULLTAG-FUNCTION is also x8664-only.  Where a function is an
+          ;; ordinary uvector (SUBTAG-FUNCTION) it already took the
+          ;; FULLTAG-MISC clause above.
+          #+x8664-target
           ((eq fulltag target::fulltag-function) 'function)
           (t (cerror "treat as ~*~s" "Invalid object tag at #x~x" obj 'bogus)
            'bogus))))


### PR DESCRIPTION
**1. `*compile-file-pathname*` must hold a pathname, not a namestring.**
CLHS gives it a value type of pathname or nil. CCL binds it to a STRING
whenever `physical-pathname-p` is true of the merged source, which needs a
directory component and is therefore the common case.

`back-translate-pathname` loses the type at `lib/pathnames.lisp:50-55`:

```lisp
(defun back-translate-pathname (path &optional hosts)
  (let ((newpath (back-translate-pathname-1 path hosts)))
    (cond ((equalp path newpath)
           (namestring (pathname path)))   ; a STRING
          (t newpath))))                   ; a PATHNAME
```

`back-translate-pathname-1` returns its argument unchanged when no logical-host
translation matches, so almost every caller gets the string branch.
`%compile-file` is the caller that stores the result where the standard
constrains it: `lib/nfcomp.lisp:204` gates on `physical-pathname-p`, `:205`
back-translates, and `:221` binds `*compile-file-pathname*` to the result.

Measured on x86-64 at 1.13 (`v1.13-309-g7cff8ca5`), varying only
`*default-pathname-defaults*`:

    DPD = #P""              -> #P"...-5.lsp"   PATHNAME             CF.16 passes
    DPD = #P"<dir>/"        -> "<dir>/...lsp"  SIMPLE-BASE-STRING   CF.16 fails

ansi-tests COMPILE-FILE.16 fails on stock x86-64 CCL at 1.12.2 and at 1.13,
21679 tests with that one failure. A red-then-green in one process, redefining
only this function, moves value 2 of the test from FAIL to PASS.
`*compile-file-truename*` is correct throughout and passes in both halves.

That gate is also where the failure hides: a suite driver that sets
`*default-pathname-defaults*` exposes the defect, and one that only chdirs does
not. Our own arm64 suite reports no failure for that second reason, so it is
not evidence either way.

The fix goes at the function, not at the binding. The three other callers in
the tree, at `lib/source-files.lisp:745`, `cocoa-ide/search-files.lisp:542` and
`cocoa-ide/search-files-pre-lion.lisp:188`, all wrap the result in `namestring`
already, so none of them can observe the change. The fix site is byte-identical
on `master` and `arm64`.

**2. Keep x8664-only tag constants out of the shared dispatch.**
`library/core-files.lisp` compiles only under `#+:linuxx8664-target` today, and
its central tag dispatch reads as if it were shared, because it uses `target::`
constants. Two of those exist only in the x8664 tag model: `TAG-TRA` and
`FULLTAG-FUNCTION`. On arm64 and ppc64 a function is an ordinary uvector
reached through the `FULLTAG-MISC` clause. Those two clauses get
`#+x8664-target`, the idiom `l1-clos-boot.lisp` already uses for the same
per-target dispatch.

`uvheader-type` in the same file hard-codes `x8664::` for the five
header-class fulltags, and those differ across targets. x8664 has
`fulltag-nodeheader-1 = 6` while arm64 has `fulltag-nodeheader-0 = 6`. On any
other target the code would look up every uvector header class in the wrong
table and report the wrong type in silence. An arm64 function header, subtag
`#x96` with low nibble 6, would land under `*nodeheader-1-types*`.

Both changes are no-ops on linuxx8664, where `TARGET` is the `X8664` package.
Neither one enables core-files anywhere new on its own.

---

**Verified at this base.** Built and run on linuxarm64 at `ec578745` with all
ten patches applied: ANSI 21679 tests, 0 failures. `tests/ccl.lsp` 243 tests, 0
failures. Image `281a49e5`, kernel `67bb66b4`.
