### PR TITLE
foreign-types: an over-aligned record member must keep its alignment

### DIFF
--- a/lib/foreign-types.lisp
+++ b/lib/foreign-types.lisp
@@ -1115,7 +1115,17 @@ Which one name refers to depends on foreign-type-spec in the obvious manner."
                                     (setq first-field-p nil)
                                     natural-alignment)
                                   (min 32 natural-alignment))
-                                (if use-natural-alignment
+                                ;; A member whose alignment exceeds one word
+                                ;; keeps it.  The bits-per-word cap states a
+                                ;; target's DEFAULT rule for a member and must
+                                ;; not override an alignment the type states
+                                ;; explicitly.  Records only: an array takes its
+                                ;; element's alignment, so admitting arrays would
+                                ;; wrongly widen an array of double on a 32-bit
+                                ;; target.
+                                (if (or use-natural-alignment
+                                        (and (typep field-type 'foreign-record-type)
+                                             (> natural-alignment bits-per-word)))
                                   natural-alignment
                                   (min bits-per-word natural-alignment)))))
                  (parsed-field


### PR DESCRIPTION
`parse-field-list` gives a member `(min bits-per-word natural-alignment)`, so on
a 64-bit target a record that requires 16-byte alignment, used as a MEMBER, is
placed as though it required only 8. The enclosing record gets the wrong member
offset, the wrong alignment and the wrong size, and `record-length`, `rlet` and
`make-record` all read that wrong size. This is #587 in its portable half.

Measured red then green in one process on stock 1.12.2 x86-64, redefining
`parse-field-list` and nothing else — it is byte-identical between 1.12.2 and the
tip, so the halves differ by exactly this patch. Every case runs in both halves.
gcc 11 agrees on x86_64 and aarch64. As `(bits align member-offset)`:

```
                 C            before          after
ovr          (128 128)    (128 128)      (128 128)     already right
outer    (256 128 128)  (192 64 64)  (256 128 128)     fixed
wrap         (128 128)    (128  64)      (128 128)     fixed
outer2   (256 128 128)  (192 64 64)  (256 128 128)     fixed
plain     (128 64 64)   (128 64 64)    (128 64 64)     unchanged
```

`wrap` is `struct wrap { struct ovr a; }` — over-aligned without carrying
`alt-align` itself, because `parse-field-list` returns that alignment as a value
and never sets the slot. That is why the test is on the member's alignment rather
than on the slot: a slot test fixes `outer` and leaves `outer2` broken, and it
would also read `alt-align` as a minimum when its own comment calls it a maximum.

Records only. An array takes its element's alignment, so admitting arrays would
give an array of `double` 8-byte alignment on a 32-bit target, which i386 SysV
does not. A record cannot reach the arm that way: on a 32-bit target a record's
alignment can only exceed 32 if something set `alt-align`.

No type reachable from a generated interface database is changed by the new arm.
`guess-alignment` caps at 64, the `.cdb` format holds a record's alignment in a
3-bit field counted in octets, and an array takes its element's. That is why the
control builds its records by hand.

Not fixed here: an array of an over-aligned record, measured and left wrong for
the reason above; a per-field `_Alignas`, which `foreign-record-field` cannot
express at all; reaching this from a generated interface database, which needs
the `.cdb` field to widen and is your call; and argument classification. On that
last point — the arm64 **call-out** path refuses an over-aligned composite
loudly, but the **callback** path has no alignment guard and advances its offset
loop by 8 with no even-slot rounding, so AAPCS64 C.8 is not honoured inbound.
x86-64 SysV MEMORY-class placement is a third case. This patch changes none of
them, and after it an over-aligned record grows to 16 bytes, so more arguments
reach those paths than before.

`VERIFIED:` built and tested on linuxarm64. ANSI `:TOTAL 21679 :FAILED 0
:EXCLUDED NIL`, ccl.lsp `:TOTAL 243 :FAILED 0`. `lib/foreign-types.lisp` is
portable and only arm64 was built; the control ran on stock x86-64.
