### PR TITLE
arm64: publish large NFP frames without a pair displacement

### DIFF
--- a/compiler/ARM64/arm64-vinsns.lisp
+++ b/compiler/ARM64/arm64-vinsns.lisp
@@ -49,17 +49,16 @@
 ;;; for unboxed temporaries, and link it onto tcr.nfp.  Layout (see
 ;;; ARM642-NFP-FRAME-SIZE): [header][saved tcr.nfp = element 0][data...].
 ;;;
-;;; The frame is constant-size (ARM642-MAX-NFP-DEPTH is known at
-;;; compile time), so the pre-indexed STP builds it atomically: a GC
-;;; at any instruction boundary sees either the old SP or a complete
-;;; self-describing ivector whose header covers the whole (unboxed)
-;;; frame, so skip_over_ivector skips it.
-;;;
-;;; The frame must fit the STP scaled-imm7 reach (<= 512 bytes).
+;;; The frame is constant-size (ARM642-MAX-NFP-DEPTH is known at compile
+;;; time).  A small frame can be published atomically with pre-indexed STP.
+;;; A large frame moves SP first so asynchronous signal delivery cannot use
+;;; the frame memory.  PC-LUSER-XP completes the immediately following pair
+;;; store if a suspension lands in the one-instruction initialization window.
 (define-arm64-vinsn save-nfp (()
                               ()
                               ((header :u64)
-                               (nfp :imm)))
+                               (nfp :imm)
+                               (size :u64)))
   ((:pred > (:apply arm642-max-nfp-depth) 0)
    (ldr nfp (:@ rcontext (:$ arm64::tcr.nfp)))    ;nfp = old tcr.nfp (the link)
    (movz header (:$ (:apply logand (:apply arm642-nfp-header) #xffff)))
@@ -67,8 +66,27 @@
                             (:apply ash (:apply arm642-nfp-header) -16)
                             #xffff)
                  :lsl 16))
-   ;; create u64-vector in one instruction
-   (stp header nfp (:@! sp (:$ (:apply - (:apply arm642-nfp-frame-size)))))
+   ((:pred <= (:apply arm642-nfp-frame-size) 512)
+    (stp header nfp (:@! sp (:$ (:apply - (:apply arm642-nfp-frame-size))))))
+   ((:pred > (:apply arm642-nfp-frame-size) 512)
+    (movz size (:$ (:apply logand (:apply arm642-nfp-frame-size) #xffff)))
+    ((:pred /= (:apply logand #xffff
+                       (:apply ash (:apply arm642-nfp-frame-size) -16)) 0)
+     (movk size (:$ (:apply logand #xffff
+                            (:apply ash (:apply arm642-nfp-frame-size) -16))
+                 :lsl 16)))
+    ((:pred /= (:apply logand #xffff
+                       (:apply ash (:apply arm642-nfp-frame-size) -32)) 0)
+     (movk size (:$ (:apply logand #xffff
+                            (:apply ash (:apply arm642-nfp-frame-size) -32))
+                 :lsl 32)))
+    ((:pred /= (:apply logand #xffff
+                       (:apply ash (:apply arm642-nfp-frame-size) -48)) 0)
+     (movk size (:$ (:apply logand #xffff
+                            (:apply ash (:apply arm642-nfp-frame-size) -48))
+                 :lsl 48)))
+    (sub sp sp size)
+    (stp header nfp (:@ sp (:$ 0))))
    (add nfp sp (:$ 0))                           ;nfp = new frame base
    (str nfp (:@ rcontext (:$ arm64::tcr.nfp))))) ;tcr.nfp = frame base
 
@@ -79,7 +97,26 @@
   ((:pred > (:apply arm642-max-nfp-depth) 0)
    (ldr nfp (:@ sp (:$ arm64::node-size)))        ;nfp = saved link (element 0)
    (str nfp (:@ rcontext (:$ arm64::tcr.nfp)))    ;restore tcr.nfp
-   (add sp sp (:$ (:apply arm642-nfp-frame-size)))))
+   ((:pred <= (:apply arm642-nfp-frame-size) 4095)
+    (add sp sp (:$ (:apply arm642-nfp-frame-size))))
+   ((:pred > (:apply arm642-nfp-frame-size) 4095)
+    (movz nfp (:$ (:apply logand (:apply arm642-nfp-frame-size) #xffff)))
+    ((:pred /= (:apply logand #xffff
+                       (:apply ash (:apply arm642-nfp-frame-size) -16)) 0)
+     (movk nfp (:$ (:apply logand #xffff
+                           (:apply ash (:apply arm642-nfp-frame-size) -16))
+                :lsl 16)))
+    ((:pred /= (:apply logand #xffff
+                       (:apply ash (:apply arm642-nfp-frame-size) -32)) 0)
+     (movk nfp (:$ (:apply logand #xffff
+                           (:apply ash (:apply arm642-nfp-frame-size) -32))
+                :lsl 32)))
+    ((:pred /= (:apply logand #xffff
+                       (:apply ash (:apply arm642-nfp-frame-size) -48)) 0)
+     (movk nfp (:$ (:apply logand #xffff
+                           (:apply ash (:apply arm642-nfp-frame-size) -48))
+                :lsl 48)))
+    (add sp sp nfp))))
 
 ;;; NFP single-float access.  The datum lives at frame-base + dnode-size +
 ;;; offset -- past the u64-vector header word and the saved-nfp link (element

--- a/lisp-kernel/arm64-exceptions.c
+++ b/lisp-kernel/arm64-exceptions.c
@@ -2487,6 +2487,27 @@ pc_luser_xp(ExceptionInformation *xp, TCR *tcr, signed_natural *alloc_disp)
   }
 
   /*
+   * Complete a pair store after a register-sized control-stack reservation.
+   * SP already protects the new memory from asynchronous signal delivery, but
+   * the pending STP must initialize it before GC can inspect the stack.  The
+   * store is idempotent: normal execution repeats it when the thread resumes.
+   * Register 31 in either source field denotes XZR.
+   */
+#define IS_STP_PAIR_TO_SP0(i) (((i) & 0xFFFF83E0) == 0xA90003E0)
+#define IS_SUB_SP_SP_REG(i)    (((i) & 0xFFE003FF) == 0xCB2003FF)
+
+  if (IS_STP_PAIR_TO_SP0(instr) &&
+      IS_SUB_SP_SP_REG(program_counter[-1])) {
+    unsigned rt = instr & 0x1f;
+    unsigned rt2 = (instr >> 10) & 0x1f;
+    LispObj *slots = (LispObj *)ptr_from_lispobj(xpSP(xp));
+
+    slots[0] = (rt == 31) ? 0 : xpGPR(xp, rt);
+    slots[1] = (rt2 == 31) ? 0 : xpGPR(xp, rt2);
+    return;
+  }
+
+  /*
    * Ensure GC safety when building lisp frames on the control stack
    *
    * The canonical way to build a lisp frame on the control stack is


### PR DESCRIPTION
A function with enough simultaneously live unboxed temporaries fails to
compile on arm64:

    > Error: Compiler bug or inconsistency:
    >        vinsn immediate -1136 (shift 0) out of range for operand
    >        class :POFF3

SAVE-NFP publishes the frame's self-describing u64-vector with one
pre-indexed STP. That displacement is a signed imm7 scaled by eight, so
it decrements SP by at most 512 bytes. The frame size is right; the
instruction cannot reach it. I hit this compiling CFFI, and a function
holding 140 live double-floats reproduces it: 140*8 + 16 = 1136 bytes,
the immediate above.

SAVE-NFP keeps the single-instruction path through 512 bytes. Beyond
that it materializes the size in a third temp, decrements SP with a
register SUB, and stores the header and prior NFP link at the new SP.

RESTORE-NFP had the sibling assumption, since one ADD immediate takes an
unsigned imm12 or an imm12 shifted by twelve. Its one-instruction path
stays through 4095 bytes, and larger sizes use the now-dead NFP temp.

Moving SP first keeps signal delivery from claiming the frame memory,
but leaves one boundary at which the frame is incomplete. PC-LUSER-XP
now normalizes it: when the current instruction is a pair store at SP+0
and the previous one is a SUB that decrements SP by a register, it copies
the two source registers from the saved context into the pending slots. The
store is idempotent, so execution simply repeats it on resume, and GC
always sees a complete frame.

ALLOC-VARIABLE-C-FRAME emits the same SUB-then-STP pair. Its size is
variable, so it cannot use the pre-indexed form, and the same
normalization appears to apply to it. I have not reproduced a failure
there, so I mention it only in case it is useful.

PPC64 does not meet this boundary because STDU carries a wider
displacement, and x86-64 selects a wider subtraction encoding. AArch64
has no register-offset STP pair form, so it needs the explicit fallback.

Built and tested on linuxarm64. The function above compiles cleanly with
the change and signals the COMPILER-BUG without it. The full ANSI suite
runs 21679 tests with 0 failures and tests/ccl.lsp runs 243 with 0.
Only arm64 files change.
