### PR TITLE
arm64: a non-tail spread call must not tear down its caller's number frame

### DIFF
--- a/compiler/ARM64/arm642.lisp
+++ b/compiler/ARM64/arm642.lisp
@@ -2942,10 +2942,19 @@
           ;; arguments pushes value-stack words and moves vsp below
           ;; the save area, so the restore reads relative to the
           ;; PRE-spread snapshot in temp1, as PPC64 does.
+          ;; All three restores belong under the same tail-p guard.  Only
+          ;; the caller's own epilogue may tear down the number frame and the
+          ;; non-volatile registers; a spread call in an ordinary value
+          ;; position is running INSIDE the frame it would be releasing.
+          ;; Unguarded, (apply f x list) in a loop popped the enclosing
+          ;; function's number frame on every iteration, so a single-float
+          ;; local homed there was read back from a dead slot -- yielding a
+          ;; denormal, a raw pointer, or fname -- and the C stack was left
+          ;; unbalanced, faulting later somewhere unrelated.
           (when tail-p
-            (arm642-restore-nvrs seg nil arm64::temp1))
-          (arm642-restore-non-volatile-fprs seg)
-          (! restore-nfp))
+            (arm642-restore-nvrs seg nil arm64::temp1)
+            (arm642-restore-non-volatile-fprs seg)
+            (! restore-nfp)))
         (if nargs
           (unless known-fixed-nargs (arm642-set-nargs seg nargs))
           (! pop-argument-registers)))


### PR DESCRIPTION
Fixes #631.

In the spread branch of the arm64 call sequence, the NVR restore is guarded by
`tail-p`, but the non-volatile-FPR restore and the number-frame teardown that
follow it are not. Only a caller's own epilogue may release those. A spread call
in an ordinary value position is running *inside* the frame it would be
releasing, so `(apply f x list)` tore down the number frame of the function it
was executing in.

The frame is pushed once and popped three times — once per loop iteration at the
spread call, and again in the epilogue. By the time the epilogue reloads the
float local, its slot is dead, so the function returns a denormal and the C stack
is left unbalanced, which is what faults later.

### Two details that differ from the report

- **`n = 1` also reproduces.** One in-loop pop plus the epilogue pop is already a
  double pop.
- **The float value is wrong**, which the report does not mention because its
  test declares the variable `ignorable` and never reads it.

Two float locals are unaffected: that case never allocates a number frame at
all, which is part of why this looked intermittent.

### It is not Darwin-specific

The report shows the darwinarm64 fatal Mach exception, which is the same message
as #632 — and #632 *is* Darwin-specific. This one is not: on linuxarm64 the same
code gives a serious-condition handler firing with NIL, followed by a fault
during read.

### Testing

Both sides measured at the same upstream commit, with the patch as the only
difference:

- **without the patch** — the probe image takes SIGSEGV, exit 139.
- **with the patch** — `(float 2 1.0)` reads back as `2.0` and `(float 1 1.0)`
  as `1.0`; the form in the report returns normally. A variant with two float
  locals is unaffected either way, which matches the analysis.

Full suite with the patch applied: ANSI 21679 tests, 0 failures; the
CCL-specific `ccl.lsp` suite 243 tests, 0 failures.
