### PR TITLE
Fix allocate_list not considering that GC may relocate initial-element on arm64 and ppc

### DIFF
--- a/lisp-kernel/arm64-exceptions.c
+++ b/lisp-kernel/arm64-exceptions.c
@@ -536,8 +536,7 @@ allocate_list(ExceptionInformation *xp, TCR *tcr)
     bytes_needed = (nconses << dnode_shift);
   LispObj
     prev = lisp_nil,
-    current,
-    initial = xpGPR(xp,arg_y);
+    current;
 
   if (nconses == 0) {
     /* Silly case */
@@ -556,7 +555,8 @@ allocate_list(ExceptionInformation *xp, TCR *tcr)
          nconses;
          prev = current, current+= dnode_size, nconses--) {
       deref(current,0) = prev;      /* cdr */
-      deref(current,1) = initial;   /* car */
+      /* GC may relocate the initial element while allocating the block. */
+      deref(current,1) = xpGPR(xp,arg_y); /* car */
     }
     xpGPR(xp,arg_z) = prev;
     xpGPR(xp,arg_y) = xpGPR(xp,allocptr);

--- a/lisp-kernel/ppc-exceptions.c
+++ b/lisp-kernel/ppc-exceptions.c
@@ -324,8 +324,7 @@ allocate_list(ExceptionInformation *xp, TCR *tcr)
     bytes_needed = (nconses << dnode_shift);
   LispObj
     prev = lisp_nil,
-    current,
-    initial = xpGPR(xp,arg_y);
+    current;
 
   if (nconses == 0) {
     /* Silly case */
@@ -339,7 +338,8 @@ allocate_list(ExceptionInformation *xp, TCR *tcr)
          nconses;
          prev = current, current+= dnode_size, nconses--) {
       deref(current,0) = prev;
-      deref(current,1) = initial;
+      /* GC may relocate the initial element while allocating the block. */
+      deref(current,1) = xpGPR(xp,arg_y);
     }
     xpGPR(xp,arg_z) = prev;
     xpGPR(xp,arg_y) = xpGPR(xp,allocptr);
@@ -2329,5 +2329,4 @@ exception_init()
 {
   install_pmcl_exception_handlers();
 }
-
 


### PR DESCRIPTION
`allocate_list` did not consider that if the GC runs during execution,
the initial-element may be moved. Since it held onto the pre-relocation
pointer, this could cause corruption. On qemu-system-aarch64 running
Debian Trixie, this can be triggered by the following program:

```common-lisp
  (defparameter *n* 110000)
  (defparameter *a* (list 1 2 3))
  (defparameter *b* (make-list *n* :initial-element *a*))
  (defparameter *c* (make-list *n* :initial-element *a*))
```

Executing:

```common-lisp
  (format t "Equal car? ~A~%" (equal (car *b*) (car *c*)))
```

Yields:

```
  Equal car? NIl
```

This appears to affect the ppc backend as well. The x86 backend appears
to have already made this correction. See the following in
x86-exceptions.c:

```c
  /*
  * Note that the GC may relocate the initial element stored in
  * arg_y, so it's not safe to save arg_y in a local variable.
  */
  deref(current, 1) = xpGPR(xp, Iarg_y);
```

I have tested the arm64 change and it fixes the above reproduction. I do not have a PPC machine to test the PPC change. I have separated the fixes into separate commits to be able to drop the PPC fix if requested.