### PR TITLE
immediate: a float constant is identified by EQL, not ZEROP

### DIFF
--- a/compiler/ARM/arm2.lisp
+++ b/compiler/ARM/arm2.lisp
@@ -1452,7 +1452,7 @@
       (if (and (= (hard-regspec-class vreg) hard-reg-class-fpr)
                (or (and (typep form 'double-float) (= (get-regspec-mode vreg) hard-reg-class-fpr-mode-double))
                    (and (typep form 'short-float)(= (get-regspec-mode vreg) hard-reg-class-fpr-mode-single))))
-        (if (zerop form)
+        (if (or (eql form 0.0d0) (eql form 0.0s0))
           (if (eql form 0.0d0)
             (! zero-double-float-register vreg)
             (! zero-single-float-register vreg))

--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -1452,7 +1452,7 @@
                    (and (typep form 'short-float)
                         (= (get-regspec-mode vreg)
                            hard-reg-class-fpr-mode-single))))
-        (if (zerop form)
+        (if (or (eql form 0.0d0) (eql form 0.0s0))
           (if (eql form 0.0d0)
             (! zero-double-float-register vreg)
             (! zero-single-float-register vreg))

--- a/compiler/X86/x862.lisp
+++ b/compiler/X86/x862.lisp
@@ -1773,7 +1773,7 @@
         (if (and (= (hard-regspec-class vreg) hard-reg-class-fpr)
                  (or (and (typep form 'double-float) (= (get-regspec-mode vreg) hard-reg-class-fpr-mode-double))
                      (and (typep form 'short-float)(= (get-regspec-mode vreg) hard-reg-class-fpr-mode-single))))
-          (if (zerop form)
+          (if (or (eql form 0.0d0) (eql form 0.0s0))
             (if (eql form 0.0d0)
               (! zero-double-float-register vreg)
               (! zero-single-float-register vreg))


### PR DESCRIPTION
`<arch>2-immediate` asks an identity question with a numeric predicate. It must
know whether the constant IS `0.0d0` or `0.0s0`, so it can zero a register
instead of loading one. The line directly below already asks that with `EQL`.
`ZEROP` expands to `(= form 0)` against a fixnum, and two defects follow.

**A NaN constant aborts the compile** (#608). The compare reaches
`fixnum-dfloat-compare`, and the shipped FPU mode leaves invalid-operation
unmasked, so `COMPILE-FILE` dies at compile time. `1D+-0` reads back as a quiet
NaN, so no library is needed to hit this.

**A negative zero double loses its sign, silently.** `(zerop -0.0d0)` is T and
`(eql -0.0d0 0.0d0)` is NIL, so `-0.0d0` takes the zero branch and reaches
`zero-single-float-register` on a double-mode vreg. The constant is zeroed
either way — the double arm would emit `+0.0d0` just as the single arm does — so
the harm is that `-0.0d0` compiles to a zeroed register, and the wrong arm is
only how it gets there.

`EQL` answers both, and the inner `EQL` is unchanged. The construct is unchanged
since 2008 (`60c5e0d5`), and I reproduced it on stock 1.12.2 LinuxX8664, so it is
not specific to the reporter's 1.13/FreeBSD. `compiler/PPC/ppc2.lisp` holds the
same construct and is deliberately untouched: no PPC Lisp can be built or tested.

`(zerop 1d+-0)` at runtime is separate and is NOT fixed here. Please do not fix
it with a quiet compare alone. Float compares are read with UNSIGNED condition
codes, so `=` becomes `e`, `<` becomes `b` and `<=` becomes `be`, while `>` and
`>=` become `a` and `ae`. `COMISD` reports unordered as ZF=PF=CF=1 and PF is
never consulted, so with `:invalid` masked, `=`, `<` and `<=` all return T
against a NaN while `>` and `>=` return NIL. A PF-aware flag test is needed too.

`VERIFIED:` built and tested on linuxarm64. ANSI `:TOTAL 21679 :FAILED 0
:EXCLUDED NIL`, ccl.lsp `:TOTAL 243 :FAILED 0`. Three files, and `x862.lisp` is
the shared x86 backend serving both widths. Built on arm64 only — not on
x86-64, x86-32 or arm32.
