### PR TITLE
A thread suspended inside a lock guard deadlocks the thread that suspended it

### DIFF
--- a/level-0/l0-misc.lisp
+++ b/level-0/l0-misc.lisp
@@ -578,6 +578,33 @@
   (defun %release-spin-lock (p)
     (setf (%get-natural p 0) 0)))
 
+;;; Take the spin word at P with thread suspension deferred, so a
+;;; world-stop cannot park this thread while it holds the word: a
+;;; suspended holder never releases it, and a thread that then needs
+;;; the word spins forever.  An *INTERRUPT-LEVEL* of -2 defers
+;;; suspension, exactly as WITH-DEFERRED-GC does.  The deferral covers
+;;; only each batch of atomic attempts; failed batches deliver any
+;;; pending suspend and yield at the enclosing WITHOUT-INTERRUPTS
+;;; level, because YIELD dispatches and makes a foreign call.  Returns
+;;; with *INTERRUPT-LEVEL* -2 and the word held; the caller restores
+;;; the level immediately after releasing the word and then calls
+;;; %CHECK-DEFERRED-GC, before any wait, error, semaphore post or
+;;; nested lock operation.
+#-futex
+(defun %get-spin-lock-deferring-suspension (p)
+  (let* ((self (%current-tcr))
+         (n *spin-lock-tries*))
+    (declare (fixnum n))
+    (loop
+      (setq *interrupt-level* -2)
+      (dotimes (i n)
+        (when (eql 0 (%ptr-store-fixnum-conditional p 0 self))
+          (return-from %get-spin-lock-deferring-suspension t)))
+      (setq *interrupt-level* -1)
+      (%check-deferred-gc)
+      (%atomic-incf-node 1 '*spin-lock-timeouts* target::symbol.vcell)
+      (yield))))
+
 (eval-when (:compile-toplevel :execute)
   (declaim (inline note-lock-wait note-lock-held note-lock-released)))
 
@@ -604,15 +631,19 @@
          (when flag
            (setf (lock-acquisition.status flag) t))
          (return t))
-       (%get-spin-lock spin)
+       (%get-spin-lock-deferring-suspension spin)
        (when (eql 1 (incf (%get-natural ptr target::lockptr.avail)))
          (setf (%get-ptr ptr target::lockptr.owner) p
                (%get-natural ptr target::lockptr.count) 1)
          (%release-spin-lock spin)
+         (setq *interrupt-level* -1)
+         (%check-deferred-gc)
          (if flag
            (setf (lock-acquisition.status flag) t))
          (return t))
-       (%release-spin-lock spin))
+       (%release-spin-lock spin)
+       (setq *interrupt-level* -1)
+       (%check-deferred-gc))
       (%process-wait-on-semaphore-ptr signal 1 0 (recursive-lock-whostate lock)))))
 
 #+futex
@@ -718,12 +749,14 @@
               t)
              (t
               (let* ((win nil))
-                (%get-spin-lock spin)
+                (%get-spin-lock-deferring-suspension spin)
                 (when (setq win (eql 1 (incf (%get-natural ptr target::lockptr.avail))))
                   (setf (%get-ptr ptr target::lockptr.owner) p
                         (%get-natural ptr target::lockptr.count) 1)
                   (if flag (setf (lock-acquisition.status flag) t)))
                 (%release-spin-lock spin)
+                (setq *interrupt-level* -1)
+                (%check-deferred-gc)
                 win)))))))
 
 
@@ -762,7 +795,7 @@
     (without-interrupts
      (when (eql 0 (decf (the fixnum
                           (%get-natural ptr target::lockptr.count))))
-       (%get-spin-lock spin)
+       (%get-spin-lock-deferring-suspension spin)
        (setf (%get-ptr ptr target::lockptr.owner) (%null-ptr))
        (let* ((pending (+ (the fixnum
                             (1- (the fixnum (%get-fixnum ptr target::lockptr.avail))))
@@ -771,6 +804,8 @@
          (setf (%get-natural ptr target::lockptr.avail) 0
                (%get-natural ptr target::lockptr.waiting) 0)
          (%release-spin-lock spin)
+         (setq *interrupt-level* -1)
+         (%check-deferred-gc)
          (dotimes (i pending)
            (%signal-semaphore-ptr signal)))))
     nil))
@@ -878,11 +913,13 @@
            (tcr (%current-tcr)))
       (declare (fixnum tcr))
       (without-interrupts
-       (%get-spin-lock ptr)               ;(%get-spin-lock (%inc-ptr ptr target::rwlock.spin))
+       (%get-spin-lock-deferring-suspension ptr)
        (if (eq (%get-object ptr target::rwlock.writer) tcr)
          (progn
            (incf (%get-signed-natural ptr target::rwlock.state))
            (%release-spin-lock ptr)
+           (setq *interrupt-level* -1)
+           (%check-deferred-gc)
            (if flag
              (setf (lock-acquisition.status flag) t))
            t)
@@ -891,15 +928,19 @@
                ;; That wasn't so bad, was it ?  We have the spinlock now.
                (setf (%get-signed-natural ptr target::rwlock.state) 1)
                (%release-spin-lock ptr)
+               (setq *interrupt-level* -1)
+               (%check-deferred-gc)
                (%set-object ptr target::rwlock.writer tcr)
                (if flag
                  (setf (lock-acquisition.status flag) t))
                t)
            (incf (%get-natural ptr target::rwlock.blocked-writers))
            (%release-spin-lock ptr)
+           (setq *interrupt-level* -1)
+           (%check-deferred-gc)
            (let* ((*interrupt-level* level))
                   (%process-wait-on-semaphore-ptr write-signal 1 0 (rwlock-write-whostate lock)))
-           (%get-spin-lock ptr)))))))
+           (%get-spin-lock-deferring-suspension ptr)))))))
 #+futex
 (defun %write-lock-rwlock-ptr (ptr lock &optional flag)
   (with-macptrs ((write-signal (%INC-ptr ptr target::rwlock.writer-signal)) )
@@ -952,10 +993,12 @@
            (tcr (%current-tcr)))
       (declare (fixnum tcr))
       (without-interrupts
-       (%get-spin-lock ptr)             ;(%get-spin-lock (%inc-ptr ptr target::rwlock.spin))
+       (%get-spin-lock-deferring-suspension ptr)
        (if (eq (%get-object ptr target::rwlock.writer) tcr)
          (progn
            (%release-spin-lock ptr)
+           (setq *interrupt-level* -1)
+           (%check-deferred-gc)
            (error 'deadlock :lock lock))
          (do* ((state
                 (%get-signed-natural ptr target::rwlock.state)
@@ -965,15 +1008,19 @@
                (setf (%get-signed-natural ptr target::rwlock.state)
                      (the fixnum (1- state)))
                (%release-spin-lock ptr)
+               (setq *interrupt-level* -1)
+               (%check-deferred-gc)
                (if flag
                  (setf (lock-acquisition.status flag) t))
                t)
            (declare (fixnum state))
            (incf (%get-natural ptr target::rwlock.blocked-readers))
            (%release-spin-lock ptr)
+           (setq *interrupt-level* -1)
+           (%check-deferred-gc)
            (let* ((*interrupt-level* level))
              (%process-wait-on-semaphore-ptr read-signal 1 0 (rwlock-read-whostate lock)))
-           (%get-spin-lock ptr)))))))
+           (%get-spin-lock-deferring-suspension ptr)))))))
 
 #+futex
 (defun %read-lock-rwlock-ptr (ptr lock &optional flag) 
@@ -1023,19 +1070,26 @@
   (with-macptrs ((reader-signal (%get-ptr ptr target::rwlock.reader-signal))
                  (writer-signal (%get-ptr ptr target::rwlock.writer-signal)))
     (without-interrupts
-     (%get-spin-lock ptr)
+     (%get-spin-lock-deferring-suspension ptr)
      (let* ((state (%get-signed-natural ptr target::rwlock.state))
             (tcr (%current-tcr)))
        (declare (fixnum state tcr))
        (cond ((> state 0)
               (unless (eql tcr (%get-object ptr target::rwlock.writer))
                 (%release-spin-lock ptr)
+                (setq *interrupt-level* -1)
+                (%check-deferred-gc)
                 (error 'not-lock-owner :lock lock))
               (decf state))
              ((< state 0) (incf state))
              (t (%release-spin-lock ptr)
+                (setq *interrupt-level* -1)
+                (%check-deferred-gc)
                 (error 'not-locked :lock lock)))
        (setf (%get-signed-natural ptr target::rwlock.state) state)
+       (let* ((nwriters 0)
+              (nreaders 0))
+         (declare (fixnum nwriters nreaders))
        (when (zerop state)
          ;; We want any thread waiting for a lock semaphore to
          ;; be able to wait interruptibly.  When a thread waits,
@@ -1058,19 +1112,27 @@
          ;; are cleared here (they can't be changed from another thread
          ;; until this thread releases the spinlock.)
          (setf (%get-signed-natural ptr target::rwlock.writer) 0)
-         (let* ((nwriters (%get-natural ptr target::rwlock.blocked-writers))
-                (nreaders (%get-natural ptr target::rwlock.blocked-readers)))
-           (declare (fixnum nreaders nwriters))
-           (when (> nwriters 0)
-             (setf (%get-natural ptr target::rwlock.blocked-writers) 0)
-             (dotimes (i nwriters)
-               (%signal-semaphore-ptr writer-signal)))
-           (when (> nreaders 0)
-             (setf (%get-natural ptr target::rwlock.blocked-readers) 0)
-             (dotimes (i nreaders)
-               (%signal-semaphore-ptr reader-signal)))))
+         (setq nwriters (%get-natural ptr target::rwlock.blocked-writers)
+               nreaders (%get-natural ptr target::rwlock.blocked-readers))
+         (when (> nwriters 0)
+           (setf (%get-natural ptr target::rwlock.blocked-writers) 0))
+         (when (> nreaders 0)
+           (setf (%get-natural ptr target::rwlock.blocked-readers) 0)))
+       ;; The semaphore posts move after the spin-word release and the
+       ;; level restore: they make foreign calls, and the word must not
+       ;; stay held across them.  The blocked counts were captured and
+       ;; cleared while the word was held, so the posts cannot be lost;
+       ;; posting more often than necessary is the documented intent.
        (%release-spin-lock ptr)
-       t))))
+       (setq *interrupt-level* -1)
+       (%check-deferred-gc)
+       (when (> nwriters 0)
+         (dotimes (i nwriters)
+           (%signal-semaphore-ptr writer-signal)))
+       (when (> nreaders 0)
+         (dotimes (i nreaders)
+           (%signal-semaphore-ptr reader-signal)))
+       t)))))
 
 #+futex
 (defun %unlock-rwlock-ptr (ptr lock)
@@ -1131,7 +1193,7 @@
        #+futex
        (%lock-futex ptr level lock nil)
        #-futex
-       (%get-spin-lock ptr)
+       (%get-spin-lock-deferring-suspension ptr)
        (let* ((state (%get-signed-natural ptr target::rwlock.state)))
          (declare (fixnum state))
          (cond ((> state 0)
@@ -1139,11 +1201,22 @@
                   #+futex
                   (%unlock-futex ptr)
                   #-futex
+                  (progn
+                    (%release-spin-lock ptr)
+                    (setq *interrupt-level* -1)
+                    (%check-deferred-gc))
+                  (error :not-lock-owner :lock lock))
+                #-futex
+                (progn
                   (%release-spin-lock ptr)
-                  (error :not-lock-owner :lock lock)))
+                  (setq *interrupt-level* -1)
+                  (%check-deferred-gc)))
                ((= state 0)
                 #+futex (%unlock-futex ptr)
-                #-futex (%release-spin-lock ptr)
+                #-futex (progn
+                          (%release-spin-lock ptr)
+                          (setq *interrupt-level* -1)
+                          (%check-deferred-gc))
                 (error :not-locked :lock lock))
                (t
                 (if (= state -1)
@@ -1153,7 +1226,10 @@
                     #+futex
                     (%unlock-futex ptr)
                     #-futex
-                    (%release-spin-lock ptr)
+                    (progn
+                      (%release-spin-lock ptr)
+                      (setq *interrupt-level* -1)
+                      (%check-deferred-gc))
                     (if flag
                       (setf (lock-acquisition.status flag) t))
                     t)
@@ -1161,7 +1237,10 @@
                     #+futex
                     (%unlock-futex ptr)
                     #-futex
-                    (%release-spin-lock ptr)
+                    (progn
+                      (%release-spin-lock ptr)
+                      (setq *interrupt-level* -1)
+                      (%check-deferred-gc))
                     (%unlock-rwlock-ptr ptr lock)
                     (let* ((*interrupt-level* level))
                       (%write-lock-rwlock-ptr ptr lock flag)))))))))))

--- a/lisp-kernel/arm64-spentry.s
+++ b/lisp-kernel/arm64-spentry.s
@@ -3408,40 +3408,37 @@ endsp bind_interrupt_level
 /* ported from ppc-spentry.s:7018-7047 (PPC64 branch) */
 /* Unbind *INTERRUPT-LEVEL*; check for pending interrupt if transitioning negative->non-negative */
 spentry unbind_interrupt_level
-        /* ppc:7019-7047.  Unbind *INTERRUPT-LEVEL*; poll for a pending interrupt
-           if the level goes from negative to non-negative.  nargs is often live,
-           so save/restore it around any poll. */
-        ldr imm0, [rcontext, #tcr.flags]                    /* ppc:7019 */
-        ldr imm2, [rcontext, #tcr.tlb_pointer]              /* ppc:7020 */
-        tst imm0, #(1<<TCR_FLAG_BIT_PENDING_SUSPEND)        /* ppc:7021 andi. cr0 */
-        ldr imm1, [rcontext, #tcr.db_link]                  /* ppc:7022 */
-        ldr temp1, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7023 old level */
-        b.ne 3f                         /* ppc:7024 bne -> missed-suspend path */
-1:      /* ppc:7025 (PPC label 0).  temp1=old level, imm1=binding, imm2=tlb_ptr. */
-        mov temp0, temp1                /* preserve old level for the cr1 test  */
-        ldr temp1, [imm1, #binding.val] /* ppc:7026 restored (new) level         */
-        ldr imm1, [imm1, #binding.link] /* ppc:7027 new db_link                  */
-        str temp1, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]   /* ppc:7029 */
-        str imm1, [rcontext, #tcr.db_link]                  /* ppc:7030 */
-        cmp temp0, #0                   /* ppc:7025 cmpri(cr1,old,0), adjacent    */
-        b.ge 2f                         /* ppc:7031 bgelr cr1: old>=0 -> return   */
-        cmp temp1, #0                   /* ppc:7028 cmpri(cr0,new,0), adjacent    */
-        b.lt 2f                         /* ppc:7032 bltlr cr0: new<0 -> return     */
-        mov imm2, nargs                 /* ppc:7033 save nargs across the poll     */
-        check_pending_interrupt         /* ppc:7034 check_pending_interrupt(cr1)   */
-        mov nargs, imm2                 /* ppc:7035 restore nargs                  */
-2:      ret                             /* ppc:7036 blr                            */
-3:      /* ppc:7037 (PPC label 5).  Missed a suspend; force suspend now if we are
-           restoring interrupt level to -1 or greater. */
-        cmp temp1, #(-2<<fixnumshift)   /* ppc:7039 cmpri(old,-2<<fixnumshift)     */
-        b.ne 1b                         /* ppc:7040 bne 0b                          */
-        ldr imm0, [imm1, #binding.val]  /* ppc:7041 restored value                 */
-        cmp imm0, temp1                 /* ppc:7042 cmpr(restored,old)              */
-        b.eq 1b                         /* ppc:7043 beq 0b                          */
-        mov imm0, #(1<<fixnumshift)     /* ppc:7044 li imm0,1<<fixnumshift          */
-        str imm0, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]    /* ppc:7045 */
-        uuo_suspend_now                 /* ppc:7046 (his misc 4) */
-        b 1b                            /* ppc:7047 b 0b                            */
+        /* Unbind *INTERRUPT-LEVEL*.  Restore the outer binding BEFORE
+           polling for a suspend request that arrived while the old level
+           deferred suspension: a poll that runs first can read the flags,
+           then lose a request that lands before the level is restored,
+           and the thread that requested the suspension waits forever.
+           Deliver a pending suspend only when the restored level no
+           longer defers suspension; when it still does, the enclosing
+           deferral delivers it.  Poll for a pending interrupt when the
+           level goes from negative to non-negative.  nargs is often
+           live, so save/restore it around that poll. */
+        ldr imm2, [rcontext, #tcr.tlb_pointer]
+        ldr imm1, [rcontext, #tcr.db_link]
+        ldr temp0, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]   /* old level */
+        ldr temp1, [imm1, #binding.val]                     /* new level */
+        ldr imm1, [imm1, #binding.link]
+        str temp1, [imm2, #INTERRUPT_LEVEL_BINDING_INDEX]   /* restore first */
+        str imm1, [rcontext, #tcr.db_link]
+        cmp temp1, #(-2<<fixnumshift)
+        b.le 1f                         /* restored level still defers */
+        ldr imm0, [rcontext, #tcr.flags]                    /* poll after restore */
+        tst imm0, #(1<<TCR_FLAG_BIT_PENDING_SUSPEND)
+        b.eq 1f
+        uuo_suspend_now
+1:      cmp temp0, #0
+        b.ge 2f                         /* old >= 0: no interrupt poll */
+        cmp temp1, #0
+        b.lt 2f                         /* new < 0: no interrupt poll */
+        mov imm2, nargs                 /* save nargs across the poll */
+        check_pending_interrupt
+        mov nargs, imm2                 /* restore nargs */
+2:      ret
 endsp unbind_interrupt_level
 
 /*

--- a/lisp-kernel/thread_manager.c
+++ b/lisp-kernel/thread_manager.c
@@ -403,9 +403,9 @@ recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
     m->count++;
     if (was_free) {
       *was_free = 0;
-      RELEASE_SPINLOCK(m->spinlock);
-      return 0;
     }
+    RELEASE_SPINLOCK(m->spinlock);
+    return 0;
   }
   if (store_conditional((natural*)&(m->avail), 0, 1) == 0) {
     m->owner = tcr;
@@ -430,8 +430,8 @@ recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
     m->count++;
     if (was_free) {
       *was_free = 0;
-      return 0;
     }
+    return 0;
   }
   if (store_conditional((natural*)&(m->avail), 0, 1) == 0) {
     m->owner = tcr;

--- a/lisp-kernel/thread_manager.c
+++ b/lisp-kernel/thread_manager.c
@@ -248,12 +248,58 @@ get_spin_lock(signed_natural *p, TCR *tcr)
 #endif
   }
 }
+
+/*
+  A thread must not stop for a suspend request while it holds one of
+  the spin locks that guard lock structures: the thread that requested
+  the suspension may need the same spin lock in order to make progress,
+  and a suspended holder never releases it.  Raise the deferral that
+  WITH-DEFERRED-GC uses (at an interrupt-level of -2 or below,
+  suspend_resume_handler records a pending suspend and returns instead
+  of stopping the thread), then deliver any suspend request that
+  arrived in the meantime once the spin lock has been released.
+  The level is restored before the pending-suspend check, so a suspend
+  that lands between the two acts on the restored level; the re-raise
+  is skipped when the restored level still defers suspension, and the
+  enclosing deferral delivers the suspend when it exits.
+*/
+static signed_natural
+defer_thread_suspension(TCR *tcr)
+{
+  signed_natural old_level = 0;
+
+  /* A TCR without thread-local bindings (mid-creation, or an early
+     bootstrap thread) has no interrupt level to defer and cannot be
+     the target of a suspend request yet. */
+  if (tcr && tcr->tlb_pointer) {
+    old_level = TCR_INTERRUPT_LEVEL(tcr);
+    TCR_INTERRUPT_LEVEL(tcr) = -(2 << fixnumshift);
+  }
+  return old_level;
+}
+
+static void
+allow_thread_suspension(TCR *tcr, signed_natural old_level)
+{
+  if (tcr && tcr->tlb_pointer) {
+    TCR_INTERRUPT_LEVEL(tcr) = old_level;
+    if ((old_level > -(2 << fixnumshift)) &&
+        (tcr->flags & (1<<TCR_FLAG_BIT_PENDING_SUSPEND))) {
+      CLR_TCR_FLAG(tcr, TCR_FLAG_BIT_PENDING_SUSPEND);
+#ifndef WINDOWS
+      pthread_kill(pthread_self(), thread_suspend_signal);
+#endif
+    }
+  }
+}
+
 #endif
 
 #ifndef USE_FUTEX
 int
 lock_recursive_lock(RECURSIVE_LOCK m, TCR *tcr)
 {
+  signed_natural old_level;
 
   if (tcr == NULL) {
     tcr = get_tcr(true);
@@ -263,15 +309,18 @@ lock_recursive_lock(RECURSIVE_LOCK m, TCR *tcr)
     return 0;
   }
   while (1) {
+    old_level = defer_thread_suspension(tcr);
     LOCK_SPINLOCK(m->spinlock,tcr);
     ++m->avail;
     if (m->avail == 1) {
       m->owner = tcr;
       m->count = 1;
       RELEASE_SPINLOCK(m->spinlock);
+      allow_thread_suspension(tcr, old_level);
       break;
     }
     RELEASE_SPINLOCK(m->spinlock);
+    allow_thread_suspension(tcr, old_level);
     SEM_WAIT_FOREVER(m->signal);
   }
   return 0;
@@ -328,6 +377,7 @@ int
 unlock_recursive_lock(RECURSIVE_LOCK m, TCR *tcr)
 {
   int ret = EPERM, pending;
+  signed_natural old_level;
 
   if (tcr == NULL) {
     tcr = get_tcr(true);
@@ -336,6 +386,7 @@ unlock_recursive_lock(RECURSIVE_LOCK m, TCR *tcr)
   if (m->owner == tcr) {
     --m->count;
     if (m->count == 0) {
+      old_level = defer_thread_suspension(tcr);
       LOCK_SPINLOCK(m->spinlock,tcr);
       m->owner = NULL;
       pending = m->avail-1 + m->waiting;     /* Don't count us */
@@ -347,6 +398,7 @@ unlock_recursive_lock(RECURSIVE_LOCK m, TCR *tcr)
         m->waiting = 0;
       }
       RELEASE_SPINLOCK(m->spinlock);
+      allow_thread_suspension(tcr, old_level);
       if (pending >= 0) {
 	SEM_RAISE(m->signal);
       }
@@ -397,7 +449,9 @@ int
 recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
 {
   TCR *owner = m->owner;
+  signed_natural old_level;
 
+  old_level = defer_thread_suspension(tcr);
   LOCK_SPINLOCK(m->spinlock,tcr);
   if (owner == tcr) {
     m->count++;
@@ -405,6 +459,7 @@ recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
       *was_free = 0;
     }
     RELEASE_SPINLOCK(m->spinlock);
+    allow_thread_suspension(tcr, old_level);
     return 0;
   }
   if (store_conditional((natural*)&(m->avail), 0, 1) == 0) {
@@ -414,10 +469,12 @@ recursive_lock_trylock(RECURSIVE_LOCK m, TCR *tcr, int *was_free)
       *was_free = 1;
     }
     RELEASE_SPINLOCK(m->spinlock);
+    allow_thread_suspension(tcr, old_level);
     return 0;
   }
 
   RELEASE_SPINLOCK(m->spinlock);
+  allow_thread_suspension(tcr, old_level);
   return EBUSY;
 }
 #else
@@ -2481,18 +2538,23 @@ int
 rwlock_rlock(rwlock *rw, TCR *tcr, struct timespec *waitfor)
 {
   int err = 0;
-  
+  signed_natural old_level;
+
+  old_level = defer_thread_suspension(tcr);
   LOCK_SPINLOCK(rw->spin, tcr);
 
   if (rw->writer == tcr) {
     RELEASE_SPINLOCK(rw->spin);
+    allow_thread_suspension(tcr, old_level);
     return EDEADLK;
   }
 
   while (rw->blocked_writers || (rw->state > 0)) {
     rw->blocked_readers++;
     RELEASE_SPINLOCK(rw->spin);
+    allow_thread_suspension(tcr, old_level);
     err = semaphore_maybe_timedwait(rw->reader_signal,waitfor);
+    old_level = defer_thread_suspension(tcr);
     LOCK_SPINLOCK(rw->spin,tcr);
     rw->blocked_readers--;
     if (err == EINTR) {
@@ -2500,11 +2562,13 @@ rwlock_rlock(rwlock *rw, TCR *tcr, struct timespec *waitfor)
     }
     if (err) {
       RELEASE_SPINLOCK(rw->spin);
+      allow_thread_suspension(tcr, old_level);
       return err;
     }
   }
   rw->state--;
   RELEASE_SPINLOCK(rw->spin);
+  allow_thread_suspension(tcr, old_level);
   return err;
 }
 #else
@@ -2552,18 +2616,23 @@ int
 rwlock_wlock(rwlock *rw, TCR *tcr, struct timespec *waitfor)
 {
   int err = 0;
+  signed_natural old_level;
 
+  old_level = defer_thread_suspension(tcr);
   LOCK_SPINLOCK(rw->spin,tcr);
   if (rw->writer == tcr) {
     rw->state++;
     RELEASE_SPINLOCK(rw->spin);
+    allow_thread_suspension(tcr, old_level);
     return 0;
   }
 
   while (rw->state != 0) {
     rw->blocked_writers++;
     RELEASE_SPINLOCK(rw->spin);
+    allow_thread_suspension(tcr, old_level);
     err = semaphore_maybe_timedwait(rw->writer_signal, waitfor);
+    old_level = defer_thread_suspension(tcr);
     LOCK_SPINLOCK(rw->spin,tcr);
     rw->blocked_writers--;
     if (err == EINTR) {
@@ -2571,12 +2640,14 @@ rwlock_wlock(rwlock *rw, TCR *tcr, struct timespec *waitfor)
     }
     if (err) {
       RELEASE_SPINLOCK(rw->spin);
+      allow_thread_suspension(tcr, old_level);
       return err;
     }
   }
   rw->state = 1;
   rw->writer = tcr;
   RELEASE_SPINLOCK(rw->spin);
+  allow_thread_suspension(tcr, old_level);
   return err;
 }
 
@@ -2617,7 +2688,9 @@ int
 rwlock_try_wlock(rwlock *rw, TCR *tcr)
 {
   int ret = EBUSY;
+  signed_natural old_level;
 
+  old_level = defer_thread_suspension(tcr);
   LOCK_SPINLOCK(rw->spin,tcr);
   if (rw->writer == tcr) {
     rw->state++;
@@ -2630,6 +2703,7 @@ rwlock_try_wlock(rwlock *rw, TCR *tcr)
     }
   }
   RELEASE_SPINLOCK(rw->spin);
+  allow_thread_suspension(tcr, old_level);
   return ret;
 }
 #else
@@ -2659,13 +2733,16 @@ int
 rwlock_try_rlock(rwlock *rw, TCR *tcr)
 {
   int ret = EBUSY;
+  signed_natural old_level;
 
+  old_level = defer_thread_suspension(tcr);
   LOCK_SPINLOCK(rw->spin,tcr);
   if (rw->state <= 0) {
     --rw->state;
     ret = 0;
   }
   RELEASE_SPINLOCK(rw->spin);
+  allow_thread_suspension(tcr, old_level);
   return ret;
 }
 #else
@@ -2693,7 +2770,9 @@ rwlock_unlock(rwlock *rw, TCR *tcr)
 
   int err = 0;
   natural blocked_readers = 0;
+  signed_natural old_level;
 
+  old_level = defer_thread_suspension(tcr);
   LOCK_SPINLOCK(rw->spin,tcr);
   if (rw->state > 0) {
     if (rw->writer != tcr) {
@@ -2713,6 +2792,7 @@ rwlock_unlock(rwlock *rw, TCR *tcr)
   }
   if (err) {
     RELEASE_SPINLOCK(rw->spin);
+    allow_thread_suspension(tcr, old_level);
     return err;
   }
   
@@ -2727,6 +2807,7 @@ rwlock_unlock(rwlock *rw, TCR *tcr)
     }
   }
   RELEASE_SPINLOCK(rw->spin);
+  allow_thread_suspension(tcr, old_level);
   return 0;
 }
 #else

--- a/lisp-kernel/x86-spentry64.s
+++ b/lisp-kernel/x86-spentry64.s
@@ -3688,32 +3688,33 @@ _endsubp(bind_interrupt_level)
 /* non-negative, check for pending interrupts.    */
 	
 _spentry(unbind_interrupt_level)
-        __(btq $TCR_FLAG_BIT_PENDING_SUSPEND,rcontext(tcr.flags))
+        /* Restore the outer binding of *INTERRUPT-LEVEL* BEFORE polling
+           for a suspend request that arrived while the old level
+           deferred suspension: a poll that runs first can read the
+           flags, then lose a request that lands before the level is
+           restored, and the thread that requested the suspension waits
+           forever.  Deliver a pending suspend only when the restored
+           level no longer defers suspension; when it still does, the
+           enclosing deferral delivers it. */
 	__(movq rcontext(tcr.db_link),%imm1)
 	__(movq rcontext(tcr.tlb_pointer),%arg_x)
 	__(movq INTERRUPT_LEVEL_BINDING_INDEX(%arg_x),%imm0)
-        __(jc 5f)
-0:      __(testq %imm0,%imm0)
 	__(movq binding.val(%imm1),%temp0)
 	__(movq binding.link(%imm1),%imm1)
 	__(movq %temp0,INTERRUPT_LEVEL_BINDING_INDEX(%arg_x))
  	__(movq %imm1,rcontext(tcr.db_link))
+        __(cmpq $-2<<fixnumshift,%temp0)
+        __(jle 0f)              /* restored level still defers */
+        __(btq $TCR_FLAG_BIT_PENDING_SUSPEND,rcontext(tcr.flags))
+        __(jnc 0f)
+        __(suspend_now())
+0:      __(testq %imm0,%imm0)
 	__(js 3f)
 2:	__(ret)
 3:	__(testq %temp0,%temp0)
 	__(js 2b)
 	__(check_pending_enabled_interrupt(4f))
 4:	__(ret)
-5:       /* Missed a suspend request; force suspend now if we're restoring
-          interrupt level to -1 or greater */
-        __(cmpq $-2<<fixnumshift,%imm0)
-        __(jne 0b)
-	__(movq binding.val(%imm1),%temp0)
-        __(cmpq %imm0,%temp0)
-        __(je 0b)
-        __(movq $-1<<fixnumshift,INTERRUPT_LEVEL_BINDING_INDEX(%arg_x))
-        __(suspend_now())
-        __(jmp 0b)
 _endsubp(unbind_interrupt_level)
 
 	


### PR DESCRIPTION
A thread can take the suspend signal while it holds one of the spin words that
guard a lock structure. It parks there. The thread that stopped the world then
needs that same word to release the exception lock. The holder cannot run until
somebody resumes it, and nobody does.

One core spins at 100 percent until somebody kills the process. No crash, no
error, no debugger entry. We have four field occurrences, and the longest wedged
for six days.

## The cycle

`%suspend-other-threads` traps to `XUUO_SUSPEND_ALL`. That handler is the only
normal-return caller of `suspend_other_threads` that returns with the world
still stopped.

Meanwhile another thread takes an allocation trap. There
`prepare_to_wait_for_exception_lock` calls `ALLOW_EXCEPTIONS`, which restores
the interrupted signal mask. That thread then takes the recursive lock's guard
word in `lock_recursive_lock`. The signal is deliverable there, and nothing
marks the spin sections. `suspend_resume_handler` defers only at
`TCR_INTERRUPT_LEVEL <= -(2 << fixnumshift)`. So the thread parks holding the
word. The suspender reaches `unlock_exception_lock_in_handler` and spins on it
forever.

Two constraints on a fix. `ALLOW_EXCEPTIONS` before the wait is deliberate, and
the comment there says why. We cannot mask the signal across the wait.

The word also does not name its owner. `get_spin_lock` swaps the caller's TCR in
on every attempt. A self-ownership test is therefore unsound.

## The fix

`with-deferred-gc` binds `*interrupt-level*` to -2. The documentation says it runs
"without responding to the signal used to suspend threads", and
`suspend_resume_handler` honors that threshold. Nobody ever applied the
mechanism to the runtime's own lock protocol, which runs at -1.

Each patch raises the level across guard acquisition and the work held under it.
It then releases, restores the previous level, and re-raises a pending suspend.
Restoring before polling is race-free. A signal before the restore sets
`PENDING_SUSPEND` for the poll to find, and one after parks normally.

- `thread_manager.c` (+83/-3), all eight non-futex routines. The helpers skip a
  TCR with no `tlb_pointer`. The initial thread takes one of these locks in
  `new_tcr`, before its thread-local vector exists. An earlier version crashed
  the boot there.
- `level-0/l0-misc.lisp` (+106/-28), the same protocol on the Lisp side. Nine
  acquisitions in seven routines, all previously under `without-interrupts`,
  which is -1 and does not defer suspension. Two fixes ride along.
  `%unlock-rwlock-ptr` now posts its semaphores after releasing the word.
  `%promote-rwlock` no longer returns from its owner arm still holding it.
- `arm64-spentry.s` (+32/-36) and `x86-spentry64.s` (+15/-15) fix
  `unbind_interrupt_level`. It tests `PENDING_SUSPEND` before restoring the
  level, then acts on the value it already loaded. A suspend arriving in that
  window is lost. PPC has the same bug and no patch, since nobody can build or
  test it.

The first commit is the `recursive_lock_trylock` count leak from #597. The
already-owned path raises the count and then falls through to EBUSY. It is here
because the deferral change touches that function.

That commit stands alone as a fix, and the deferral commit does not apply
without it. The leak fix moves `RELEASE_SPINLOCK` and `return 0` out of the
`if (was_free)` block, and the deferral commit adds `allow_thread_suspension`
against that corrected shape. Take the two together or take neither.

## Testing

**A correction to an earlier version of this section.** The driver behind the
per-reproducer counts printed its success line from the environment variable it
was handed rather than from the log, so "3000 of 3000" in both places and the
20,000 soak stated the value passed in. Those runs may well have completed. The
numbers do not establish that they did, and they are gone. The red results
below parse the log for a heartbeat stall, and the gdb captures are direct
observations, so both stand.

The strongest result needs no widener at all. Stock CCL 1.13 LinuxX8664, one
2-vCPU x86-64 host, no instrumentation of any kind:

| build | result |
|---|---|
| stock, unpatched | RED 3 of 3, wedged at 39,500 / 164,500 / 200,250 cycles |
| with the two deferral patches | clean 3 of 3 to the 299,750 cap, and 625,500 in a longer run |

Every wedge shows one thread runnable and spinning in
`unlock_exception_lock_in_handler` -> `unlock_recursive_lock` -> `get_spin_lock`,
with 25 sleeping in `suspend_resume_handler` and `sem_wait_forever`.

The wedge point is stochastic over an order of magnitude. Ten runs wedge at
18,500 / 28,500 / 39,500 / 51,750 / 70,500 / 88,250 / 103,250 / 137,000 /
164,500 / 200,250 cycles, and one unpatched run survived to 199,750 before I
stopped it. A short clean run proves nothing here.

Three reproducers, each watched red and then green, all on Linux x86-64.

The first covers the C side. It runs N threads allocating hard while one loops a
small `with-other-threads-suspended` body. The window is about ten instructions,
so a throwaway spin inside `LOCK_SPINLOCK` widens it, gated on an environment
variable. Widened and unfixed, it wedges before the first heartbeat. `thread
apply all bt` then shows a worker parked in `suspend_resume_handler` on top of
`get_spin_lock`, which is the field signature. With the C patch it stops
wedging.

The second covers the Lisp side and uses read locks as the vehicle. A reader
that owns the lock never blocks another reader, so a suspended reader-owner
cannot stall the world-stopper by design. That leaves the guard word as the only
shared serialization point. With the Lisp patch withheld, the run stalls
permanently and never reaches a heartbeat. The capture shows the readers in the
`%get-spin-lock` spin loop, and no thread waiting on a lock semaphore. With the
patch restored, the stall does not return.

Nothing else differs between the two runs.

We watched every suite result below twice, and kernel identity moved at every
step.

- x86-64: ANSI 21679 tests 0 failed, `ccl.lsp` 243 tests 0 failed, on eleven
  consecutive runs.
- arm64, full build from a clean reset: ANSI 21679 tests 0 failed, `ccl.lsp` 243
  tests 0 failed.

The third covers `unbind_interrupt_level`, and its observable is different. A
missed suspend there is not permanent. The victim self-heals at its next unbind,
so the cost is a world-stop that waits for it. The reproducer therefore times
every world-stop rather than watching for a wedge. A sled widens the window at
the pre-fix instruction order. A matching sled sits at the post-fix point. Both
runs therefore carry the same added delay, and they differ only in where the
window falls.

Pre-fix, 2000 iterations: 2 missed suspends, longest world-stop 157 ms. Post-fix,
same workload and the same added delay: 0 missed, longest 19 ms. Two events are
not a rate, and I am not offering one. What the run shows is the latency
separation, and it agrees with the mechanism. Before the fix, the window spans
the flags read to the restore, so a signal landing in it defers against a stale
read. After the fix, it spans the restore to the poll, where a signal parks at
once.

Nothing here reproduces on arm64. For the C and Lisp patches that is a thin gap,
since the code is shared and only the host differs. For `arm64-spentry.s` it is a
real one. That file is its own assembly. The arm64 half of the unbind fix rests
on the ordering argument, on matching the x86-64 change instruction for
instruction, and on a full arm64 build with both suites.

The `recursive_lock_trylock` commit has no test of its own either. It is the
#597 fix, unchanged, and it rests on reading and on the suites.

All three reproducers and their wideners are test-only, so I keep them out of
the series. They now live in Clozure/ccl-tests#10 under `extended-tests/`.

## Related

#597 also reports that `:futex` never turns on. The feature guard reads
`#+(and linux-target no ...)`, and there is no feature named `no`. That is why
the non-futex protocol is live code on every Linux target. Enabling futex
removes the guard word and this whole class of defect, and it is a separate
decision.

Gary Palter asked us to submit this rather than hold it.

## Where these tests live

This reproducer had no home. It is not an ANSI test. It needs several threads, a
widened window and a gdb capture. We have a number of tests in that shape from
the arm64 port. Each came from a real defect that a full ANSI run passed, and
each passes on stock x86-64. They cover declared element types at speed 3 safety 0,
FFI and callbacks, threads and interrupts, GC and purify, backtrace, and fasl
round-trips.

Answered, and done. Clozure/ccl-tests#10 adds `extended-tests/` with these
reproducers in it.

