### PR TITLE
Fix and clarify the ADVISE documentation examples

### DIFF
--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -20,3 +20,12 @@ ccl.html: *.ccldoc style.css
 	 -e '(ccldoc:output-html *d* "ccl.html" :stylesheet "ccl:doc;manual;style.css")' \
 	 -e '(quit)'
 
+.PHONY: check
+check:
+	@corrected="$$(grep -F -c "(some #'(lambda (n) (not (numberp n))) (car arglist))" debugging.ccldoc)"; \
+	 buggy="$$(grep -F -c "(some #'(lambda (n) (not (numberp n))) arglist)" debugging.ccldoc)"; \
+	 test "$$corrected" -eq 2 && test "$$buggy" -eq 0 || { \
+	   printf '%s\n' 'Both ADVISE examples must inspect (car arglist), not arglist' >&2; \
+	   exit 1; \
+	 }
+

--- a/doc/manual/debugging.ccldoc
+++ b/doc/manual/debugging.ccldoc
@@ -334,8 +334,10 @@ error is signaled.")
 	")
 		"
 	The following code uses a
-	piece of advice to make foo return zero if any of its
-	arguments is not a number. Using :around advice, you can do
+	piece of advice to make foo return zero if any element of its
+	{code numlist} argument is not a number. The advice's {code arglist}
+	contains all arguments passed to {code foo}, so {code (car arglist)}
+	retrieves {code numlist}. Using :around advice, you can do
 	the following:
 	"
 	  (code-block "


### PR DESCRIPTION
## Summary
- clarify that ADVISE's `arglist` contains every argument passed to the advised function
- explain why `(car arglist)` retrieves `foo`'s `numlist` argument
- add a focused documentation regression check requiring both corrected examples

Closes #26.

## Validation
- `make -C doc/manual check && git diff --check`
- `docker run --rm -v /workspace/repository:/workspace -v /tmp/ccldoc:/ccldoc -w /workspace gcc@sha256:9ca91b05c7b07d2979f16413e8b2cd6ec8a7c80ffca4121ccab0aeba33f90460 make -C doc/manual CCL=/workspace/lx86cl64 CCLDOC_ROOT=/ccldoc ccl.html`

Validation observed for this change:
- `docker run --rm -v /workspace/repository:/workspace -v /tmp/ccldoc:/ccldoc -w /workspace gcc@sha256:9ca91b05c7b07d2979f16413e8b2cd6ec8a7c80ffca4121ccab0aeba33f90460 make -C doc/manual CCL=/workspace/lx86cl64 CCLDOC_ROOT=/ccldoc ccl.html`
- `make -C doc/manual check && git diff --check`

Fixes #26

<!-- repo-agent-case:1645ab0c-0e4e-434b-943a-96fe95557abd -->